### PR TITLE
Update statuses after Urbana discussion.

### DIFF
--- a/xml/issue2160.xml
+++ b/xml/issue2160.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2160" status="Review">
+<issue num="2160" status="Ready">
 <title>Unintended destruction ordering-specification of <tt>resize</tt></title>
 <section><sref ref="[vector.capacity]"/></section>
 <submitter>Daniel Kr&uuml;gler</submitter>
@@ -122,6 +122,8 @@ General agreement that implementations should not be required to change.
 </p>
 
 <note>2014-06-28 Daniel provides alternative wording</note>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
 
 </discussion>
 

--- a/xml/issue2307.xml
+++ b/xml/issue2307.xml
@@ -3,12 +3,12 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2307" status="New">
+<issue num="2307" status="Open">
 <title>Should the Standard Library use <tt>explicit</tt> only when necessary?</title>
 <section><sref ref="[containers]"/></section>
 <submitter>Zhihao Yuan</submitter>
 <date>26 Sep 2013</date>
-<priority>1</priority>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -25,6 +25,9 @@ but the behavior is inconsistent with that of
 <blockquote><pre>
 vector(size_type count, const T&amp; value, const Allocator&amp; alloc = Allocator());
 </pre></blockquote>
+
+<note>Urbana 2014-11-07: Move to Open</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2310.xml
+++ b/xml/issue2310.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2310" status="New">
+<issue num="2310" status="Open">
 <title>Public <em>exposition only</em> member in <tt>std::array</tt></title>
 <section><sref ref="[array.overview]"/></section>
 <submitter>Jonathan Wakely</submitter>
@@ -24,6 +24,9 @@ implementation to provide "equivalent external behavior" to a public
 array member, then <sref ref="[objects.within.classes]"/> needs to cover public
 members too, or some other form should be used in <sref ref="[array.overview]"/>.
 </p>
+
+<note>Urbana 2014-11-07: Move to Open</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2364.xml
+++ b/xml/issue2364.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2364" status="Review">
+<issue num="2364" status="Ready">
 <title><tt>deque</tt> and <tt>vector</tt> <tt>pop_back</tt> don't specify iterator invalidation requirements</title>
 <section><sref ref="[deque.modifiers]"/>, <sref ref="[vector.modifiers]"/></section>
 <submitter>Deskin Miller</submitter>
@@ -113,6 +113,8 @@ AM: The containers clause is known to be suboptimal in many ways.
 <p/>
 Looks good 
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
 
 </discussion>
 

--- a/xml/issue2383.xml
+++ b/xml/issue2383.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2383" status="New">
+<issue num="2383" status="Open">
 <title>Overflow cannot be ill-formed for chrono::duration integer literals</title>
 <section><sref ref="[time.duration.literals]"/></section>
 <submitter>Jonathan Wakely</submitter>
@@ -28,6 +28,9 @@ Overflow could be detected if the duration integer literals were
 literal operator templates, otherwise overflow can either be undefined
 or a run-time error, not ill-formed.
 </p>
+
+<note>Urbana 2014-11-07: Move to Open</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2403.xml
+++ b/xml/issue2403.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2403" status="New">
+<issue num="2403" status="Ready">
 <title><tt>stof()</tt> should call <tt>strtof()</tt> and <tt>wcstof()</tt></title>
 <section><sref ref="[string.conversions]"/></section>
 <submitter>Stephan T. Lavavej</submitter>
@@ -78,6 +78,9 @@ correctly rounded result.
 <p>
 Marshall Clow will look at this.
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2411.xml
+++ b/xml/issue2411.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2411" status="New">
+<issue num="2411" status="Ready">
 <title><tt>shared_ptr</tt> is only contextually convertible to <tt>bool</tt></title>
 <section><sref ref="[util.smartptr.shared]"/></section>
 <submitter>Jonathan Wakely</submitter>
@@ -30,6 +30,9 @@ Library Fundamentals TS. The declarations of the conversion operator in <sref re
 <sref ref="[util.smartptr.shared.obs]"/> are <tt>explicit</tt> which contradicts the "convertible to <tt>bool</tt>" statement. The
 intention is definitely for <tt>shared_ptr</tt> to only be contextually convertible to <tt>bool</tt>.
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2414.xml
+++ b/xml/issue2414.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2414" status="New">
+<issue num="2414" status="Open">
 <title>Member function reentrancy should be implementation-defined</title>
 <section><sref ref="[reentrancy]"/></section>
 <submitter>Stephan T. Lavavej</submitter>
@@ -21,6 +21,9 @@ very specific scenarios.
 <p/>
 (For clarity, this issue has been split off from LWG <iref ref="2382"/>.)
 </p>
