### PR TITLE
[LWG2571] Restore missing sentence

### DIFF
--- a/xml/issue2571.xml
+++ b/xml/issue2571.xml
@@ -10,7 +10,7 @@
 
 <discussion>
 <p>
-The initial paragraphs of <sref ref="[map.modifiers]"/> currently says:
+The initial paragraphs of <sref ref="[map.modifiers]"/> currently read:
 </p>
 <blockquote>
 <pre>
@@ -30,6 +30,9 @@ P&amp;&amp;&gt;::value</tt> is <tt>true</tt>.
 </blockquote>
 </blockquote>
 <p>
+Clearly, p2's requirement makes no sense for <tt>insert(InputIterator, InputIterator)</tt> - it doesn't even have 
+a template parameter called <tt>P</tt>.
+<p/>
 This paragraph used to have text saying "The signature taking <tt>InputIterator</tt> parameters does not require 
 <tt>CopyConstructible</tt> of either <tt>key_type</tt> or <tt>mapped_type</tt> if the dereferenced <tt>InputIterator</tt> 
 returns a non-<tt>const</tt> rvalue <tt>pair&lt;key_type,mapped_type&gt;</tt>. Otherwise <tt>CopyConstructible</tt> is 


### PR DESCRIPTION
A sentence explaining what makes no sense was dropped.