### PR TITLE
use <iref> in lwg-issues.xml

### DIFF
--- a/xml/lwg-issues.xml
+++ b/xml/lwg-issues.xml
@@ -214,15 +214,15 @@ ownership of it.
 <li>2240 issues total, up by 50.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 10 Tentatively Ready issues: <a href="lwg-active.html#2596">2596</a>, <a href="lwg-active.html#2683">2683</a>, <a href="lwg-active.html#2684">2684</a>, <a href="lwg-active.html#2685">2685</a>, <a href="lwg-active.html#2688">2688</a>, <a href="lwg-active.html#2689">2689</a>, <a href="lwg-active.html#2698">2698</a>, <a href="lwg-active.html#2706">2706</a>, <a href="lwg-active.html#2707">2707</a>, <a href="lwg-active.html#2710">2710</a>.</li>
-<li>Added the following Tentatively NAD issue: <a href="lwg-active.html#2692">2692</a>.</li>
-<li>Added the following 37 New issues: <a href="lwg-active.html#2595">2595</a>, <a href="lwg-active.html#2597">2597</a>, <a href="lwg-active.html#2598">2598</a>, <a href="lwg-active.html#2599">2599</a>, <a href="lwg-active.html#2675">2675</a>, <a href="lwg-active.html#2676">2676</a>, <a href="lwg-active.html#2677">2677</a>, <a href="lwg-active.html#2678">2678</a>, <a href="lwg-active.html#2679">2679</a>, <a href="lwg-active.html#2680">2680</a>, <a href="lwg-active.html#2681">2681</a>, <a href="lwg-active.html#2682">2682</a>, <a href="lwg-active.html#2686">2686</a>, <a href="lwg-active.html#2687">2687</a>, <a href="lwg-active.html#2691">2691</a>, <a href="lwg-active.html#2693">2693</a>, <a href="lwg-active.html#2694">2694</a>, <a href="lwg-active.html#2695">2695</a>, <a href="lwg-active.html#2696">2696</a>, <a href="lwg-active.html#2697">2697</a>, <a href="lwg-active.html#2699">2699</a>, <a href="lwg-active.html#2700">2700</a>, <a href="lwg-active.html#2701">2701</a>, <a href="lwg-active.html#2702">2702</a>, <a href="lwg-active.html#2703">2703</a>, <a href="lwg-active.html#2704">2704</a>, <a href="lwg-active.html#2705">2705</a>, <a href="lwg-active.html#2708">2708</a>, <a href="lwg-active.html#2709">2709</a>, <a href="lwg-active.html#2711">2711</a>, <a href="lwg-active.html#2712">2712</a>, <a href="lwg-active.html#2713">2713</a>, <a href="lwg-active.html#2714">2714</a>, <a href="lwg-active.html#2715">2715</a>, <a href="lwg-active.html#2716">2716</a>, <a href="lwg-active.html#2717">2717</a>, <a href="lwg-active.html#2718">2718</a>.</li>
-<li>Added the following 2 LEWG issues: <a href="lwg-active.html#2600">2600</a>, <a href="lwg-active.html#2690">2690</a>.</li>
-<li>Changed the following issue to Tentatively Ready (from New): <a href="lwg-active.html#2674">2674</a>.</li>
-<li>Changed the following issue to Tentatively Ready (from Open): <a href="lwg-active.html#2509">2509</a>.</li>
-<li>Changed the following 2 issues to Tentatively Resolved (from New): <a href="lwg-active.html#2208">2208</a>, <a href="lwg-active.html#2529">2529</a>.</li>
-<li>Changed the following issue to Tentatively Resolved (from Open): <a href="lwg-active.html#2179">2179</a>.</li>
-<li>Changed the following issue to Tentatively Resolved (from LEWG): <a href="lwg-active.html#2391">2391</a>.</li>
+<li>Added the following 10 Tentatively Ready issues: <iref ref="2596" />, <iref ref="2683" />, <iref ref="2684" />, <iref ref="2685" />, <iref ref="2688" />, <iref ref="2689" />, <iref ref="2698" />, <iref ref="2706" />, <iref ref="2707" />, <iref ref="2710" />.</li>
+<li>Added the following Tentatively NAD issue: <iref ref="2692" />.</li>
+<li>Added the following 37 New issues: <iref ref="2595" />, <iref ref="2597" />, <iref ref="2598" />, <iref ref="2599" />, <iref ref="2675" />, <iref ref="2676" />, <iref ref="2677" />, <iref ref="2678" />, <iref ref="2679" />, <iref ref="2680" />, <iref ref="2681" />, <iref ref="2682" />, <iref ref="2686" />, <iref ref="2687" />, <iref ref="2691" />, <iref ref="2693" />, <iref ref="2694" />, <iref ref="2695" />, <iref ref="2696" />, <iref ref="2697" />, <iref ref="2699" />, <iref ref="2700" />, <iref ref="2701" />, <iref ref="2702" />, <iref ref="2703" />, <iref ref="2704" />, <iref ref="2705" />, <iref ref="2708" />, <iref ref="2709" />, <iref ref="2711" />, <iref ref="2712" />, <iref ref="2713" />, <iref ref="2714" />, <iref ref="2715" />, <iref ref="2716" />, <iref ref="2717" />, <iref ref="2718" />.</li>
+<li>Added the following 2 LEWG issues: <iref ref="2600" />, <iref ref="2690" />.</li>
+<li>Changed the following issue to Tentatively Ready (from New): <iref ref="2674" />.</li>
+<li>Changed the following issue to Tentatively Ready (from Open): <iref ref="2509" />.</li>
+<li>Changed the following 2 issues to Tentatively Resolved (from New): <iref ref="2208" />, <iref ref="2529" />.</li>
+<li>Changed the following issue to Tentatively Resolved (from Open): <iref ref="2179" />.</li>
+<li>Changed the following issue to Tentatively Resolved (from LEWG): <iref ref="2391" />.</li>
 </ul></li>
 </ul>
 </li>
@@ -237,24 +237,24 @@ ownership of it.
 <li>2190 issues total, up by 3.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 3 New issues: <a href="lwg-active.html#2592">2592</a>, <a href="lwg-active.html#2593">2593</a>, <a href="lwg-active.html#2594">2594</a>.</li>
