### PR TITLE
Minor wording tweaks for issue 2534

### DIFF
--- a/xml/issue2534.xml
+++ b/xml/issue2534.xml
@@ -37,8 +37,8 @@ template &lt;class charT, class traits, class T&gt;
 <p/>
 -2- <i>Returns</i>: <tt>os</tt>
 <p/>
-<ins>-?- <i>Remarks</i>: This overload shall not participate in overload resolution unless the expression 
-<tt>os &lt;&lt; x</tt>, considered as an unevaluated operand, is well-formed.</ins>
+<ins>-?- <i>Remarks</i>: This function shall not participate in overload resolution unless the expression 
+<tt>os &lt;&lt; x</tt>, is well-formed.</ins>
 </p>
 </blockquote>
 </blockquote>
@@ -57,8 +57,8 @@ template &lt;class charT, class traits, class T&gt;
 <p/>
 -2- <i>Returns</i>: <tt>is</tt>
 <p/>
-<ins>-?- <i>Remarks</i>: This overload shall not participate in overload resolution unless the expression 
-<tt>is &gt;&gt; x</tt>, considered as an unevaluated operand, is well-formed.</ins>
+<ins>-?- <i>Remarks</i>: This function shall not participate in overload resolution unless the expression 
+<tt>is &gt;&gt; x</tt>, is well-formed.</ins>
 </p>
 </blockquote>
 </blockquote>


### PR DESCRIPTION
Apply conventional phrasing, as highlighted in Chicago review.
Then a candidate for Tentatively Ready.