### PR TITLE
Apply LEWG prioritization and SG assignment from Kona meeting.

### DIFF
--- a/xml/issue0255.xml
+++ b/xml/issue0255.xml
@@ -8,6 +8,7 @@
 <section><sref ref="[streambuf]"/></section>
 <submitter>Martin Sebor</submitter>
 <date>12 Aug 2000</date>
+<priority>1</priority>
 
 <discussion>
 <p>
@@ -48,6 +49,9 @@ Move to NAD Future.
 This is related to LWG <iref ref="423"/>.
 </p>
 </blockquote>
+
+<note>2015-10 Kona</note>
+<p>Needs a paper. Find a way to let vendors schedule the ABI break.</p>
 
 </discussion>
 

--- a/xml/issue0423.xml
+++ b/xml/issue0423.xml
@@ -8,7 +8,8 @@
     <section><sref ref="[input.output]"/></section>
     <submitter>Martin Sebor</submitter>
     <date>18 Sep 2003</date>
-    <discussion>
+    <priority>2</priority>
+<discussion>
 
 <p>
 A third party test suite tries to exercise istream::ignore(N) with

--- a/xml/issue0523.xml
+++ b/xml/issue0523.xml
@@ -8,6 +8,7 @@
 <section><sref ref="[re]"/></section>
 <submitter>Eric Niebler</submitter>
 <date>1 Jul 2005</date>
+<priority>3</priority>
 
 <discussion>
 <p>

--- a/xml/issue0936.xml
+++ b/xml/issue0936.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="936" status="LEWG">
+<issue num="936" status="SG1">
 <title>Mutex type overspecified</title>
 <section><sref ref="[thread.mutex.requirements]"/></section>
 <submitter>Pete Becker</submitter>

--- a/xml/issue0961.xml
+++ b/xml/issue0961.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="961" status="LEWG">
+<issue num="961" status="SG1">
 <title>Various threading bugs #11</title>
 <section><sref ref="[thread.mutex.requirements]"/></section>
 <submitter>Pete Becker</submitter>

--- a/xml/issue1053.xml
+++ b/xml/issue1053.xml
@@ -8,6 +8,7 @@
 <section><sref ref="[algorithms]"/></section>
 <submitter>Alisdair Meredith</submitter>
 <date>12 Mar 2009</date>
+<priority>2</priority>
 
 <discussion>
 
@@ -60,6 +61,9 @@ clearly addressed by the Summit resolution.
 <blockquote><p>
 Too inventive, too late, would really need a paper. Moved to NAD Future.
 </p></blockquote>
+
+<note>2015-10 Kona</note>
+<p>Diamond operators make this easier, but it needs a paper.</p>
 
 </discussion>
 

--- a/xml/issue1154.xml
+++ b/xml/issue1154.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1154" status="LEWG">
+<issue num="1154" status="SG6">
 <title><tt>complex</tt> should accept integral types</title>
 <section><sref ref="[complex.numbers]"/></section>
 <submitter>LWG</submitter>

--- a/xml/issue1203.xml
+++ b/xml/issue1203.xml
@@ -6,6 +6,7 @@
 <section><sref ref="[ostream.rvalue]"/><sref ref="[istream.rvalue]"/></section>
 <submitter>Howard Hinnant</submitter>
 <date>6 Sep 2009</date>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -84,6 +85,13 @@ implemented and tested.
 NAD Future.  No concensus for change.
 </p></blockquote>
 
+<note>2015-10 Kona</note>
+<p>
+  See also <a
+  href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0117r0.html">P0117</a>
+  and <a href="https://issues.isocpp.org/show_bug.cgi?id=137">LEWG137</a> on
+  easier formatting to strings.
+</p>
 </discussion>
 
 <resolution>

--- a/xml/issue1217.xml
+++ b/xml/issue1217.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1217" status="LEWG">
+<issue num="1217" status="SG6">
 <title>Quaternion support</title>
 <section><sref ref="[complex.numbers]"/></section>
 <submitter>Ted Shaneyfelt</submitter>

--- a/xml/issue1235.xml
+++ b/xml/issue1235.xml
@@ -3,11 +3,12 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1235" status="LEWG">
+<issue num="1235" status="SG6">
 <title>Issue with C++0x random number proposal</title>
 <section><sref ref="[rand.concept.dist]"/></section>
 <submitter>Matthias Troyer</submitter>
 <date>12 Oct 2009</date>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -114,6 +115,14 @@ This function can be overloaded for optimized enginges like
 <blockquote><p>
 NAD Future.  No time to add this feature for C++0X.
 </p></blockquote>
+
+<note>
+2015-10 Kona:
+</note>
+
+<p>
+Numerics SG should take this.
+</p>
 
 </discussion>
 