-<li>Changed the following 7 issues to Ready (from Review): <a href="lwg-active.html#2181">2181</a>, <a href="lwg-active.html#2309">2309</a>, <a href="lwg-active.html#2310">2310</a>, <a href="lwg-active.html#2328">2328</a>, <a href="lwg-active.html#2393">2393</a>, <a href="lwg-active.html#2441">2441</a>, <a href="lwg-active.html#2516">2516</a>.</li>
-<li>Changed the following 11 issues to Ready (from New): <a href="lwg-active.html#2542">2542</a>, <a href="lwg-active.html#2549">2549</a>, <a href="lwg-active.html#2550">2550</a>, <a href="lwg-active.html#2551">2551</a>, <a href="lwg-active.html#2555">2555</a>, <a href="lwg-active.html#2573">2573</a>, <a href="lwg-active.html#2667">2667</a>, <a href="lwg-active.html#2669">2669</a>, <a href="lwg-active.html#2670">2670</a>, <a href="lwg-active.html#2671">2671</a>, <a href="lwg-active.html#2673">2673</a>.</li>
-<li>Changed the following issue to Ready (from Open): <a href="lwg-active.html#2426">2426</a>.</li>
-<li>Changed the following 2 issues to Ready (from LEWG): <a href="lwg-active.html#2436">2436</a>, <a href="lwg-active.html#2451">2451</a>.</li>
-<li>Changed the following issue to Open (from Review): <a href="lwg-active.html#2424">2424</a>.</li>
-<li>Changed the following issue to Open (from New): <a href="lwg-active.html#2368">2368</a>.</li>
-<li>Changed the following 3 issues to WP (from Ready): <a href="lwg-defects.html#2276">2276</a>, <a href="lwg-defects.html#2523">2523</a>, <a href="lwg-defects.html#2537">2537</a>.</li>
-<li>Changed the following 25 issues to WP (from Tentatively Ready): <a href="lwg-defects.html#2192">2192</a>, <a href="lwg-defects.html#2450">2450</a>, <a href="lwg-defects.html#2520">2520</a>, <a href="lwg-defects.html#2522">2522</a>, <a href="lwg-defects.html#2539">2539</a>, <a href="lwg-defects.html#2545">2545</a>, <a href="lwg-defects.html#2557">2557</a>, <a href="lwg-defects.html#2558">2558</a>, <a href="lwg-defects.html#2559">2559</a>, <a href="lwg-defects.html#2560">2560</a>, <a href="lwg-defects.html#2565">2565</a>, <a href="lwg-defects.html#2566">2566</a>, <a href="lwg-defects.html#2571">2571</a>, <a href="lwg-defects.html#2572">2572</a>, <a href="lwg-defects.html#2574">2574</a>, <a href="lwg-defects.html#2575">2575</a>, <a href="lwg-defects.html#2576">2576</a>, <a href="lwg-defects.html#2577">2577</a>, <a href="lwg-defects.html#2579">2579</a>, <a href="lwg-defects.html#2581">2581</a>, <a href="lwg-defects.html#2582">2582</a>, <a href="lwg-defects.html#2583">2583</a>, <a href="lwg-defects.html#2585">2585</a>, <a href="lwg-defects.html#2586">2586</a>, <a href="lwg-defects.html#2590">2590</a>.</li>
-<li>Changed the following issue to WP (from Review): <a href="lwg-defects.html#2296">2296</a>.</li>
-<li>Changed the following issue to Resolved (from New): <a href="lwg-defects.html#2554">2554</a>.</li>
-<li>Changed the following issue to Resolved (from Open): <a href="lwg-defects.html#2456">2456</a>.</li>
-<li>Changed the following issue to NAD Editorial (from New): <a href="lwg-closed.html#2666">2666</a>.</li>
-<li>Changed the following issue to NAD (from Review): <a href="lwg-closed.html#2402">2402</a>.</li>
-<li>Changed the following issue to NAD (from New): <a href="lwg-closed.html#2553">2553</a>.</li>
-<li>Changed the following issue to NAD (from LEWG): <a href="lwg-closed.html#2372">2372</a>.</li>
-<li>Changed the following 2 issues to NAD Arrays (from Ready): <a href="lwg-closed.html#2253">2253</a>, <a href="lwg-closed.html#2255">2255</a>.</li>
-<li>Changed the following 3 issues to NAD Arrays (from Open): <a href="lwg-closed.html#2254">2254</a>, <a href="lwg-closed.html#2264">2264</a>, <a href="lwg-closed.html#2277">2277</a>.</li>
+<li>Added the following 3 New issues: <iref ref="2592" />, <iref ref="2593" />, <iref ref="2594" />.</li>
+<li>Changed the following 7 issues to Ready (from Review): <iref ref="2181" />, <iref ref="2309" />, <iref ref="2310" />, <iref ref="2328" />, <iref ref="2393" />, <iref ref="2441" />, <iref ref="2516" />.</li>
+<li>Changed the following 11 issues to Ready (from New): <iref ref="2542" />, <iref ref="2549" />, <iref ref="2550" />, <iref ref="2551" />, <iref ref="2555" />, <iref ref="2573" />, <iref ref="2667" />, <iref ref="2669" />, <iref ref="2670" />, <iref ref="2671" />, <iref ref="2673" />.</li>
+<li>Changed the following issue to Ready (from Open): <iref ref="2426" />.</li>
+<li>Changed the following 2 issues to Ready (from LEWG): <iref ref="2436" />, <iref ref="2451" />.</li>
+<li>Changed the following issue to Open (from Review): <iref ref="2424" />.</li>
+<li>Changed the following issue to Open (from New): <iref ref="2368" />.</li>
+<li>Changed the following 3 issues to WP (from Ready): <iref ref="2276" />, <iref ref="2523" />, <iref ref="2537" />.</li>
+<li>Changed the following 25 issues to WP (from Tentatively Ready): <iref ref="2192" />, <iref ref="2450" />, <iref ref="2520" />, <iref ref="2522" />, <iref ref="2539" />, <iref ref="2545" />, <iref ref="2557" />, <iref ref="2558" />, <iref ref="2559" />, <iref ref="2560" />, <iref ref="2565" />, <iref ref="2566" />, <iref ref="2571" />, <iref ref="2572" />, <iref ref="2574" />, <iref ref="2575" />, <iref ref="2576" />, <iref ref="2577" />, <iref ref="2579" />, <iref ref="2581" />, <iref ref="2582" />, <iref ref="2583" />, <iref ref="2585" />, <iref ref="2586" />, <iref ref="2590" />.</li>
+<li>Changed the following issue to WP (from Review): <iref ref="2296" />.</li>
+<li>Changed the following issue to Resolved (from New): <iref ref="2554" />.</li>
+<li>Changed the following issue to Resolved (from Open): <iref ref="2456" />.</li>
+<li>Changed the following issue to NAD Editorial (from New): <iref ref="2666" />.</li>
+<li>Changed the following issue to NAD (from Review): <iref ref="2402" />.</li>
+<li>Changed the following issue to NAD (from New): <iref ref="2553" />.</li>
+<li>Changed the following issue to NAD (from LEWG): <iref ref="2372" />.</li>
+<li>Changed the following 2 issues to NAD Arrays (from Ready): <iref ref="2253" />, <iref ref="2255" />.</li>
+<li>Changed the following 3 issues to NAD Arrays (from Open): <iref ref="2254" />, <iref ref="2264" />, <iref ref="2277" />.</li>
 </ul></li>
 </ul>
 </revision>
@@ -269,16 +269,16 @@ ownership of it.
 <li>2187 issues total, up by 111.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 19 Tentatively Ready issues: <a href="lwg-active.html#2557">2557</a>, <a href="lwg-active.html#2558">2558</a>, <a href="lwg-active.html#2559">2559</a>, <a href="lwg-active.html#2560">2560</a>, <a href="lwg-active.html#2565">2565</a>, <a href="lwg-active.html#2566">2566</a>, <a href="lwg-active.html#2571">2571</a>, <a href="lwg-active.html#2572">2572</a>, <a href="lwg-active.html#2574">2574</a>, <a href="lwg-active.html#2575">2575</a>, <a href="lwg-active.html#2576">2576</a>, <a href="lwg-active.html#2577">2577</a>, <a href="lwg-active.html#2579">2579</a>, <a href="lwg-active.html#2581">2581</a>, <a href="lwg-active.html#2582">2582</a>, <a href="lwg-active.html#2583">2583</a>, <a href="lwg-active.html#2585">2585</a>, <a href="lwg-active.html#2586">2586</a>, <a href="lwg-active.html#2590">2590</a>.</li>
