### PR TITLE
[LWG2714] That extractor isn't a member

### DIFF
--- a/xml/issue2714.xml
+++ b/xml/issue2714.xml
@@ -88,7 +88,7 @@ operator>>(basic_istream&lt;charT, traits&gt;&amp; is, complex&lt;T&gt;&amp; x);
 <li> Otherwise, returns the character to <tt>is</tt>, extracts an object <tt>u</tt> of type <tt>T</tt> from <tt>is</tt>, and assigns <tt>complex&lt;T&gt;(u)</tt> to <tt>x</tt>.
 </li>
 </ul>
-In the description above, characters are extracted from <tt>is</tt> as if by <tt>basic_istream::operator&gt;&gt;</tt> (<sref ref="[istream::extractors]"/>), and returned
+In the description above, characters are extracted from <tt>is</tt> as if by <tt>operator&gt;&gt;</tt> (<sref ref="[istream::extractors]"/>), and returned
 to the stream as if by <tt>basic_istream::putback</tt> (<sref ref="[istream.unformatted]" />). Character equality is determined using <tt>traits::eq</tt>.
 An object <tt>t</tt> of type <tt>T</tt> is extracted from <tt>is</tt> as if by <tt> is &gt;&gt; t</tt>.
 <p/>


### PR DESCRIPTION
I copied this wording from [quoted.manip], turns out it's wrong :(