### PR TITLE
[LWG2685] correct <section> + formatting fixes

### DIFF
--- a/xml/issue2685.xml
+++ b/xml/issue2685.xml
@@ -2,17 +2,17 @@
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
 <issue num="2685" status="New">
-<title>shared_ptr deleters must not not throw on move construction</title>
-<section><sref ref="[section.ref.here]"/></section>
+<title><tt>shared_ptr</tt> deleters must not not throw on move construction</title>
+<section><sref ref="[util.smartptr.shared.const]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>3 May 2016</date>
 <priority>99</priority>
 
 <discussion>
-<p>In [util.smartptr.shared.const] p8 the shared_ptr constructors taking
+<p>In <sref ref="[util.smartptr.shared.const]"/> p8 the <tt>shared_ptr</tt> constructors taking
 a deleter say:</p>
 
-<p>"The copy constructor and destructor of D shall not throw exceptions."</p>
+<blockquote><p>The copy constructor and destructor of <tt>D</tt> shall not throw exceptions.</p></blockquote>
 
 <p>It's been pointed out that this doesn't forbid throwing moves, which
 makes it difficult to avoid a leak here:</p>
@@ -33,7 +33,7 @@ constructor might not be a copy constructor, and that copies made
 using any constructor must not throw.</p>
 
 <p>N.B. the same wording is used for the allocator argument, but that's
-redundant because the Allocator requirements already forbid exceptions
+redundant because the <tt>Allocator</tt> requirements already forbid exceptions
 when copying or moving.
 </p>
 </discussion>
@@ -41,24 +41,27 @@ when copying or moving.
 <resolution>
 <p>
 [Drafting note: the relevant expressions we're concerned about are
-enumerated in the CopyConstructible and MoveConstructible
+enumerated in the <tt>CopyConstructible</tt> and <tt>MoveConstructible</tt>
 requirements, so I see no need to repeat them by saying something
-clunky like "Initialization of an object of type D from an expression
-of type (possibly const) D shall not throw exceptions", we can just
+clunky like "Initialization of an object of type <tt>D</tt> from an expression
+of type (possibly const) <tt>D</tt> shall not throw exceptions", we can just
 refer to them. An alternative would be to define
-NothrowCopyConstructible, which includes CopyConstructible but
+<tt>NothrowCopyConstructible</tt>, which includes <tt>CopyConstructible</tt> but
 requires that construction and destruction do not throw.]
 </p>
 
 <p>
-Change [util.smartptr.shared.const] p8
+Change <sref ref="[util.smartptr.shared.const]"/> p8:
 </p>
 
+<blockquote>
 <p>
-<tt>D</tt> shall be CopyConstructible <ins>and such construction shall not
+<tt>D</tt> shall be <tt>CopyConstructible</tt> <ins>and such construction shall not
 throw exceptions.</ins> The <del>copy constructor and</del> destructor
 of <tt>D</tt> shall not throw exceptions.
 </p>
+</blockquote>
+
 </resolution>
 
 </issue>


### PR DESCRIPTION
Fix [section.ref.here], added a bunch of `<tt>`'s, and indented two quotes.