-<li>Added the following 30 New issues: <a href="lwg-active.html#2554">2554</a>, <a href="lwg-active.html#2555">2555</a>, <a href="lwg-active.html#2556">2556</a>, <a href="lwg-active.html#2561">2561</a>, <a href="lwg-active.html#2562">2562</a>, <a href="lwg-active.html#2563">2563</a>, <a href="lwg-active.html#2564">2564</a>, <a href="lwg-active.html#2567">2567</a>, <a href="lwg-active.html#2568">2568</a>, <a href="lwg-active.html#2569">2569</a>, <a href="lwg-active.html#2570">2570</a>, <a href="lwg-active.html#2573">2573</a>, <a href="lwg-active.html#2578">2578</a>, <a href="lwg-active.html#2584">2584</a>, <a href="lwg-active.html#2587">2587</a>, <a href="lwg-active.html#2588">2588</a>, <a href="lwg-active.html#2589">2589</a>, <a href="lwg-active.html#2591">2591</a>, <a href="lwg-active.html#2663">2663</a>, <a href="lwg-active.html#2664">2664</a>, <a href="lwg-active.html#2665">2665</a>, <a href="lwg-active.html#2666">2666</a>, <a href="lwg-active.html#2667">2667</a>, <a href="lwg-active.html#2668">2668</a>, <a href="lwg-active.html#2669">2669</a>, <a href="lwg-active.html#2670">2670</a>, <a href="lwg-active.html#2671">2671</a>, <a href="lwg-active.html#2672">2672</a>, <a href="lwg-active.html#2673">2673</a>, <a href="lwg-active.html#2674">2674</a>.</li>
-<li>Added the following 3 NAD Future issues: <a href="lwg-closed.html#2611">2611</a>, <a href="lwg-closed.html#2612">2612</a>, <a href="lwg-closed.html#2654">2654</a>.</li>
-<li>Added the following 41 WP issues: <a href="lwg-defects.html#2601">2601</a>, <a href="lwg-defects.html#2602">2602</a>, <a href="lwg-defects.html#2603">2603</a>, <a href="lwg-defects.html#2605">2605</a>, <a href="lwg-defects.html#2606">2606</a>, <a href="lwg-defects.html#2607">2607</a>, <a href="lwg-defects.html#2608">2608</a>, <a href="lwg-defects.html#2609">2609</a>, <a href="lwg-defects.html#2614">2614</a>, <a href="lwg-defects.html#2615">2615</a>, <a href="lwg-defects.html#2616">2616</a>, <a href="lwg-defects.html#2618">2618</a>, <a href="lwg-defects.html#2619">2619</a>, <a href="lwg-defects.html#2621">2621</a>, <a href="lwg-defects.html#2622">2622</a>, <a href="lwg-defects.html#2624">2624</a>, <a href="lwg-defects.html#2625">2625</a>, <a href="lwg-defects.html#2627">2627</a>, <a href="lwg-defects.html#2629">2629</a>, <a href="lwg-defects.html#2632">2632</a>, <a href="lwg-defects.html#2633">2633</a>, <a href="lwg-defects.html#2634">2634</a>, <a href="lwg-defects.html#2635">2635</a>, <a href="lwg-defects.html#2636">2636</a>, <a href="lwg-defects.html#2637">2637</a>, <a href="lwg-defects.html#2640">2640</a>, <a href="lwg-defects.html#2641">2641</a>, <a href="lwg-defects.html#2644">2644</a>, <a href="lwg-defects.html#2645">2645</a>, <a href="lwg-defects.html#2647">2647</a>, <a href="lwg-defects.html#2648">2648</a>, <a href="lwg-defects.html#2649">2649</a>, <a href="lwg-defects.html#2650">2650</a>, <a href="lwg-defects.html#2652">2652</a>, <a href="lwg-defects.html#2653">2653</a>, <a href="lwg-defects.html#2655">2655</a>, <a href="lwg-defects.html#2656">2656</a>, <a href="lwg-defects.html#2657">2657</a>, <a href="lwg-defects.html#2658">2658</a>, <a href="lwg-defects.html#2660">2660</a>, <a href="lwg-defects.html#2662">2662</a>.</li>
-<li>Added the following 2 NAD Editorial issues: <a href="lwg-closed.html#2639">2639</a>, <a href="lwg-closed.html#2659">2659</a>.</li>
-<li>Added the following 14 NAD issues: <a href="lwg-closed.html#2580">2580</a>, <a href="lwg-closed.html#2604">2604</a>, <a href="lwg-closed.html#2610">2610</a>, <a href="lwg-closed.html#2613">2613</a>, <a href="lwg-closed.html#2617">2617</a>, <a href="lwg-closed.html#2623">2623</a>, <a href="lwg-closed.html#2626">2626</a>, <a href="lwg-closed.html#2628">2628</a>, <a href="lwg-closed.html#2630">2630</a>, <a href="lwg-closed.html#2631">2631</a>, <a href="lwg-closed.html#2638">2638</a>, <a href="lwg-closed.html#2642">2642</a>, <a href="lwg-closed.html#2646">2646</a>, <a href="lwg-closed.html#2661">2661</a>.</li>
-<li>Added the following 2 Dup issues: <a href="lwg-closed.html#2643">2643</a>, <a href="lwg-closed.html#2651">2651</a>.</li>
-<li>Changed the following issue to Tentatively Ready (from New): <a href="lwg-active.html#2545">2545</a>.</li>
-<li>Changed the following 2 issues to Review (from Open): <a href="lwg-active.html#2310">2310</a>, <a href="lwg-active.html#2516">2516</a>.</li>
-<li>Changed the following issue to NAD (from New): <a href="lwg-closed.html#2552">2552</a>.</li>
+<li>Added the following 19 Tentatively Ready issues: <iref ref="2557" />, <iref ref="2558" />, <iref ref="2559" />, <iref ref="2560" />, <iref ref="2565" />, <iref ref="2566" />, <iref ref="2571" />, <iref ref="2572" />, <iref ref="2574" />, <iref ref="2575" />, <iref ref="2576" />, <iref ref="2577" />, <iref ref="2579" />, <iref ref="2581" />, <iref ref="2582" />, <iref ref="2583" />, <iref ref="2585" />, <iref ref="2586" />, <iref ref="2590" />.</li>
+<li>Added the following 30 New issues: <iref ref="2554" />, <iref ref="2555" />, <iref ref="2556" />, <iref ref="2561" />, <iref ref="2562" />, <iref ref="2563" />, <iref ref="2564" />, <iref ref="2567" />, <iref ref="2568" />, <iref ref="2569" />, <iref ref="2570" />, <iref ref="2573" />, <iref ref="2578" />, <iref ref="2584" />, <iref ref="2587" />, <iref ref="2588" />, <iref ref="2589" />, <iref ref="2591" />, <iref ref="2663" />, <iref ref="2664" />, <iref ref="2665" />, <iref ref="2666" />, <iref ref="2667" />, <iref ref="2668" />, <iref ref="2669" />, <iref ref="2670" />, <iref ref="2671" />, <iref ref="2672" />, <iref ref="2673" />, <iref ref="2674" />.</li>
+<li>Added the following 3 NAD Future issues: <iref ref="2611" />, <iref ref="2612" />, <iref ref="2654" />.</li>
+<li>Added the following 41 WP issues: <iref ref="2601" />, <iref ref="2602" />, <iref ref="2603" />, <iref ref="2605" />, <iref ref="2606" />, <iref ref="2607" />, <iref ref="2608" />, <iref ref="2609" />, <iref ref="2614" />, <iref ref="2615" />, <iref ref="2616" />, <iref ref="2618" />, <iref ref="2619" />, <iref ref="2621" />, <iref ref="2622" />, <iref ref="2624" />, <iref ref="2625" />, <iref ref="2627" />, <iref ref="2629" />, <iref ref="2632" />, <iref ref="2633" />, <iref ref="2634" />, <iref ref="2635" />, <iref ref="2636" />, <iref ref="2637" />, <iref ref="2640" />, <iref ref="2641" />, <iref ref="2644" />, <iref ref="2645" />, <iref ref="2647" />, <iref ref="2648" />, <iref ref="2649" />, <iref ref="2650" />, <iref ref="2652" />, <iref ref="2653" />, <iref ref="2655" />, <iref ref="2656" />, <iref ref="2657" />, <iref ref="2658" />, <iref ref="2660" />, <iref ref="2662" />.</li>
+<li>Added the following 2 NAD Editorial issues: <iref ref="2639" />, <iref ref="2659" />.</li>
+<li>Added the following 14 NAD issues: <iref ref="2580" />, <iref ref="2604" />, <iref ref="2610" />, <iref ref="2613" />, <iref ref="2617" />, <iref ref="2623" />, <iref ref="2626" />, <iref ref="2628" />, <iref ref="2630" />, <iref ref="2631" />, <iref ref="2638" />, <iref ref="2642" />, <iref ref="2646" />, <iref ref="2661" />.</li>
+<li>Added the following 2 Dup issues: <iref ref="2643" />, <iref ref="2651" />.</li>
+<li>Changed the following issue to Tentatively Ready (from New): <iref ref="2545" />.</li>
+<li>Changed the following 2 issues to Review (from Open): <iref ref="2310" />, <iref ref="2516" />.</li>
+<li>Changed the following issue to NAD (from New): <iref ref="2552" />.</li>
 </ul></li>
 </ul>
 </revision>
