### PR TITLE
Update 2567 wording according to LWG review

### DIFF
--- a/xml/issue2567.xml
+++ b/xml/issue2567.xml
@@ -56,9 +56,9 @@ not necessarily <del>have a BaseCharacteristic
 of</del> <ins>derive from</ins> either true_type or
 false_type. — end note ]</p>
 </blockquote>
-</discussion>
 
-<resolution>
+<p><strong>Previous resolution [SUPERSEDED]:</strong></p>
+<blockquote class="note">
 <p>In [meta.logical]/3, edit as follows:</p>
 
 <p>The <del>BaseCharacteristic of a</del> specialization <tt>conjunction&lt;B1, ..., BN&gt;</tt>
@@ -86,6 +86,41 @@ BaseCharacteristic is the last type in the list.</del><br/>
 [ Note: This means a specialization of <tt>disjunction</tt> does
 not necessarily <del>have a BaseCharacteristic
 of</del> <ins>derive from</ins> either true_type or
+false_type. — end note ]</p></blockquote>
+</discussion>
+
+<resolution>
+<p>In [meta.logical]/3, edit as follows:</p>
+
+<p>The <del>BaseCharacteristic of a</del> specialization <tt>conjunction&lt;B1, ..., BN&gt;</tt>
+<ins>has a public and unambiguous base that is either<br/>
+* the first type <tt>Bi</tt> in the list <tt>true_type, B1, ..., BN</tt> for
+which <tt>Bi::value == false</tt>, or<br/>
+* if there is no such <tt>Bi</tt>, the last type in the list.</ins><br/>
+<del>is the first type <tt>Bi</tt> in the list <tt>true_type, B1, ..., BN</tt> for
+which <tt>Bi::value == false</tt>, or if every <tt>Bi::value != false</tt>, the
+BaseCharacteristic is the last type in the list.</del><br/>
+<ins>The member names of the base class shall not be hidden and be unambiguously
+available in <tt>conjunction</tt>.</ins><br/>
+[ Note: This means a specialization of <tt>conjunction</tt> does
+not necessarily <del>have a BaseCharacteristic
+of</del> <ins>inherit from</ins> either true_type or
+false_type. — end note ]</p>
+
+<p>In [meta.logical]/6, edit as follows:</p>
+<p>The <del>BaseCharacteristic of a</del> specialization <tt>disjunction&lt;B1, ..., BN&gt;</tt>
+<ins>has a public and unambiguous base that is either<br/>
+* the first type <tt>Bi</tt> in the list <tt>true_type, B1, ..., BN</tt> for
+which <tt>Bi::value != false</tt>, or<br/>
+* if there is no such <tt>Bi</tt>, the last type in the list.</ins><br/>
+<del>is the first type <tt>Bi</tt> in the list <tt>true_type, B1, ..., BN</tt> for
+which <tt>Bi::value != false</tt>, or if every <tt>Bi::value == false</tt>, the
+BaseCharacteristic is the last type in the list.</del><br/>
+<ins>The member names of the base class shall not be hidden and be unambiguously
+available in <tt>disjunction</tt>.</ins><br/>
+[ Note: This means a specialization of <tt>disjunction</tt> does
+not necessarily <del>have a BaseCharacteristic
+of</del> <ins>inherit from</ins> either true_type or
 false_type. — end note ]</p>
 
 </resolution>


### PR DESCRIPTION
Added "member names shall not be hidden" language.
Change "derive from" to "inherit from".