--- a/xml/issue1238.xml
+++ b/xml/issue1238.xml
@@ -8,6 +8,7 @@
 <section><sref ref="[algorithms]"/></section>
 <submitter>Alisdair Meredith</submitter>
 <date>15 Oct 2009</date>
+<priority>2</priority>
 
 <discussion>
 <p>

--- a/xml/issue1282.xml
+++ b/xml/issue1282.xml
@@ -8,6 +8,7 @@
 <section><sref ref="[algorithms]"/></section>
 <submitter>Igor Semenov</submitter>
 <date>7 Dec 2009</date>
+<priority>1</priority>
 
 <discussion>
 <ol style="list-style-type:upper-roman">
@@ -106,6 +107,12 @@ for ( int i = 0; i &lt; v.size(); ++i )
 2010-01-22 Moved to Tentatively NAD Future after 5 positive votes on c++std-lib.
 Rationale added below.
 </note>
+
+<note>2015-10 Kona</note>
+<p>
+  <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3593.html">N3593</a>
+  proposes this.
+</p>
 </discussion>
 
 <rationale>

--- a/xml/issue1396.xml
+++ b/xml/issue1396.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1396" status="LEWG">
+<issue num="1396" status="Dup">
 <title><tt>regex</tt> should support allocators</title>
 <section><sref ref="[re.regex]"/></section>
 <submitter>INCITS</submitter>
@@ -37,6 +37,11 @@ would solve this issue.
 <note>2011-03-22 Madrid</note>
 
 <p>Close 1396 as NAD Future.</p>
+
+
+<note>2015-10 Kona</note>
+<p>Tracked in <a href="https://issues.isocpp.org/show_bug.cgi?id=9">LEWG9</a>.</p>
+
 </discussion>
 
 <rationale><p>No consensus for a change at this time</p></rationale>

--- a/xml/issue1459.xml
+++ b/xml/issue1459.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1459" status="LEWG">
+<issue num="1459" status="SG1">
 <title>Overlapping evaluations are allowed</title>
 <section><sref ref="[atomics.order]"/></section>
 <submitter>Canada</submitter>

--- a/xml/issue1484.xml
+++ b/xml/issue1484.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1484" status="LEWG">
+<issue num="1484" status="SG1">
 <title>Need a way to join a thread with a timeout</title>
 <section><sref ref="[thread.thread.class]"/></section>
 <submitter>INCITS</submitter>

--- a/xml/issue1488.xml
+++ b/xml/issue1488.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1488" status="LEWG">
+<issue num="1488" status="SG1">
 <title>Improve interoperability between the C++0x and C1x threads APIs</title>
 <section><sref ref="[thread.mutex]"/></section>
 <submitter>INCITS</submitter>

--- a/xml/issue1493.xml
+++ b/xml/issue1493.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1493" status="LEWG">
+<issue num="1493" status="SG1">
 <title>Add <tt>mutex</tt>, <tt>recursive_mutex</tt>, <tt>is_locked</tt> function</title>
 <section><sref ref="[thread.mutex.requirements]"/></section>
 <submitter>INCITS</submitter>

--- a/xml/issue1499.xml
+++ b/xml/issue1499.xml
@@ -3,7 +3,7 @@
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="1499" status="LEWG">
+<issue num="1499" status="SG1">
 <title>Condition variables preclude wakeup optimization</title>
 <section><sref ref="[thread.condition]"/></section>
 <submitter>INCITS</submitter>

--- a/xml/issue2055.xml
+++ b/xml/issue2055.xml
@@ -8,6 +8,7 @@
 <section><sref ref="[numeric.ops]"/></section>
 <submitter>Chris Jefferson</submitter>
 <date>1 Jan 2011</date>
+<priority>1</priority>
 
 <discussion>
 <p>

--- a/xml/issue2417.xml
+++ b/xml/issue2417.xml
@@ -8,7 +8,7 @@
 <section><sref ref="[optional.relops]"/> <sref ref="[optional.comp_with_t]"/></section>
 <submitter>Daniel Kr&uuml;gler</submitter>
 <date>20 Jun 2014</date>
-<priority>99</priority>
+<priority>2</priority>
 
 <discussion>
 <p><b>Addresses: fund.ts</b></p>

--- a/xml/issue2451.xml
+++ b/xml/issue2451.xml
@@ -8,7 +8,7 @@
 <section><sref ref="[optional.object]"/></section>
 <submitter>Geoffrey Romer</submitter>
 <date>31 Oct 2014</date>
-<priority>99</priority>
+<priority>1</priority>
 
 <discussion>
 <p><b>Addresses: fund.ts</b></p>


### PR DESCRIPTION
This is ~half of the issues in LEWG status. I made up SG6 status and picked "Dup" to mark that we have an issues.isocpp.org bug to replace the LWG issue.