@@ -292,22 +292,22 @@ ownership of it.
 <li>2076 issues total, up by 10.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 10 New issues: <a href="lwg-active.html#2544">2544</a>, <a href="lwg-active.html#2545">2545</a>, <a href="lwg-active.html#2546">2546</a>, <a href="lwg-active.html#2547">2547</a>, <a href="lwg-active.html#2548">2548</a>, <a href="lwg-active.html#2549">2549</a>, <a href="lwg-active.html#2550">2550</a>, <a href="lwg-active.html#2551">2551</a>, <a href="lwg-active.html#2552">2552</a>, <a href="lwg-active.html#2553">2553</a>.</li>
-<li>Changed the following 2 issues to Ready (from New): <a href="lwg-active.html#2523">2523</a>, <a href="lwg-active.html#2537">2537</a>.</li>
-<li>Changed the following issue to Ready (from Open): <a href="lwg-active.html#2276">2276</a>.</li>
-<li>Changed the following 3 issues to Tentatively Ready (from New): <a href="lwg-active.html#2520">2520</a>, <a href="lwg-active.html#2522">2522</a>, <a href="lwg-active.html#2539">2539</a>.</li>
-<li>Changed the following 2 issues to Tentatively Ready (from Open): <a href="lwg-active.html#2192">2192</a>, <a href="lwg-active.html#2450">2450</a>.</li>
-<li>Changed the following issue to Review (from Ready): <a href="lwg-active.html#2181">2181</a>.</li>
-<li>Changed the following 4 issues to Review (from Open): <a href="lwg-active.html#2309">2309</a>, <a href="lwg-active.html#2393">2393</a>, <a href="lwg-active.html#2402">2402</a>, <a href="lwg-active.html#2441">2441</a>.</li>
-<li>Changed the following issue to Open (from Tentatively Ready): <a href="lwg-active.html#2510">2510</a>.</li>
-<li>Changed the following 10 issues to Open (from New): <a href="lwg-active.html#2117">2117</a>, <a href="lwg-active.html#2164">2164</a>, <a href="lwg-active.html#2290">2290</a>, <a href="lwg-active.html#2468">2468</a>, <a href="lwg-active.html#2499">2499</a>, <a href="lwg-active.html#2505">2505</a>, <a href="lwg-active.html#2509">2509</a>, <a href="lwg-active.html#2516">2516</a>, <a href="lwg-active.html#2524">2524</a>, <a href="lwg-active.html#2543">2543</a>.</li>
-<li>Changed the following issue to SG1 (from New): <a href="lwg-active.html#2533">2533</a>.</li>
-<li>Changed the following 35 issues to WP (from Ready): <a href="lwg-defects.html#1169">1169</a>, <a href="lwg-defects.html#2072">2072</a>, <a href="lwg-defects.html#2101">2101</a>, <a href="lwg-defects.html#2111">2111</a>, <a href="lwg-defects.html#2119">2119</a>, <a href="lwg-defects.html#2127">2127</a>, <a href="lwg-defects.html#2133">2133</a>, <a href="lwg-defects.html#2156">2156</a>, <a href="lwg-defects.html#2218">2218</a>, <a href="lwg-defects.html#2219">2219</a>, <a href="lwg-defects.html#2244">2244</a>, <a href="lwg-defects.html#2250">2250</a>, <a href="lwg-defects.html#2259">2259</a>, <a href="lwg-defects.html#2336">2336</a>, <a href="lwg-defects.html#2353">2353</a>, <a href="lwg-defects.html#2367">2367</a>, <a href="lwg-defects.html#2380">2380</a>, <a href="lwg-defects.html#2384">2384</a>, <a href="lwg-defects.html#2385">2385</a>, <a href="lwg-defects.html#2435">2435</a>, <a href="lwg-defects.html#2447">2447</a>, <a href="lwg-defects.html#2462">2462</a>, <a href="lwg-defects.html#2466">2466</a>, <a href="lwg-defects.html#2469">2469</a>, <a href="lwg-defects.html#2473">2473</a>, <a href="lwg-defects.html#2476">2476</a>, <a href="lwg-defects.html#2477">2477</a>, <a href="lwg-defects.html#2483">2483</a>, <a href="lwg-defects.html#2484">2484</a>, <a href="lwg-defects.html#2485">2485</a>, <a href="lwg-defects.html#2486">2486</a>, <a href="lwg-defects.html#2487">2487</a>, <a href="lwg-defects.html#2489">2489</a>, <a href="lwg-defects.html#2492">2492</a>, <a href="lwg-defects.html#2494">2494</a>.</li>
-<li>Changed the following 8 issues to WP (from Tentatively Ready): <a href="lwg-defects.html#2224">2224</a>, <a href="lwg-defects.html#2234">2234</a>, <a href="lwg-defects.html#2273">2273</a>, <a href="lwg-defects.html#2495">2495</a>, <a href="lwg-defects.html#2500">2500</a>, <a href="lwg-defects.html#2515">2515</a>, <a href="lwg-defects.html#2517">2517</a>, <a href="lwg-defects.html#2526">2526</a>.</li>
-<li>Changed the following issue to Resolved (from Core): <a href="lwg-defects.html#2165">2165</a>.</li>
-<li>Changed the following 2 issues to NAD (from New): <a href="lwg-closed.html#2474">2474</a>, <a href="lwg-closed.html#2538">2538</a>.</li>
-<li>Changed the following issue to NAD (from Open): <a href="lwg-closed.html#2379">2379</a>.</li>
-<li>Changed the following issue to NAD (from Resolved): <a href="lwg-closed.html#2319">2319</a>.</li>
+<li>Added the following 10 New issues: <iref ref="2544" />, <iref ref="2545" />, <iref ref="2546" />, <iref ref="2547" />, <iref ref="2548" />, <iref ref="2549" />, <iref ref="2550" />, <iref ref="2551" />, <iref ref="2552" />, <iref ref="2553" />.</li>
+<li>Changed the following 2 issues to Ready (from New): <iref ref="2523" />, <iref ref="2537" />.</li>
+<li>Changed the following issue to Ready (from Open): <iref ref="2276" />.</li>
+<li>Changed the following 3 issues to Tentatively Ready (from New): <iref ref="2520" />, <iref ref="2522" />, <iref ref="2539" />.</li>
+<li>Changed the following 2 issues to Tentatively Ready (from Open): <iref ref="2192" />, <iref ref="2450" />.</li>
+<li>Changed the following issue to Review (from Ready): <iref ref="2181" />.</li>
+<li>Changed the following 4 issues to Review (from Open): <iref ref="2309" />, <iref ref="2393" />, <iref ref="2402" />, <iref ref="2441" />.</li>
+<li>Changed the following issue to Open (from Tentatively Ready): <iref ref="2510" />.</li>
+<li>Changed the following 10 issues to Open (from New): <iref ref="2117" />, <iref ref="2164" />, <iref ref="2290" />, <iref ref="2468" />, <iref ref="2499" />, <iref ref="2505" />, <iref ref="2509" />, <iref ref="2516" />, <iref ref="2524" />, <iref ref="2543" />.</li>
+<li>Changed the following issue to SG1 (from New): <iref ref="2533" />.</li>
+<li>Changed the following 35 issues to WP (from Ready): <iref ref="1169" />, <iref ref="2072" />, <iref ref="2101" />, <iref ref="2111" />, <iref ref="2119" />, <iref ref="2127" />, <iref ref="2133" />, <iref ref="2156" />, <iref ref="2218" />, <iref ref="2219" />, <iref ref="2244" />, <iref ref="2250" />, <iref ref="2259" />, <iref ref="2336" />, <iref ref="2353" />, <iref ref="2367" />, <iref ref="2380" />, <iref ref="2384" />, <iref ref="2385" />, <iref ref="2435" />, <iref ref="2447" />, <iref ref="2462" />, <iref ref="2466" />, <iref ref="2469" />, <iref ref="2473" />, <iref ref="2476" />, <iref ref="2477" />, <iref ref="2483" />, <iref ref="2484" />, <iref ref="2485" />, <iref ref="2486" />, <iref ref="2487" />, <iref ref="2489" />, <iref ref="2492" />, <iref ref="2494" />.</li>
+<li>Changed the following 8 issues to WP (from Tentatively Ready): <iref ref="2224" />, <iref ref="2234" />, <iref ref="2273" />, <iref ref="2495" />, <iref ref="2500" />, <iref ref="2515" />, <iref ref="2517" />, <iref ref="2526" />.</li>
+<li>Changed the following issue to Resolved (from Core): <iref ref="2165" />.</li>
+<li>Changed the following 2 issues to NAD (from New): <iref ref="2474" />, <iref ref="2538" />.</li>
+<li>Changed the following issue to NAD (from Open): <iref ref="2379" />.</li>
+<li>Changed the following issue to NAD (from Resolved): <iref ref="2319" />.</li>
 </ul></li>
 </ul>
 </revision>
