### PR TITLE
[LWG2545] Actually set status to Tentatively Ready

### DIFF
--- a/xml/issue2545.xml
+++ b/xml/issue2545.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="2545" status="New">
+<issue num="2545" status="Tentatively Ready">
 <title>Simplify wording for <tt>bind</tt> without explicitly specified return type</title>
 <section><sref ref="[func.bind.bind]"/></section>
 <submitter>Tomasz Kami&nacute;ski</submitter>


### PR DESCRIPTION
https://github.com/cplusplus/LWG/commit/bf0b7cd2dc48e142ac879e3f9376b99124f16f76#diff-3e13bfb7e2d3efd9c1d4106401c6bda0 added a note saying "Move to Tentatively ready" without actually changing the issue status.

Feel free to reject if that's actually the intent :)