### PR TITLE
add updated wording referencing SSIZE_MAX and _POSIX_SSIZE_MAX

### DIFF
--- a/xml/issue2251.xml
+++ b/xml/issue2251.xml
@@ -25,7 +25,7 @@ conform to multiple standards at once. We should make users' and implementers' l
 
 <p>
 <b>Wording from Jayson Oldfather:</b>
-<p> I decided to use the phrase to describe <tt>ssize_t</tt> below because of the text describing it in the <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html#tag_13_67">POSIX</a> standard. In it, it describes <tt>ssize_t</tt> with the value range of <tt>[-1,{SSIZE_MAX}]</tt>.</p></p>
+<p> I decided to use the phrase to describe <tt>ssize_t</tt> below because of the text describing it in the <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_types.h.html#tag_13_67">POSIX</a> standard. In it, it describes <tt>ssize_t</tt> with the value range of <tt>[-1,{SSIZE_MAX}]</tt>.<tt>SSIZE_MAX</tt> is specified in the <a href="http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html#tag_13_24">POSIX</a> standard as a minimum value of <tt>_POSIX_SSIZE_MAX</tt>. This macro is referenced in the wording below.</p></p>
 
 </discussion>
 
@@ -66,7 +66,7 @@ Ammend <sref ref="[support.types]"/>, Table 30 as indicated:
 
 <p>Add the following paragraph to describe <tt>ssize_t</tt></p>
 <blockquote><p><ins>
--?- The type <tt>ssize_t</tt> is an implementation-defined signed integer type that shall contain the minimum range <tt>[-1, {SSIZE_MAX}]</tt>.
+-?- The type <tt>ssize_t</tt> is an implementation-defined signed integer type that shall contain the minimum range <tt>[-1, {SSIZE_MAX}]</tt> where <tt>SSIZE_MAX</tt> is specified at a minimum of <tt>_POSIX_SSIZE_MAX</tt>.
 </ins></p></blockquote>
 <p>Ammend p7 as follows:</p>
 <blockquote><p>


### PR DESCRIPTION
add wording relating these two in discussion and in the P/R wording

I'm not entirely sure the wording is still correct as ammended. I added the link to the POSIX limits.h specification in the discussion where it mentions the minimum value for SSIZE_MAX as _POSIX_SSIZE_MAX but I'm unsure whether that information should be represented in the P/R. I am also unsure whether I should have moved the previous P/R into a blockquote above the resolution as a "Previous Resolution" and ammended the Resolution section instead.