@@ -321,12 +321,12 @@ ownership of it.
 <li>2066 issues total, up by 40.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 4 Tentatively Ready issues: <a href="lwg-active.html#2510">2510</a>, <a href="lwg-active.html#2515">2515</a>, <a href="lwg-active.html#2517">2517</a>, <a href="lwg-active.html#2526">2526</a>.</li>
-<li>Added the following 36 New issues: <a href="lwg-active.html#2504">2504</a>, <a href="lwg-active.html#2505">2505</a>, <a href="lwg-active.html#2506">2506</a>, <a href="lwg-active.html#2507">2507</a>, <a href="lwg-active.html#2508">2508</a>, <a href="lwg-active.html#2509">2509</a>, <a href="lwg-active.html#2511">2511</a>, <a href="lwg-active.html#2512">2512</a>, <a href="lwg-active.html#2513">2513</a>, <a href="lwg-active.html#2514">2514</a>, <a href="lwg-active.html#2516">2516</a>, <a href="lwg-active.html#2518">2518</a>, <a href="lwg-active.html#2519">2519</a>, <a href="lwg-active.html#2520">2520</a>, <a href="lwg-active.html#2521">2521</a>, <a href="lwg-active.html#2522">2522</a>, <a href="lwg-active.html#2523">2523</a>, <a href="lwg-active.html#2524">2524</a>, <a href="lwg-active.html#2525">2525</a>, <a href="lwg-active.html#2527">2527</a>, <a href="lwg-active.html#2528">2528</a>, <a href="lwg-active.html#2529">2529</a>, <a href="lwg-active.html#2530">2530</a>, <a href="lwg-active.html#2531">2531</a>, <a href="lwg-active.html#2532">2532</a>, <a href="lwg-active.html#2533">2533</a>, <a href="lwg-active.html#2534">2534</a>, <a href="lwg-active.html#2535">2535</a>, <a href="lwg-active.html#2536">2536</a>, <a href="lwg-active.html#2537">2537</a>, <a href="lwg-active.html#2538">2538</a>, <a href="lwg-active.html#2539">2539</a>, <a href="lwg-active.html#2540">2540</a>, <a href="lwg-active.html#2541">2541</a>, <a href="lwg-active.html#2542">2542</a>, <a href="lwg-active.html#2543">2543</a>.</li>
-<li>Changed the following 2 issues to Tentatively Ready (from New): <a href="lwg-active.html#2495">2495</a>, <a href="lwg-active.html#2500">2500</a>.</li>
-<li>Changed the following 2 issues to Tentatively Ready (from Open): <a href="lwg-active.html#2234">2234</a>, <a href="lwg-active.html#2273">2273</a>.</li>
-<li>Changed the following issue to Resolved (from Open): <a href="lwg-defects.html#2051">2051</a>.</li>
-<li>Changed the following issue to NAD (from New): <a href="lwg-closed.html#2326">2326</a>.</li>
+<li>Added the following 4 Tentatively Ready issues: <iref ref="2510" />, <iref ref="2515" />, <iref ref="2517" />, <iref ref="2526" />.</li>
+<li>Added the following 36 New issues: <iref ref="2504" />, <iref ref="2505" />, <iref ref="2506" />, <iref ref="2507" />, <iref ref="2508" />, <iref ref="2509" />, <iref ref="2511" />, <iref ref="2512" />, <iref ref="2513" />, <iref ref="2514" />, <iref ref="2516" />, <iref ref="2518" />, <iref ref="2519" />, <iref ref="2520" />, <iref ref="2521" />, <iref ref="2522" />, <iref ref="2523" />, <iref ref="2524" />, <iref ref="2525" />, <iref ref="2527" />, <iref ref="2528" />, <iref ref="2529" />, <iref ref="2530" />, <iref ref="2531" />, <iref ref="2532" />, <iref ref="2533" />, <iref ref="2534" />, <iref ref="2535" />, <iref ref="2536" />, <iref ref="2537" />, <iref ref="2538" />, <iref ref="2539" />, <iref ref="2540" />, <iref ref="2541" />, <iref ref="2542" />, <iref ref="2543" />.</li>
+<li>Changed the following 2 issues to Tentatively Ready (from New): <iref ref="2495" />, <iref ref="2500" />.</li>
+<li>Changed the following 2 issues to Tentatively Ready (from Open): <iref ref="2234" />, <iref ref="2273" />.</li>
+<li>Changed the following issue to Resolved (from Open): <iref ref="2051" />.</li>
+<li>Changed the following issue to NAD (from New): <iref ref="2326" />.</li>
 </ul></li>
 </ul>
 </revision>
@@ -340,28 +340,28 @@ ownership of it.
 <li>2026 issues total, up by 12.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 2 Ready issues: <a href="lwg-active.html#2492">2492</a>, <a href="lwg-active.html#2494">2494</a>.</li>
