### PR TITLE
Update 2567 from LWG review at 2016-08-04 5:30 PM Chicago Time

### DIFF
--- a/xml/issue2567.xml
+++ b/xml/issue2567.xml
@@ -90,9 +90,10 @@ false_type. — end note ]</p></blockquote>
 
 Merged the resolution of <iref ref="2587"/> with this issue. This proposed resolution
 resolves both, and includes fixes from Daniel for negation.
-</discussion>
 
-<resolution>
+Last review of this with LWG turned up a true_type typo in the definition of disjunction, and some editorial changes.
+<p><strong>Previous resolution [SUPERSEDED]:</strong></p>
+<blockquote class="note">
 <p>This wording is relative to N4606.</p>
 <ol>
 <li>
@@ -147,6 +148,74 @@ of</del> <ins>inherit from</ins> either <tt>true_type</tt> or <tt>false_type</tt
 <p>In <sref ref="[meta.logical]" /> p8, edit as follows</p>
 <pre>
 template&lt;class B&gt; struct negation : bool_constant&lt;!<ins>bool(</ins>B::value<ins>)</ins>&gt; { };
+</pre>
+<blockquote>
+<p>
+-8- The class template negation forms the logical negation of its template type argument. The type
+<tt>negation&lt;B&gt;</tt> is a UnaryTypeTrait with a BaseCharacteristic of
+<tt>bool_constant&lt;!<ins>bool(</ins>B::value<ins>)</ins>&gt;</tt>.
+</p>
+</blockquote>
+</li>
+</ol>
+</blockquote>
+</discussion>
+
+<resolution>
+<p>This wording is relative to N4606.</p>
+<ol>
+<li>
+<p>In <sref ref="[meta.logical]" /> p3, edit as follows:</p>
+<pre>
+template&lt;class... B&gt; struct conjunction : <em>see below</em> { };
+</pre>
+<blockquote>
+<p>-3- The <del>BaseCharacteristic of a</del> specialization <tt>conjunction&lt;B1, ..., BN&gt;</tt>
+<ins>has a public and unambiguous base that is either</ins>
+<ul style="list-style-type: none">
+<li><ins>&mdash; the first type <tt>Bi</tt> in the list <tt>true_type, B1, ..., BN</tt> for
+which <tt>bool(Bi::value)</tt> is <tt>false</tt>, or</ins></li>
+<li><ins>&mdash; if there is no such <tt>Bi</tt>, the last type in the list.</ins></li>
+</ul>
+<del>is the first type <tt>Bi</tt> in the list <tt>true_type, B1, ..., BN</tt> for
+which <tt>Bi::value == false</tt>, or if every <tt>Bi::value != false</tt>, the
+BaseCharacteristic is the last type in the list.</del><ins>[<em>Note: </em>
+This means a specialization of <tt>conjunction</tt> does not necessarily <del>have a BaseCharacteristic
+of</del> <ins>inherit from</ins> either <tt>true_type</tt> or <tt>false_type</tt>.
+&mdash;<em>end note</em>]</ins></p>
+<p><ins>-?- The member names of the base class, other than <tt>conjunction</tt> and <tt>operator=</tt>,
+shall not be hidden and shall be unambiguously available in <tt>conjunction</tt>.</ins></p>
+</blockquote>
+</li>
+
+<li>
+<p>In <sref ref="[meta.logical]" /> p6, edit as follows:</p>
+<pre>
+template&lt;class... B&gt; struct disjunction : <em>see below</em> { };
+</pre>
+<blockquote>
+<p>-6- The <del>BaseCharacteristic of a</del> specialization <tt>disjunction&lt;B1, ..., BN&gt;</tt>
+<ins>has a public and unambiguous base that is either</ins>
+<ul style="list-style-type: none">
+<li><ins>&mdash; the first type <tt>Bi</tt> in the list <tt>false_type, B1, ..., BN</tt> for
+which <tt>bool(Bi::value)</tt> is <tt>true</tt>, or,</ins></li>
+<li><ins>&mdash; if there is no such <tt>Bi</tt>, the last type in the list.</ins></li>
+</ul>
+<del>is the first type <tt>Bi</tt> in the list <tt>false_type, B1, ..., BN</tt> for
+which <tt>Bi::value != false</tt>, or if every <tt>Bi::value == false</tt>, the
+BaseCharacteristic is the last type in the list.</del><ins>[<em>Note: </em>This
+means a specialization of <tt>disjunction</tt> does not necessarily <del>have a BaseCharacteristic
+of</del> <ins>inherit from</ins> either <tt>true_type</tt> or <tt>false_type</tt>.
+&mdash;<em>end note</em>]</ins></p>
+<p><ins>-?- The member names of the base class, other than <tt>disjunction</tt> and <tt>operator=</tt>,
+shall not be hidden and shall be unambiguously available in <tt>disjunction</tt>.</ins></p>
+</blockquote>
+</li>
+
+<li>
+<p>In <sref ref="[meta.logical]" /> p8, edit as follows</p>
+<pre>
+template&lt;class B&gt; struct negation : <em>see below</em> { };
 </pre>
 <blockquote>
 <p>


### PR DESCRIPTION
When we transcribed the original text we made a typo when transcribing the disjunction text, saying true_type instead of false_type. Also applied editorial changes from the room; moving the note into the previous paragraph, and removing the base class from the negation synopsis.