### PR TITLE
Revised wording for issue 2261

### DIFF
--- a/xml/issue2261.xml
+++ b/xml/issue2261.xml
@@ -54,11 +54,13 @@ the "Note" markups.</note>
 
 <blockquote><p>
 Unless otherwise specified, all containers defined in this clause obtain
-memory using an allocator<ins> [Note: The containers and their iterators
-access the memory allocated by such an allocator only through objects of
-type <tt>_P_</tt> or <tt>pointer_traits&lt;_P_>::rebind&lt;<i>unspecified</i>&gt;</tt>, where
-<tt>_P_</tt> is <tt>allocator_traits&lt;allocator_type&gt;::pointer</tt>.
---end note]</ins> (see 17.6.3.5).
+memory using an allocator<ins> [Note: In particular, containers and iterators
+shall not store references to allocated elements other than through the
+allocator's pointer type, i.e., as objects of type <tt><i>P</i></tt> or
+<tt>pointer_traits&lt;<i>P</i>&gt;::rebind&lt;<i>unspecified</i>&gt;</tt>,
+where <tt><i>P</i></tt> is
+<tt>allocator_traits&lt;allocator_type&gt;::pointer</tt>.  --end note]</ins>
+(see 17.6.3.5).
 </p></blockquote>
 </resolution>
 


### PR DESCRIPTION
Clarified wording with Billy Oneal to confirm that the concern
is only for storing pointers as data members and parts of the
container's data structure, and does not apply to use of local
variables within functions, which will often need to produce a
native pointer, e.g., passing an address to a 'construct' call.