-<li>Added the following 10 New issues: <a href="lwg-active.html#2493">2493</a>, <a href="lwg-active.html#2495">2495</a>, <a href="lwg-active.html#2496">2496</a>, <a href="lwg-active.html#2497">2497</a>, <a href="lwg-active.html#2498">2498</a>, <a href="lwg-active.html#2499">2499</a>, <a href="lwg-active.html#2500">2500</a>, <a href="lwg-active.html#2501">2501</a>, <a href="lwg-active.html#2502">2502</a>, <a href="lwg-active.html#2503">2503</a>.</li>
-<li>Changed the following 2 issues to Ready (from Review): <a href="lwg-active.html#2111">2111</a>, <a href="lwg-active.html#2380">2380</a>.</li>
-<li>Changed the following 20 issues to Ready (from New): <a href="lwg-active.html#2244">2244</a>, <a href="lwg-active.html#2250">2250</a>, <a href="lwg-active.html#2259">2259</a>, <a href="lwg-active.html#2336">2336</a>, <a href="lwg-active.html#2353">2353</a>, <a href="lwg-active.html#2367">2367</a>, <a href="lwg-active.html#2384">2384</a>, <a href="lwg-active.html#2385">2385</a>, <a href="lwg-active.html#2435">2435</a>, <a href="lwg-active.html#2462">2462</a>, <a href="lwg-active.html#2466">2466</a>, <a href="lwg-active.html#2473">2473</a>, <a href="lwg-active.html#2476">2476</a>, <a href="lwg-active.html#2477">2477</a>, <a href="lwg-active.html#2483">2483</a>, <a href="lwg-active.html#2484">2484</a>, <a href="lwg-active.html#2485">2485</a>, <a href="lwg-active.html#2486">2486</a>, <a href="lwg-active.html#2487">2487</a>, <a href="lwg-active.html#2489">2489</a>.</li>
-<li>Changed the following 12 issues to Ready (from Open): <a href="lwg-active.html#1169">1169</a>, <a href="lwg-active.html#2072">2072</a>, <a href="lwg-active.html#2101">2101</a>, <a href="lwg-active.html#2119">2119</a>, <a href="lwg-active.html#2127">2127</a>, <a href="lwg-active.html#2133">2133</a>, <a href="lwg-active.html#2156">2156</a>, <a href="lwg-active.html#2181">2181</a>, <a href="lwg-active.html#2218">2218</a>, <a href="lwg-active.html#2219">2219</a>, <a href="lwg-active.html#2447">2447</a>, <a href="lwg-active.html#2469">2469</a>.</li>
-<li>Changed the following issue to Tentatively Ready (from Open): <a href="lwg-active.html#2224">2224</a>.</li>
-<li>Changed the following issue to Review (from New): <a href="lwg-active.html#2296">2296</a>.</li>
-<li>Changed the following issue to Review (from Open): <a href="lwg-active.html#2328">2328</a>.</li>
-<li>Changed the following 11 issues to Open (from New): <a href="lwg-active.html#2262">2262</a>, <a href="lwg-active.html#2289">2289</a>, <a href="lwg-active.html#2338">2338</a>, <a href="lwg-active.html#2348">2348</a>, <a href="lwg-active.html#2349">2349</a>, <a href="lwg-active.html#2370">2370</a>, <a href="lwg-active.html#2398">2398</a>, <a href="lwg-active.html#2402">2402</a>, <a href="lwg-active.html#2422">2422</a>, <a href="lwg-active.html#2450">2450</a>, <a href="lwg-active.html#2456">2456</a>.</li>
-<li>Changed the following 8 issues to Open (from SG1): <a href="lwg-active.html#2245">2245</a>, <a href="lwg-active.html#2265">2265</a>, <a href="lwg-active.html#2276">2276</a>, <a href="lwg-active.html#2309">2309</a>, <a href="lwg-active.html#2363">2363</a>, <a href="lwg-active.html#2379">2379</a>, <a href="lwg-active.html#2426">2426</a>, <a href="lwg-active.html#2441">2441</a>.</li>
-<li>Changed the following issue to LEWG (from New): <a href="lwg-active.html#2372">2372</a>.</li>
-<li>Changed the following issue to EWG (from New): <a href="lwg-active.html#2432">2432</a>.</li>
-<li>Changed the following issue to Deferred (from Open): <a href="lwg-active.html#2202">2202</a>.</li>
-<li>Changed the following 14 issues to WP (from Ready): <a href="lwg-defects.html#2160">2160</a>, <a href="lwg-defects.html#2168">2168</a>, <a href="lwg-defects.html#2364">2364</a>, <a href="lwg-defects.html#2403">2403</a>, <a href="lwg-defects.html#2406">2406</a>, <a href="lwg-defects.html#2411">2411</a>, <a href="lwg-defects.html#2425">2425</a>, <a href="lwg-defects.html#2427">2427</a>, <a href="lwg-defects.html#2428">2428</a>, <a href="lwg-defects.html#2433">2433</a>, <a href="lwg-defects.html#2434">2434</a>, <a href="lwg-defects.html#2438">2438</a>, <a href="lwg-defects.html#2439">2439</a>, <a href="lwg-defects.html#2440">2440</a>.</li>
-<li>Changed the following 18 issues to WP (from Tentatively Ready): <a href="lwg-defects.html#2059">2059</a>, <a href="lwg-defects.html#2076">2076</a>, <a href="lwg-defects.html#2239">2239</a>, <a href="lwg-defects.html#2369">2369</a>, <a href="lwg-defects.html#2378">2378</a>, <a href="lwg-defects.html#2410">2410</a>, <a href="lwg-defects.html#2415">2415</a>, <a href="lwg-defects.html#2418">2418</a>, <a href="lwg-defects.html#2437">2437</a>, <a href="lwg-defects.html#2448">2448</a>, <a href="lwg-defects.html#2454">2454</a>, <a href="lwg-defects.html#2455">2455</a>, <a href="lwg-defects.html#2458">2458</a>, <a href="lwg-defects.html#2459">2459</a>, <a href="lwg-defects.html#2463">2463</a>, <a href="lwg-defects.html#2467">2467</a>, <a href="lwg-defects.html#2470">2470</a>, <a href="lwg-defects.html#2482">2482</a>.</li>
-<li>Changed the following 3 issues to WP (from New): <a href="lwg-defects.html#2420">2420</a>, <a href="lwg-defects.html#2464">2464</a>, <a href="lwg-defects.html#2488">2488</a>.</li>
-<li>Changed the following issue to WP (from Open): <a href="lwg-defects.html#2063">2063</a>.</li>
-<li>Changed the following 2 issues to WP (from SG1): <a href="lwg-defects.html#2407">2407</a>, <a href="lwg-defects.html#2442">2442</a>.</li>
-<li>Changed the following issue to Resolved (from Review): <a href="lwg-defects.html#2228">2228</a>.</li>
-<li>Changed the following 3 issues to Resolved (from Open): <a href="lwg-defects.html#1526">1526</a>, <a href="lwg-defects.html#2274">2274</a>, <a href="lwg-defects.html#2397">2397</a>.</li>
-<li>Changed the following 5 issues to NAD (from New): <a href="lwg-closed.html#2079">2079</a>, <a href="lwg-closed.html#2251">2251</a>, <a href="lwg-closed.html#2351">2351</a>, <a href="lwg-closed.html#2373">2373</a>, <a href="lwg-closed.html#2386">2386</a>.</li>
-<li>Changed the following issue to NAD (from Open): <a href="lwg-closed.html#2388">2388</a>.</li>
+<li>Added the following 2 Ready issues: <iref ref="2492" />, <iref ref="2494" />.</li>
+<li>Added the following 10 New issues: <iref ref="2493" />, <iref ref="2495" />, <iref ref="2496" />, <iref ref="2497" />, <iref ref="2498" />, <iref ref="2499" />, <iref ref="2500" />, <iref ref="2501" />, <iref ref="2502" />, <iref ref="2503" />.</li>
+<li>Changed the following 2 issues to Ready (from Review): <iref ref="2111" />, <iref ref="2380" />.</li>
+<li>Changed the following 20 issues to Ready (from New): <iref ref="2244" />, <iref ref="2250" />, <iref ref="2259" />, <iref ref="2336" />, <iref ref="2353" />, <iref ref="2367" />, <iref ref="2384" />, <iref ref="2385" />, <iref ref="2435" />, <iref ref="2462" />, <iref ref="2466" />, <iref ref="2473" />, <iref ref="2476" />, <iref ref="2477" />, <iref ref="2483" />, <iref ref="2484" />, <iref ref="2485" />, <iref ref="2486" />, <iref ref="2487" />, <iref ref="2489" />.</li>
+<li>Changed the following 12 issues to Ready (from Open): <iref ref="1169" />, <iref ref="2072" />, <iref ref="2101" />, <iref ref="2119" />, <iref ref="2127" />, <iref ref="2133" />, <iref ref="2156" />, <iref ref="2181" />, <iref ref="2218" />, <iref ref="2219" />, <iref ref="2447" />, <iref ref="2469" />.</li>
+<li>Changed the following issue to Tentatively Ready (from Open): <iref ref="2224" />.</li>
+<li>Changed the following issue to Review (from New): <iref ref="2296" />.</li>
+<li>Changed the following issue to Review (from Open): <iref ref="2328" />.</li>
+<li>Changed the following 11 issues to Open (from New): <iref ref="2262" />, <iref ref="2289" />, <iref ref="2338" />, <iref ref="2348" />, <iref ref="2349" />, <iref ref="2370" />, <iref ref="2398" />, <iref ref="2402" />, <iref ref="2422" />, <iref ref="2450" />, <iref ref="2456" />.</li>
+<li>Changed the following 8 issues to Open (from SG1): <iref ref="2245" />, <iref ref="2265" />, <iref ref="2276" />, <iref ref="2309" />, <iref ref="2363" />, <iref ref="2379" />, <iref ref="2426" />, <iref ref="2441" />.</li>
+<li>Changed the following issue to LEWG (from New): <iref ref="2372" />.</li>
+<li>Changed the following issue to EWG (from New): <iref ref="2432" />.</li>
+<li>Changed the following issue to Deferred (from Open): <iref ref="2202" />.</li>
+<li>Changed the following 14 issues to WP (from Ready): <iref ref="2160" />, <iref ref="2168" />, <iref ref="2364" />, <iref ref="2403" />, <iref ref="2406" />, <iref ref="2411" />, <iref ref="2425" />, <iref ref="2427" />, <iref ref="2428" />, <iref ref="2433" />, <iref ref="2434" />, <iref ref="2438" />, <iref ref="2439" />, <iref ref="2440" />.</li>
+<li>Changed the following 18 issues to WP (from Tentatively Ready): <iref ref="2059" />, <iref ref="2076" />, <iref ref="2239" />, <iref ref="2369" />, <iref ref="2378" />, <iref ref="2410" />, <iref ref="2415" />, <iref ref="2418" />, <iref ref="2437" />, <iref ref="2448" />, <iref ref="2454" />, <iref ref="2455" />, <iref ref="2458" />, <iref ref="2459" />, <iref ref="2463" />, <iref ref="2467" />, <iref ref="2470" />, <iref ref="2482" />.</li>
+<li>Changed the following 3 issues to WP (from New): <iref ref="2420" />, <iref ref="2464" />, <iref ref="2488" />.</li>
+<li>Changed the following issue to WP (from Open): <iref ref="2063" />.</li>
+<li>Changed the following 2 issues to WP (from SG1): <iref ref="2407" />, <iref ref="2442" />.</li>
+<li>Changed the following issue to Resolved (from Review): <iref ref="2228" />.</li>
+<li>Changed the following 3 issues to Resolved (from Open): <iref ref="1526" />, <iref ref="2274" />, <iref ref="2397" />.</li>
+<li>Changed the following 5 issues to NAD (from New): <iref ref="2079" />, <iref ref="2251" />, <iref ref="2351" />, <iref ref="2373" />, <iref ref="2386" />.</li>
+<li>Changed the following issue to NAD (from Open): <iref ref="2388" />.</li>
 </ul></li>
 </ul>
 </revision>
