### PR TITLE
Use <iref> rather than hard-coded links.

### DIFF
--- a/xml/issue0309.xml
+++ b/xml/issue0309.xml
@@ -248,8 +248,7 @@ istream&amp; operator&gt;&gt; (istream &amp;strm, S &amp;s)
 </p>
 
 <p>
-The current proposed resolution of issue #309
-(http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-active.html#309)  is
+The current proposed resolution of issue #309 is
 unacceptable.   I write commerical software and coding around this
 makes my code ugly, non-intuitive, and requires comments referring
 people to this very issue.   Following is the full explanation of my

--- a/xml/issue0435.xml
+++ b/xml/issue0435.xml
@@ -15,7 +15,6 @@
 It has been pointed out that the proposed resolution in DR <iref ref="25"/> may not be
 quite up to snuff: <br/>
 http://gcc.gnu.org/ml/libstdc++/2003-09/msg00147.html
-http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#25<br/>
 </p>
 
 <p>

--- a/xml/issue0538.xml
+++ b/xml/issue0538.xml
@@ -12,8 +12,8 @@
 <discussion>
 <p>
 I believe I botched the resolution of
-<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#241">
-241 "Does unique_copy() require CopyConstructible and Assignable?"</a> which now
+<iref ref="241" />
+"Does unique_copy() require CopyConstructible and Assignable?" which now
 has WP status.
 </p>
 

--- a/xml/issue0554.xml
+++ b/xml/issue0554.xml
@@ -12,7 +12,7 @@
 <discussion>
 <p>
 I believe we have a bug in the resolution of:
-<a href="http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#184">lwg 184</a>
+<iref ref="184" />
 (WP status).
 </p>
 

--- a/xml/issue1448.xml
+++ b/xml/issue1448.xml
@@ -76,7 +76,7 @@ matter, but it looks a bit inconsistent.
 <note>2011-03-09: Nicolai Josuttis comments and drafts wording</note>
 
 <p>First, it seems the current wording is just an editorial mistake.
-When we added issue <a href="http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#432">432</a>
+When we added issue <iref ref="432" />
 to the draft standard (in <a href="http://www.open-std.org/jtc1/sc22/wg21/prot/14882fdis/n1733.pdf">n1733</a>), 
 the wording in the issue:
 </p>

--- a/xml/issue2002.xml
+++ b/xml/issue2002.xml
@@ -28,7 +28,7 @@ on iterator values. In this case a user should better know that this will be don
 there is no guarantee at all that inter-container comparison of iterators 
 is a feasible operation. This was a clear outcome of the resolution provided in 
 <a href= "http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3066.html">N3066</a> 
-for LWG issue <a href= "http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-closed.html#446">446</a>.
+for LWG issue <iref ref="446" />.
 It could also mean that a character-based comparison of the individual <tt>sub_match</tt>
 elements should be done - this would be equivalent to applying <tt>operator==</tt> to
 the subexpressions, prefix and suffix.

--- a/xml/issue2051.xml
+++ b/xml/issue2051.xml
@@ -70,7 +70,7 @@ Move to Open at the request of the Evolution Working Group.
 
 <note>Lenexa 2015-05-05</note>
 <p>
-<p>VV: While in the area of tuples, http://cplusplus.github.io/LWG/lwg-active.html#2051 should have status of WP, it is resolved by Daniel's "improving pair and tuple" paper.</p>
+<p>VV: While in the area of tuples, LWG 2051 should have status of WP, it is resolved by Daniel's "improving pair and tuple" paper.</p>
 <p>MC: status Resolved, by N4387</p>
 </p>
 

--- a/xml/issue2310.xml
+++ b/xml/issue2310.xml
@@ -26,7 +26,7 @@ members too, or some other form should be used in <sref ref="[array.overview]"/>
 </p>
 
 <note>Urbana 2014-11-07: Move to Open</note>
-<note>Kona 2015-10: Link to <a href="lwg-active.html#2516">2516</a></note>
+<note>Kona 2015-10: Link to <iref ref="2516"/></note>
 <note>2015-11-14, Geoffrey Romer provides wording</note>
 </discussion>
 

--- a/xml/issue2474.xml
+++ b/xml/issue2474.xml
@@ -31,7 +31,7 @@ default for all user-defined types.
 <p>VV: I don't personally have this problem, but the proposed resolution seems frightening to me.</p>
 <p>VV: There's a related issue, 2294, and also 2192.</p>
 <p>STL: 2086 is about user-defined types in &lt;cmath&gt;, fixed in C++14. The PR for 2474 wants to undo the fix.</p>
-<p>Link to <a href="lwg-active.html#2086">2086</a> and NAD.</p>
+<p>Link to <iref ref="2086"/> and NAD.</p>
 </discussion>
 
 <resolution>

--- a/xml/issue2516.xml
+++ b/xml/issue2516.xml
@@ -33,7 +33,7 @@ Geoffrey: Will survey "exposition-only" use and come up with wording to define "
 <p>WEB: Are there any non-members in the Standard that are "exposition only"? STL: DECAY_COPY and INVOKE. </p><p>GR: There are a few enums. </p><p>HH: We have nested class types that are exposition-only. HH: We're about to make "none_t" an exposition-only type. [Everyone lists some examples from the Standard that are EO.] GR: "bitmask" contains some hypothetical types. That potentially contains user requirements (since regexp requires certain trait members to be "bitmask types").</p>
 <p>STL: What's the priority of this issue? Does this have any effect on implementations? Is there anything mysterious that could happen? </p><p>AM: 2. </p><p>STL: How did that happen? It's at best priority 4. We have so many better things we could be doing.</p>
 <p>WEB: "exposition only" in [???] is just used as plain English, not as words of power. GR: That gives me enough to make wording to fix this. </p><p>STL: I wouldn't mind if we didn't fix this ever.</p>
-<p>MC: @JW, please write up wording for <a href="lwg-active.html#2310">2310</a> to make the EO members private. JW: I can't do that, because that'd make the class a non-aggregate. </p><p>WEB: Please cross-link both issues and move 2516 to "open".</p>
+<p>MC: @JW, please write up wording for <iref ref="2310" /> to make the EO members private. JW: I can't do that, because that'd make the class a non-aggregate. </p><p>WEB: Please cross-link both issues and move 2516 to "open".</p>
 
 <note>2015-11-14, Geoffrey Romer provides wording</note>
 </discussion>


### PR DESCRIPTION
Replaced hard-coded links with `<iref>` in 538, 554, 1448, 2002, 2310, 2474 and 2516.
For LWG 309, removed a hard-coded self link.
For LWG 435, removed a hard-coded link redundant to an `<iref>` two lines above.
For LWG 2051, replaced a self-reference URL with just the issue number.