### PR TITLE
Tweak 2710 (small correction and improvements)

### DIFF
--- a/xml/issue2710.xml
+++ b/xml/issue2710.xml
@@ -10,23 +10,23 @@
 
 <discussion>
 <p>
-From N4582 [structure.specifications] p3 and p4
+From N4582 17.5.1.4 [structure.specifications] p3 and p4
 </p>
 <blockquote>
 <p>
 -3- Descriptions of function semantics contain the following elements (as appropriate):
 </p>
 <ul>
-<li><p><i>Requires</i>: the preconditions for calling the function</p></li>
-<li><p><i>Effects</i>: the actions performed by the function</p></li>
-<li><p><i>Synchronization</i>: the synchronization operations (1.10) applicable to the function</p></li>
-<li><p><i>Postconditions</i>: the observable results established by the function</p></li>
-<li><p><i>Returns</i>: a description of the value(s) returned by the function</p></li>
-<li><p><i>Throws</i>: any exceptions thrown by the function, and the conditions that would cause the exception</p></li>
-<li><p><i>Complexity</i>: the time and/or space complexity of the function</p></li>
-<li><p><i>Remarks</i>: additional semantic constraints on the function</p></li>
-<li><p><i>Error conditions</i>: the error conditions for error codes reported by the function.</p></li>
-<li><p><i>Notes</i>: non-normative comments about the function</p></li>
+<li><i>Requires</i>: the preconditions for calling the function</li>
+<li><i>Effects</i>: the actions performed by the function</li>
+<li><i>Synchronization</i>: the synchronization operations (1.10) applicable to the function</li>
+<li><i>Postconditions</i>: the observable results established by the function</li>
+<li><i>Returns</i>: a description of the value(s) returned by the function</li>
+<li><i>Throws</i>: any exceptions thrown by the function, and the conditions that would cause the exception</li>
+<li><i>Complexity</i>: the time and/or space complexity of the function</li>
+<li><i>Remarks</i>: additional semantic constraints on the function</li>
+<li><i>Error conditions</i>: the error conditions for error codes reported by the function.</li>
+<li><i>Notes</i>: non-normative comments about the function</li>
 </ul>
 <p>
 -4- Whenever the <i>Effects:</i> element specifies that the semantics of some function <tt>F</tt> are 
@@ -43,9 +43,8 @@ sequence.
 </p>
 </blockquote>
 <p>
-The last sentence of the above quoted part says "the semantics of the
-code sequence are determined by ..." and lists all elements in p3 except
-"<i>Synchronization:</i>" .
+The third sentence of p4 says "the semantics of the code sequence are determined
+by ..." and lists all elements in p3 except "<i>Synchronization:</i>" .
 <p/>
 I think it was just an oversight because p4 was added by library issue
 <iref ref="997"/>, and its proposed resolution was drafted at the time (2009) before


### PR DESCRIPTION
- Put the section number for ease to identify the quoted section
- Save spaces of p3
- Correct the reference to the sentence in question
- Put the paragraph number on the resolution to be more specific