@@ -375,20 +375,20 @@ ownership of it.
 <li>2014 issues total, up by 33.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 5 Tentatively Ready issues: <a href="lwg-active.html#2459">2459</a>, <a href="lwg-active.html#2463">2463</a>, <a href="lwg-active.html#2467">2467</a>, <a href="lwg-active.html#2470">2470</a>, <a href="lwg-active.html#2482">2482</a>.</li>
-<li>Added the following 27 New issues: <a href="lwg-active.html#2460">2460</a>, <a href="lwg-active.html#2461">2461</a>, <a href="lwg-active.html#2462">2462</a>, <a href="lwg-active.html#2464">2464</a>, <a href="lwg-active.html#2465">2465</a>, <a href="lwg-active.html#2466">2466</a>, <a href="lwg-active.html#2468">2468</a>, <a href="lwg-active.html#2471">2471</a>, <a href="lwg-active.html#2472">2472</a>, <a href="lwg-active.html#2473">2473</a>, <a href="lwg-active.html#2474">2474</a>, <a href="lwg-active.html#2475">2475</a>, <a href="lwg-active.html#2476">2476</a>, <a href="lwg-active.html#2477">2477</a>, <a href="lwg-active.html#2478">2478</a>, <a href="lwg-active.html#2479">2479</a>, <a href="lwg-active.html#2480">2480</a>, <a href="lwg-active.html#2481">2481</a>, <a href="lwg-active.html#2483">2483</a>, <a href="lwg-active.html#2484">2484</a>, <a href="lwg-active.html#2485">2485</a>, <a href="lwg-active.html#2486">2486</a>, <a href="lwg-active.html#2487">2487</a>, <a href="lwg-active.html#2488">2488</a>, <a href="lwg-active.html#2489">2489</a>, <a href="lwg-active.html#2490">2490</a>, <a href="lwg-active.html#2491">2491</a>.</li>
-<li>Added the following Open issue: <a href="lwg-active.html#2469">2469</a>.</li>
-<li>Changed the following issue to Tentatively Ready (from Review): <a href="lwg-active.html#2378">2378</a>.</li>
-<li>Changed the following 11 issues to Tentatively Ready (from New): <a href="lwg-active.html#2076">2076</a>, <a href="lwg-active.html#2239">2239</a>, <a href="lwg-active.html#2369">2369</a>, <a href="lwg-active.html#2410">2410</a>, <a href="lwg-active.html#2415">2415</a>, <a href="lwg-active.html#2418">2418</a>, <a href="lwg-active.html#2437">2437</a>, <a href="lwg-active.html#2448">2448</a>, <a href="lwg-active.html#2454">2454</a>, <a href="lwg-active.html#2455">2455</a>, <a href="lwg-active.html#2458">2458</a>.</li>
-<li>Changed the following issue to Tentatively Ready (from Open): <a href="lwg-active.html#2059">2059</a>.</li>
-<li>Changed the following issue to Tentatively NAD (from New): <a href="lwg-active.html#2337">2337</a>.</li>
-<li>Changed the following issue to Tentatively NAD (from Open): <a href="lwg-active.html#760">760</a>.</li>
-<li>Changed the following 5 issues to Open (from New): <a href="lwg-active.html#2312">2312</a>, <a href="lwg-active.html#2388">2388</a>, <a href="lwg-active.html#2393">2393</a>, <a href="lwg-active.html#2444">2444</a>, <a href="lwg-active.html#2447">2447</a>.</li>
-<li>Changed the following 4 issues to LEWG (from New): <a href="lwg-active.html#2391">2391</a>, <a href="lwg-active.html#2417">2417</a>, <a href="lwg-active.html#2436">2436</a>, <a href="lwg-active.html#2451">2451</a>.</li>
-<li>Changed the following issue to EWG (from Open): <a href="lwg-active.html#2089">2089</a>.</li>
-<li>Changed the following issue to Core (from New): <a href="lwg-active.html#2452">2452</a>.</li>
-<li>Changed the following 13 issues to SG1 (from New): <a href="lwg-active.html#2236">2236</a>, <a href="lwg-active.html#2245">2245</a>, <a href="lwg-active.html#2265">2265</a>, <a href="lwg-active.html#2276">2276</a>, <a href="lwg-active.html#2309">2309</a>, <a href="lwg-active.html#2334">2334</a>, <a href="lwg-active.html#2363">2363</a>, <a href="lwg-active.html#2379">2379</a>, <a href="lwg-active.html#2407">2407</a>, <a href="lwg-active.html#2412">2412</a>, <a href="lwg-active.html#2426">2426</a>, <a href="lwg-active.html#2442">2442</a>, <a href="lwg-active.html#2445">2445</a>.</li>
-<li>Changed the following issue to SG1 (from Open): <a href="lwg-active.html#2441">2441</a>.</li>
+<li>Added the following 5 Tentatively Ready issues: <iref ref="2459" />, <iref ref="2463" />, <iref ref="2467" />, <iref ref="2470" />, <iref ref="2482" />.</li>
+<li>Added the following 27 New issues: <iref ref="2460" />, <iref ref="2461" />, <iref ref="2462" />, <iref ref="2464" />, <iref ref="2465" />, <iref ref="2466" />, <iref ref="2468" />, <iref ref="2471" />, <iref ref="2472" />, <iref ref="2473" />, <iref ref="2474" />, <iref ref="2475" />, <iref ref="2476" />, <iref ref="2477" />, <iref ref="2478" />, <iref ref="2479" />, <iref ref="2480" />, <iref ref="2481" />, <iref ref="2483" />, <iref ref="2484" />, <iref ref="2485" />, <iref ref="2486" />, <iref ref="2487" />, <iref ref="2488" />, <iref ref="2489" />, <iref ref="2490" />, <iref ref="2491" />.</li>
+<li>Added the following Open issue: <iref ref="2469" />.</li>
+<li>Changed the following issue to Tentatively Ready (from Review): <iref ref="2378" />.</li>
+<li>Changed the following 11 issues to Tentatively Ready (from New): <iref ref="2076" />, <iref ref="2239" />, <iref ref="2369" />, <iref ref="2410" />, <iref ref="2415" />, <iref ref="2418" />, <iref ref="2437" />, <iref ref="2448" />, <iref ref="2454" />, <iref ref="2455" />, <iref ref="2458" />.</li>
+<li>Changed the following issue to Tentatively Ready (from Open): <iref ref="2059" />.</li>
+<li>Changed the following issue to Tentatively NAD (from New): <iref ref="2337" />.</li>
+<li>Changed the following issue to Tentatively NAD (from Open): <iref ref="760" />.</li>
+<li>Changed the following 5 issues to Open (from New): <iref ref="2312" />, <iref ref="2388" />, <iref ref="2393" />, <iref ref="2444" />, <iref ref="2447" />.</li>
+<li>Changed the following 4 issues to LEWG (from New): <iref ref="2391" />, <iref ref="2417" />, <iref ref="2436" />, <iref ref="2451" />.</li>
+<li>Changed the following issue to EWG (from Open): <iref ref="2089" />.</li>
+<li>Changed the following issue to Core (from New): <iref ref="2452" />.</li>
+<li>Changed the following 13 issues to SG1 (from New): <iref ref="2236" />, <iref ref="2245" />, <iref ref="2265" />, <iref ref="2276" />, <iref ref="2309" />, <iref ref="2334" />, <iref ref="2363" />, <iref ref="2379" />, <iref ref="2407" />, <iref ref="2412" />, <iref ref="2426" />, <iref ref="2442" />, <iref ref="2445" />.</li>
+<li>Changed the following issue to SG1 (from Open): <iref ref="2441" />.</li>
 </ul></li>
 </ul>
 </revision>

