### PR TITLE
Fix broken link

### DIFF
--- a/xml/issue0383.xml
+++ b/xml/issue0383.xml
@@ -43,7 +43,7 @@ expression  return type   semantics    pre/post-condition
 </pre>
 
 <p>
-(See <a href="http://aspn.activestate.com/ASPN/Mail/Message/boost/1395763">http://aspn.activestate.com/ASPN/Mail/Message/boost/1395763</a>.)
+(See <a href="http://lists.boost.org/Archives/boost/2002/10/37636.php">http://lists.boost.org/Archives/boost/2002/10/37636.php</a>.)
 </p>
 
 <p>


### PR DESCRIPTION
The boost list is no longer archived at Activestate. I think the post I found is the right one, but can't be sure.
