### PR TITLE
Tweak 2705

### DIFF
--- a/xml/issue2705.xml
+++ b/xml/issue2705.xml
@@ -21,7 +21,9 @@ v.assign(v.size() * 2, v[0]);
 </pre></blockquote>
 <p>
 All of these use an element of itself which may be moved or destroyed by
-the modification from what I see so far, the first three are required to work. Please
+the modification.
+<p/>
+From what I see so far, the first three are required to work. Please
 see library issue <iref ref="526"/> for validity of them.
 <p/>
 But only the last one is undefined because it violates a precondition of
@@ -32,33 +34,61 @@ Should it be like that, really?
 The precondition is in table "Sequence container requirements" in
 [sequence.reqmts] (Table 107 at the next of 23.2.3 p3 in N4582).
 </p>
-<ul>
-<li><p><tt>X</tt> denotes a sequence container class</p></li>
-<li><p><tt>a</tt> denotes a value of <tt>X</tt> containing elements of type <tt>T</tt></p></li>
-<li><p><tt>n</tt> denotes a value of <tt>X::size_type</tt></p></li>
-<li><p><tt>t</tt> denotes an lvalue or a <tt>const</tt> rvalue of <tt>X::value_type</tt></p></li>
-</ul>
-<blockquote><p>
-<tt>a.assign(n,t)</tt> <tt>void</tt><br/>
+<blockquote>
+<p>
+In Tables 107 and 108, <tt>X</tt> denotes a sequence container class,
+<tt>a</tt> denotes a value of <tt>X</tt> containing elements of type <tt>T</tt>,
+... <tt>n</tt> denotes a value of <tt>X::size_type</tt>,
+... <tt>t</tt> denotes an lvalue or a <tt>const</tt> rvalue of <tt>X::value_type</tt>,
+...
+</p>
+<p>...</p>
+<table border="1">
+<caption>Table 107 &mdash; Sequence container requirements (in addition to container)</caption>
+<tr>
+<th>Expression</th>
+<th>Return type</th>
+<th>Assertion&#47;note<br/>pre-&#47;post-condition</th>
+</tr>
+<tr>
+<td colspan="3" align="center">
+<tt>[&hellip;]</tt>
+</td>
+</tr>
+<tr>
+<td>
+<tt>a.assign(n, t)</tt>
+</td>
+<td><tt>void</tt></td>
+<td>
 <i>Requires</i>: <tt>T</tt> shall be <tt>CopyInsertable</tt> into <tt>X</tt> and <tt>CopyAssignable</tt>.<br/>
 pre: <tt>t</tt> is not a reference into <tt>a</tt>.<br/>
 Replaces elements in <tt>a</tt> with <tt>n</tt> copies of <tt>t</tt>.
-</p></blockquote>
+</td>
+</tr>
+</table>
+</blockquote>
 <p>
 I looked into the following implementations:
 </p>
 <ul>
 <li><p>
-libc++ relies on the precondition. It deallocates first on <tt>n &gt; capacity()</tt> case, 
+libc++ relies on the precondition.
+<p/>
+It deallocates first on <tt>n &gt; capacity()</tt> case,
 see <a href="https://github.com/llvm-mirror/libcxx/blob/release_38/include/vector#L1415">here</a>.
 </p></li>
 <li><p>
-libstdc++ doesn't rely on the precondition. It creates temporary <tt>vector(n, t)</tt> and <tt>swap()</tt> 
-on <tt>n &gt; capacity()</tt> case, see 
+libstdc++ doesn't rely on the precondition.
+<p/>
+It creates temporary <tt>vector(n, t)</tt> and <tt>swap()</tt>
+on <tt>n &gt; capacity()</tt> case, see
 <a href="https://github.com/gcc-mirror/gcc/blob/gcc_5_3_0_release/libstdc%2B%2B-v3/include/bits/vector.tcc#L223">here</a>.
 </p></li>
 <li><p>
-MSVC relies on the precondition. It unconditionally does <tt>clear()</tt> and then <tt>insert(begin(), n, t)</tt>.
+MSVC relies on the precondition.
+<p/>
+It unconditionally does <tt>clear()</tt> and then <tt>insert(begin(), n, t)</tt>.
 I looked into my local "%PROGRAMFILES(X86)%/Microsoft Visual Studio 14.0/VC/include/vector".
 </p></li>
 </ul>


### PR DESCRIPTION
- Break wrongly connected sentences
- Make the blockquote looks more like from the standard
- Add breaks to make the inconsistency among implementations easier to
  see