### PR TITLE
[LWG2566] Adjust example in discussion

### DIFF
--- a/xml/issue2566.xml
+++ b/xml/issue2566.xml
@@ -17,7 +17,7 @@ argument (which need not be used) for the second template parameter (<tt>Contain
 are defined using <tt>Container</tt>'s member typedefs.
 <p/>
 This permits confusing and arguably nonsensical types like <tt>queue&lt;double, deque&lt;std::string&gt;&gt;</tt> or 
-<tt>priority_queue&lt;void, vector&lt;int&gt;&gt;</tt>, which presumably wasn't intended.
+<tt>priority_queue&lt;std::nothrow_t, vector&lt;int&gt;&gt;</tt>, which presumably wasn't intended.
 </p>
 </discussion>
 


### PR DESCRIPTION
`priority_queue<void, stuff>` is actually banned by [res.on.functions]/2.5.