+
+<note>Urbana 2014-11-07: Move to Open</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2425.xml
+++ b/xml/issue2425.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2425" status="New">
+<issue num="2425" status="Ready">
 <title><tt>operator delete(void*, size_t)</tt> doesn't invalidate pointers sufficiently</title>
 <section><sref ref="[new.delete]"/></section>
 <submitter>Richard Smith</submitter>
@@ -28,6 +28,9 @@ This should say:
 <p>
 Likewise at the end of <sref ref="[new.delete.array]"/>/11, <ins><tt>operator delete[](void*, std::size_t)</tt></ins>.
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2427.xml
+++ b/xml/issue2427.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2427" status="New">
+<issue num="2427" status="Ready">
 <title>Container adaptors as sequence containers, redux</title>
 <section><sref ref="[sequences.general]"/></section>
 <submitter>Tim Song</submitter>
@@ -18,6 +18,9 @@ LWG <iref ref="2194"/> removed "These container adaptors meet the requirements f
 However, N3936 <sref ref="[sequences.general]"/>/p2 still says "The headers <tt>&lt;queue&gt;</tt> and <tt>&lt;stack&gt;</tt> 
 define container adaptors (23.6) that also meet the requirements for sequence containers." I assume this is just an oversight.
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2428.xml
+++ b/xml/issue2428.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2428" status="New">
+<issue num="2428" status="Ready">
 <title>"External declaration" used without being defined</title>
 <section><sref ref="[using.headers]"/></section>
 <submitter>Tim Song</submitter>
@@ -37,6 +37,9 @@ is no need to specifically limit the statement in <sref ref="[using.headers]"/>/
 since every non-file-scope declaration is necessarily inside a file-scope declaration, so banning including a header 
 inside file-scope declarations necessarily bans including one inside non-file-scope declarations as well.
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2433.xml
+++ b/xml/issue2433.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2433" status="New">
+<issue num="2433" status="Ready">
 <title><tt>uninitialized_copy()</tt>/etc. should tolerate overloaded <tt>operator&amp;</tt></title>
 <section><sref ref="[specialized.algorithms]"/></section>
 <submitter>Stephan T. Lavavej</submitter>
@@ -19,6 +19,9 @@ This restriction isn't necessary anymore. In fact, this is the section that defi
 thanks to <sref ref="[contents]"/>/3 "Whenever a name <tt>x</tt> defined in the standard library is mentioned, the name 
 <tt>x</tt> is assumed to be fully qualified as <tt>::std::x</tt>, unless explicitly described otherwise.")
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2434.xml
+++ b/xml/issue2434.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2434" status="New">
+<issue num="2434" status="Ready">
 <title><tt>shared_ptr::use_count()</tt> is efficient</title>
 <section><sref ref="[util.smartptr.shared.obs]"/></section>
 <submitter>Stephan T. Lavavej</submitter>
@@ -18,6 +18,9 @@ example). However, there aren't any <tt>shared_ptr</tt> implementations that use
 after C++11 recognized the existence of multithreading. Everyone uses atomic refcounts, so <tt>use_count()</tt> 
 is just an atomic load.
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2438.xml
+++ b/xml/issue2438.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2438" status="New">
+<issue num="2438" status="Ready">
 <title><tt>std::iterator</tt> inheritance shouldn't be mandated</title>
 <section><sref ref="[iterator.basic]"/></section>
 <submitter>Stephan T. Lavavej</submitter>
@@ -29,6 +29,9 @@ continue deriving from <tt>std::iterator</tt> if they want.
 <p/>
 (Editorial note: The order of the typedefs follows the order of <tt>std::iterator</tt>'s template parameters.)
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2439.xml
+++ b/xml/issue2439.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2439" status="New">
+<issue num="2439" status="Ready">
 <title><tt>unique_copy()</tt> sometimes can't fall back to reading its output</title>
 <section><sref ref="[alg.unique]"/></section>
 <submitter>Stephan T. Lavavej</submitter>
@@ -49,6 +49,9 @@ input-only, output forward+, different value types: needs <tt>CopyConstructible<
 <p/>
 input-only, output-only: needs <tt>CopyConstructible</tt> and <tt>CopyAssignable</tt>
 </p></blockquote>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>

--- a/xml/issue2440.xml
+++ b/xml/issue2440.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2440" status="New">
+<issue num="2440" status="Ready">
 <title><tt>seed_seq::size()</tt> should be <tt>noexcept</tt></title>
 <section><sref ref="[rand.util.seedseq]"/></section>
 <submitter>Stephan T. Lavavej</submitter>
@@ -14,6 +14,9 @@
 <p>
 Obvious.
 </p>
+
+<note>Urbana 2014-11-07: Move to Ready</note>
+
 </discussion>
 
 <resolution>


### PR DESCRIPTION
This applies the changes moving issues to Ready or Open, when there is no other discussion. I hope the notes are in the right form.

There are some other updates documented in the wiki on the LWG_Friday_issue_processing page which need new wording rather than simply changing the status.
