### PR TITLE
Fix is_callable usage error in PR.

### DIFF
--- a/xml/issue2543.xml
+++ b/xml/issue2543.xml
@@ -150,8 +150,8 @@ template hash, the specialization of <tt>hash&lt;T&gt;</tt> has the following pr
 <li><ins><tt>is_move_constructible_v&lt;hash&lt;T&gt;&gt;</tt> is <tt>false</tt></ins></li>
 <li><ins><tt>is_copy_assignable_v&lt;hash&lt;T&gt;&gt;</tt> is <tt>false</tt></ins></li>
 <li><ins><tt>is_move_assignable_v&lt;hash&lt;T&gt;&gt;</tt> is <tt>false</tt></ins></li>
-<li><ins><tt>is_callable_v&lt;hash&lt;T&gt;, T&amp;&gt;</tt> is <tt>false</tt></ins></li>
-<li><ins><tt>is_callable_v&lt;hash&lt;T&gt;, const T&amp;&gt;</tt> is <tt>false</tt></ins></li>
+<li><ins><tt>is_callable_v&lt;hash&lt;T&gt;(T&amp;)&gt;</tt> is <tt>false</tt></ins></li>
+<li><ins><tt>is_callable_v&lt;hash&lt;T&gt;(const T&amp;)&gt;</tt> is <tt>false</tt></ins></li>
 </ul>
 <p>
 <ins>[<i>Note:</i> this means that the specialization of <tt>hash</tt> exists, but any


### PR DESCRIPTION
is_callable takes the callable object and arguments as a function type
'is_callable<C(Args...)>', not as 'is_callable<C, Args...>'.