--- a/xml/lwg-issues.xml
+++ b/xml/lwg-issues.xml
@@ -432,7 +432,7 @@ ownership of it.
 <li>1969 issues total, up by 31.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 31 New issues: <iref ref="2416"/>, <iref ref="2417"/>, <iref ref="2418"/>, <iref ref="2419"/>, <iref ref="2420"/>, <iref ref="2421"/>, <iref ref="2422"\>, <iref ref="2423"\>, <iref ref="2424"\>, <iref ref="2425"\>, <iref ref="2426"\>, <iref ref="2427"\>, <iref ref="2428"\>, <iref ref="2429"\>, <iref ref="2430"\>, <iref ref="2431"\>, <iref ref="2432"\>, <iref ref="2433"\>, <iref ref="2434"\>, <iref ref="2435"\>, <iref ref="2436"\>, <iref ref="2437"\>, <iref ref="2438"\>, <iref ref="2439"\>, <iref ref="2440"\>, <iref ref="2441"\>, <iref ref="2442"\>, <iref ref="2443"\>, <iref ref="2444"\>, <iref ref="2445"\>, <iref ref="2446"\>.</li>
+<li>Added the following 31 New issues: <iref ref="2416"/>, <iref ref="2417"/>, <iref ref="2418"/>, <iref ref="2419"/>, <iref ref="2420"/>, <iref ref="2421"/>, <iref ref="2422"/>, <iref ref="2423"/>, <iref ref="2424"/>, <iref ref="2425"/>, <iref ref="2426"/>, <iref ref="2427"/>, <iref ref="2428"/>, <iref ref="2429"/>, <iref ref="2430"/>, <iref ref="2431"/>, <iref ref="2432"/>, <iref ref="2433"/>, <iref ref="2434"/>, <iref ref="2435"/>, <iref ref="2436"/>, <iref ref="2437"/>, <iref ref="2438"/>, <iref ref="2439"/>, <iref ref="2440"/>, <iref ref="2441"/>, <iref ref="2442"/>, <iref ref="2443"/>, <iref ref="2444"/>, <iref ref="2445"/>, <iref ref="2446"/>.</li>
 <li>No issues changed.</li>
 </ul></li>
 </ul>
@@ -447,22 +447,22 @@ ownership of it.
 <li>1938 issues total, up by 26.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 6 Ready issues: <iref ref="2396"\>, <iref ref="2399"\>, <iref ref="2400"\>, <iref ref="2401"\>, <iref ref="2404"\>, <iref ref="2408"\>.</li>
-<li>Added the following 15 New issues: <iref ref="2391"\>, <iref ref="2392"\>, <iref ref="2393"\>, <iref ref="2394"\>, <iref ref="2398"\>, <iref ref="2402"\>, <iref ref="2403"\>, <iref ref="2406"\>, <iref ref="2407"\>, <iref ref="2410"\>, <iref ref="2411"\>, <iref ref="2412"\>, <iref ref="2413"\>, <iref ref="2414"\>, <iref ref="2415"\>.</li>
-<li>Added the following Open issue: <iref ref="2397"\>.</li>
-<li>Added the following 3 WP issues: <iref ref="2390"\>, <iref ref="2395"\>, <iref ref="2409"\>.</li>
-<li>Added the following NAD issue: <iref ref="2405"\>.</li>
-<li>Changed the following issue to Ready (from New): <iref ref="2377"\>.</li>
-<li>Changed the following 2 issues to Ready (from Deferred): <iref ref="2253"\>, <iref ref="2255"\>.</li>
-<li>Changed the following 2 issues to Tentatively Ready (from New): <iref ref="2325"\>, <iref ref="2387"\>.</li>
-<li>Changed the following issue to Tentatively NAD (from New): <iref ref="2382"\>.</li>
-<li>Changed the following 3 issues to Review (from New): <iref ref="2364"\>, <iref ref="2378"\>, <iref ref="2380"\>.</li>
-<li>Changed the following 2 issues to Review (from Open): <iref ref="2118"\>, <iref ref="2160"\>.</li>
-<li>Changed the following 3 issues to Open (from New): <iref ref="2168"\>, <iref ref="2238"\>, <iref ref="2273"\>.</li>
-<li>Changed the following 3 issues to Open (from Deferred): <iref ref="2254"\>, <iref ref="2264"\>, <iref ref="2277"\>.</li>
-<li>Changed the following 3 issues to WP (from New): <iref ref="2371"\>, <iref ref="2374"\>, <iref ref="2389"\>.</li>
-<li>Changed the following 4 issues to Resolved (from Deferred): <iref ref="2282"\>, <iref ref="2283"\>, <iref ref="2287"\>, <iref ref="2333"\>.</li>
-<li>Changed the following issue to NAD (from Deferred): <iref ref="2305"\>.</li>
+<li>Added the following 6 Ready issues: <iref ref="2396"/>, <iref ref="2399"/>, <iref ref="2400"/>, <iref ref="2401"/>, <iref ref="2404"/>, <iref ref="2408"/>.</li>
+<li>Added the following 15 New issues: <iref ref="2391"/>, <iref ref="2392"/>, <iref ref="2393"/>, <iref ref="2394"/>, <iref ref="2398"/>, <iref ref="2402"/>, <iref ref="2403"/>, <iref ref="2406"/>, <iref ref="2407"/>, <iref ref="2410"/>, <iref ref="2411"/>, <iref ref="2412"/>, <iref ref="2413"/>, <iref ref="2414"/>, <iref ref="2415"/>.</li>
+<li>Added the following Open issue: <iref ref="2397"/>.</li>
+<li>Added the following 3 WP issues: <iref ref="2390"/>, <iref ref="2395"/>, <iref ref="2409"/>.</li>
+<li>Added the following NAD issue: <iref ref="2405"/>.</li>
+<li>Changed the following issue to Ready (from New): <iref ref="2377"/>.</li>
+<li>Changed the following 2 issues to Ready (from Deferred): <iref ref="2253"/>, <iref ref="2255"/>.</li>
+<li>Changed the following 2 issues to Tentatively Ready (from New): <iref ref="2325"/>, <iref ref="2387"/>.</li>
+<li>Changed the following issue to Tentatively NAD (from New): <iref ref="2382"/>.</li>
+<li>Changed the following 3 issues to Review (from New): <iref ref="2364"/>, <iref ref="2378"/>, <iref ref="2380"/>.</li>
+<li>Changed the following 2 issues to Review (from Open): <iref ref="2118"/>, <iref ref="2160"/>.</li>
+<li>Changed the following 3 issues to Open (from New): <iref ref="2168"/>, <iref ref="2238"/>, <iref ref="2273"/>.</li>
+<li>Changed the following 3 issues to Open (from Deferred): <iref ref="2254"/>, <iref ref="2264"/>, <iref ref="2277"/>.</li>
+<li>Changed the following 3 issues to WP (from New): <iref ref="2371"/>, <iref ref="2374"/>, <iref ref="2389"/>.</li>
+<li>Changed the following 4 issues to Resolved (from Deferred): <iref ref="2282"/>, <iref ref="2283"/>, <iref ref="2287"/>, <iref ref="2333"/>.</li>
+<li>Changed the following issue to NAD (from Deferred): <iref ref="2305"/>.</li>
 </ul></li>
 </ul>
 </revision>


### PR DESCRIPTION
So that links to issues work correctly. Note that the revision history for R91 and earlier already uses it.