### PR TITLE
Revise wording for 2193

### DIFF
--- a/xml/issue2193.xml
+++ b/xml/issue2193.xml
@@ -94,9 +94,12 @@ Issue <iref ref="2303"/> describes the more general problem related to explicit 
 library and may help to solve this problem here as well.
 </p>
 
-</discussion>
+<note>2014-02-13, Issaquah, Jonathan revises wording</note>
 
-<resolution>
+<p><strong>Previous resolution from Daniel [SUPERSEDED]:</strong></p>
+
+<blockquote class="note">
+
 <p>This wording is relative to N3376.</p>
 
 <p>The more general criterion for performing the suggested transformation was: Any type with an initializer-list 
@@ -313,6 +316,254 @@ explicit unordered_multiset(size_type n<del> = <i>see below</i></del>,
                             const key_equal&amp; eql = key_equal(),
                             const allocator_type&amp; a = allocator_type());
 </pre></blockquote>
+</li>
+</ol>
+
+</blockquote>
+
+</discussion>
+
+<resolution>
+<p>This wording is relative to N3376.</p>
+
+<p>The more general criterion for performing the suggested transformation was: Any type with an initializer-list 
+constructor that also has an explicit default constructor.</p>
+
+<ol>
+<li><p>Change class template <tt>basic_string</tt> synopsis, <sref ref="[basic.string]"/> p5 as indicated:</p>
+<blockquote><pre>
+<ins>basic_string() : basic_string(Allocator()) { }</ins>
+explicit basic_string(const Allocator&amp; a<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[string.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit basic_string(const Allocator&amp; a<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>deque</tt> synopsis, <sref ref="[deque.overview]"/> p2 as indicated:</p>
+<blockquote><pre>
+<ins>deque() : deque(Allocator()) { }</ins>
+explicit deque(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[deque.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit deque(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>forward_list</tt> synopsis, <sref ref="[forwardlist.overview]"/> p3 as indicated:</p>
+<blockquote><pre>
+<ins>forward_list() : forward_list(Allocator()) { }</ins>
+explicit forward_list(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[forwardlist.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit forward_list(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>list</tt> synopsis, <sref ref="[list.overview]"/> p2 as indicated:</p>
+<blockquote><pre>
+<ins>list() : list(Allocator()) { }</ins>
+explicit list(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[list.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit list(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>vector</tt> synopsis, <sref ref="[vector.overview]"/> p2 as indicated:</p>
+<blockquote><pre>
+<ins>vector() : vector(Allocator()) { }</ins>
+explicit vector(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[vector.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit vector(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change class template specialization <tt>vector&lt;bool&gt;</tt> synopsis, <sref ref="[vector.bool]"/> p1 as indicated:</p>
+<blockquote><pre>
+<ins>vector() : vector(Allocator()) { }</ins>
+explicit vector(const Allocator&amp;<del> = Allocator()</del>);
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>map</tt> synopsis, <sref ref="[map.overview]"/> p2 as indicated:</p>
+<blockquote><pre>
+<ins>map() : map(Compare()) { }</ins>
+explicit map(const Compare&amp; comp<del> = Compare()</del>,
+             const Allocator&amp; = Allocator());
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[map.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit map(const Compare&amp; comp<del> = Compare()</del>,
+             const Allocator&amp; = Allocator());
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>multimap</tt> synopsis, <sref ref="[multimap.overview]"/> p2 as indicated:</p>
+<blockquote><pre>
+<ins>multimap() : multimap(Compare()) { }</ins>
+explicit multimap(const Compare&amp; comp<del> = Compare()</del>,
+                  const Allocator&amp; = Allocator());
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[multimap.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit multimap(const Compare&amp; comp<del> = Compare()</del>,
+                  const Allocator&amp; = Allocator());
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>set</tt> synopsis, <sref ref="[set.overview]"/> p2 as indicated:</p>
+<blockquote><pre>
+<ins>set() : set(Compare()) { }</ins>
+explicit set(const Compare&amp; comp<del> = Compare()</del>,
+             const Allocator&amp; = Allocator());
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[set.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit set(const Compare&amp; comp<del> = Compare()</del>,
+             const Allocator&amp; = Allocator());
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>multiset</tt> synopsis, <sref ref="[multiset.overview]"/> p2 as indicated:</p>
+<blockquote><pre>
+<ins>multiset() : multiset(Compare()) { }</ins>
+explicit multiset(const Compare&amp; comp<del> = Compare()</del>,
+                  const Allocator&amp; = Allocator());
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[multiset.cons]"/> before p1 as indicated:</p>
+<blockquote><pre>
+explicit multiset(const Compare&amp; comp<del> = Compare()</del>,
+                  const Allocator&amp; = Allocator());
+</pre></blockquote>
+</li>
+
+<li><p>Change class template <tt>unordered_map</tt> synopsis, <sref ref="[unord.map.overview]"/> p3 as indicated:</p>
+<blockquote><pre>
+<ins>unordered_map();</ins>
+explicit unordered_map(size_type n<del> = <i>see below</i></del>,
+                       const hasher&amp; hf = hasher(),
+                       const key_equal&amp; eql = key_equal(),
+                       const allocator_type&amp; a = allocator_type());
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[unord.map.cnstr]"/> before p1 as indicated:</p>
+<blockquote><pre>
+<ins>unordered_map() : unordered_map(size_type(<i>see below</i>)) { }</ins>
+explicit unordered_map(size_type n<del> = <i>see below</i></del>,
+                       const hasher&amp; hf = hasher(),
+                       const key_equal&amp; eql = key_equal(),
+                       const allocator_type&amp; a = allocator_type());
+</pre>
+
+-1- <i>Effects:</i> Constructs an empty <code>unordered_map</code> using the specified hash function, key equality func-<br />
+tion, and allocator, and using at least <i>n</i> buckets. <del>If <i>n</i> is not provided,</del> <ins>For the default constructor</ins><br />
+the number of buckets is implementation-defined. <code>max_load_factor()</code> returns 1.0.
+</blockquote>
+
+</li>
+
+<li><p>Change class template <tt>unordered_multimap</tt> synopsis, <sref ref="[unord.multimap.overview]"/> p3 as indicated:</p>
+<blockquote><pre>
+<ins>unordered_multimap();</ins>
+explicit unordered_multimap(size_type n<del> = <i>see below</i></del>,
+                            const hasher&amp; hf = hasher(),
+                            const key_equal&amp; eql = key_equal(),
+                            const allocator_type&amp; a = allocator_type());
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[unord.multimap.cnstr]"/> before p1 as indicated:</p>
+<blockquote><pre>
+<ins>unordered_multimap() : unordered_multimap(size_type(<i>see below</i>)) { }</ins>
+explicit unordered_multimap(size_type n<del> = <i>see below</i></del>,
+                            const hasher&amp; hf = hasher(),
+                            const key_equal&amp; eql = key_equal(),
+                            const allocator_type&amp; a = allocator_type());
+</pre>
+
+-1- <i>Effects:</i> Constructs an empty <code>unordered_multimap</code> using the specified hash function, key equality<br />
+function, and allocator, and using at least <i>n</i> buckets. <del>If <i>n</i> is not provided,</del> <ins>For the default constructor</ins><br />
+the number of buckets is implementation-defined. <code>max_load_factor()</code> returns 1.0.
+
+</blockquote>
+</li>
+
+<li><p>Change class template <tt>unordered_set</tt> synopsis, <sref ref="[unord.set.overview]"/> p3 as indicated:</p>
+<blockquote><pre>
+<ins>unordered_set();</ins>
+explicit unordered_set(size_type n<del> = <i>see below</i></del>,
+                       const hasher&amp; hf = hasher(),
+                       const key_equal&amp; eql = key_equal(),
+                       const allocator_type&amp; a = allocator_type());
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[unord.set.cnstr]"/> before p1 as indicated:</p>
+<blockquote><pre>
+<ins>unordered_set() : unordered_set(size_type(<i>see below</i>)) { }</ins>
+explicit unordered_set(size_type n<del> = <i>see below</i></del>,
+                       const hasher&amp; hf = hasher(),
+                       const key_equal&amp; eql = key_equal(),
+                       const allocator_type&amp; a = allocator_type());
+</pre>
+
+-1- <i>Effects:</i> Constructs an empty <code>unordered_set</code> using the specified hash function, key equality func-<br />
+tion, and allocator, and using at least <i>n</i> buckets. <del>If <i>n</i> is not provided,</del> <ins>For the default constructor</ins><br />
+the number of buckets is implementation-defined. <code>max_load_factor()</code> returns 1.0.
+
+</blockquote>
+</li>
+
+<li><p>Change class template <tt>unordered_multiset</tt> synopsis, <sref ref="[unord.multiset.overview]"/> p3 as indicated:</p>
+<blockquote><pre>
+<ins>unordered_multiset();</ins>
+explicit unordered_multiset(size_type n<del> = <i>see below</i></del>,
+                            const hasher&amp; hf = hasher(),
+                            const key_equal&amp; eql = key_equal(),
+                            const allocator_type&amp; a = allocator_type());
+</pre></blockquote>
+</li>
+
+<li><p>Change <sref ref="[unord.multiset.cnstr]"/> before p1 as indicated:</p>
+<blockquote><pre>
+<ins>unordered_multiset() : unordered_multiset(size_type(<i>see below</i>)) { }</ins>
+explicit unordered_multiset(size_type n<del> = <i>see below</i></del>,
+                            const hasher&amp; hf = hasher(),
+                            const key_equal&amp; eql = key_equal(),
+                            const allocator_type&amp; a = allocator_type());
+</pre>
+
+-1- <i>Effects:</i> Constructs an empty <code>unordered_multiset</code> using the specified hash function, key equality<br />
+function, and allocator, and using at least <i>n</i> buckets. <del>If <i>n</i> is not provided,</del> <ins>For the default constructor</ins><br />
+the number of buckets is implementation-defined. <code>max_load_factor()</code> returns 1.0.
+
+</blockquote>
 </li>
 </ol>
 


### PR DESCRIPTION
New wording for unordered containers to remove "see below"
from synopsis and alter function descriptions to specify
behaviour of default constructors.
