### PR TITLE
lwg-issues.xml: correct revision history of R102

### DIFF
--- a/xml/lwg-issues.xml
+++ b/xml/lwg-issues.xml
@@ -215,28 +215,19 @@ ownership of it.
 <li>2450 issues total, up by 103.</li>
 </ul></li>
 <li><b>Details:</b><ul>
-<li>Added the following 3 Ready issues: <iref ref="2785" />, <iref ref="2786" />, <iref ref="2787" />.</li>
-<li>Added the following Tentatively Ready issue: <iref ref="2794" />.</li>
-<li>Added the following 34 New issues: <iref ref="2788" />, <iref ref="2789" />, <iref ref="2790" />, <iref ref="2792" />, <iref ref="2793" />, <iref ref="2795" />, <iref ref="2796" />, <iref ref="2797" />, <iref ref="2799" />, <iref ref="2800" />, <iref ref="2801" />, <iref ref="2802" />, <iref ref="2803" />, <iref ref="2804" />, <iref ref="2805" />, <iref ref="2806" />, <iref ref="2807" />, <iref ref="2808" />, <iref ref="2809" />, <iref ref="2810" />, <iref ref="2811" />, <iref ref="2812" />, <iref ref="2813" />, <iref ref="2814" />, <iref ref="2815" />, <iref ref="2816" />, <iref ref="2818" />, <iref ref="2819" />, <iref ref="2820" />, <iref ref="2821" />, <iref ref="2822" />, <iref ref="2823" />, <iref ref="2824" />, <iref ref="2825" />.</li>
-<li>Added the following Open issue: <iref ref="2798" />.</li>
-<li>Added the following 2 Resolved issues: <iref ref="2791" />, <iref ref="2817" />.</li>
-<li>Changed the following 3 issues to Ready (from New): <iref ref="2781" />, <iref ref="2782" />, <iref ref="2784" />.</li>
-<li>Changed the following issue to Tentatively Ready (from Open): <iref ref="2260" />.</li>
-<li>Changed the following issue to Review (from New): <iref ref="2697" />.</li>
-<li>Changed the following 3 issues to Open (from Tentatively Ready): <iref ref="2569" />, <iref ref="2754" />, <iref ref="2768" />.</li>
-<li>Changed the following 2 issues to Open (from New): <iref ref="2597" />, <iref ref="2730" />.</li>
-<li>Changed the following issue to LEWG (from New): <iref ref="2780" />.</li>
-<li>Changed the following issue to Pending NAD Editorial (from Open): <iref ref="2178" />.</li>
-<li>Changed the following 66 issues to WP (from Tentatively Ready): <iref ref="2062" />, <iref ref="2166" />, <iref ref="2221" />, <iref ref="2223" />, <iref ref="2261" />, <iref ref="2394" />, <iref ref="2460" />, <iref ref="2468" />, <iref ref="2475" />, <iref ref="2503" />, <iref ref="2510" />, <iref ref="2514" />, <iref ref="2519" />, <iref ref="2531" />, <iref ref="2534" />, <iref ref="2536" />, <iref ref="2540" />, <iref ref="2544" />, <iref ref="2556" />, <iref ref="2562" />, <iref ref="2567" />, <iref ref="2570" />, <iref ref="2578" />, <iref ref="2584" />, <iref ref="2589" />, <iref ref="2591" />, <iref ref="2598" />, <iref ref="2664" />, <iref ref="2672" />, <iref ref="2678" />, <iref ref="2679" />, <iref ref="2680" />, <iref ref="2681" />, <iref ref="2686" />, <iref ref="2694" />, <iref ref="2696" />, <iref ref="2699" />, <iref ref="2712" />, <iref ref="2722" />, <iref ref="2729" />, <iref ref="2732" />, <iref ref="2733" />, <iref ref="2735" />, <iref ref="2736" />, <iref ref="2738" />, <iref ref="2739" />, <iref ref="2740" />, <iref ref="2742" />, <iref ref="2744" />, <iref ref="2745" />, <iref ref="2747" />, <iref ref="2748" />, <iref ref="2749" />, <iref ref="2750" />, <iref ref="2752" />, <iref ref="2755" />, <iref ref="2756" />, <iref ref="2758" />, <iref ref="2759" />, <iref ref="2760" />, <iref ref="2765" />, <iref ref="2767" />, <iref ref="2771" />, <iref ref="2773" />, <iref ref="2777" />, <iref ref="2778" />.</li>
-<li>Changed the following 4 issues to WP (from New): <iref ref="2518" />, <iref ref="2521" />, <iref ref="2525" />, <iref ref="2527" />.</li>
-<li>Changed the following 3 issues to WP (from Open): <iref ref="2568" />, <iref ref="2588" />, <iref ref="2770" />.</li>
-<li>Changed the following 2 issues to Resolved (from Tentatively Ready): <iref ref="2543" />, <iref ref="2753" />.</li>
-<li>Changed the following issue to Resolved (from New): <iref ref="2763" />.</li>
-<li>Changed the following issue to Resolved (from Open): <iref ref="2465" />.</li>
-<li>Changed the following issue to Resolved (from SG1): <iref ref="2445" />.</li>
-<li>Changed the following issue to NAD Editorial (from New): <iref ref="2201" />.</li>
-<li>Changed the following issue to NAD (from New): <iref ref="2668" />.</li>
-<li>Changed the following 2 issues to NAD (from Open): <iref ref="1173" />, <iref ref="2199" />.</li>
+<li>Added the following 9 Tentatively Ready issues: <iref ref="2826" />, <iref ref="2834" />, <iref ref="2835" />, <iref ref="2837" />, <iref ref="2838" />, <iref ref="2842" />, <iref ref="2850" />, <iref ref="2853" />, <iref ref="2855" />.</li>
+<li>Added the following 89 New issues: <iref ref="2827" />, <iref ref="2829" />, <iref ref="2832" />, <iref ref="2833" />, <iref ref="2836" />, <iref ref="2839" />, <iref ref="2840" />, <iref ref="2841" />, <iref ref="2843" />, <iref ref="2844" />, <iref ref="2845" />, <iref ref="2846" />, <iref ref="2847" />, <iref ref="2848" />, <iref ref="2849" />, <iref ref="2851" />, <iref ref="2852" />, <iref ref="2856" />, <iref ref="2858" />, <iref ref="2859" />, <iref ref="2860" />, <iref ref="2861" />, <iref ref="2862" />, <iref ref="2863" />, <iref ref="2864" />, <iref ref="2865" />, <iref ref="2866" />, <iref ref="2867" />, <iref ref="2868" />, <iref ref="2869" />, <iref ref="2870" />, <iref ref="2871" />, <iref ref="2872" />, <iref ref="2873" />, <iref ref="2874" />, <iref ref="2875" />, <iref ref="2876" />, <iref ref="2877" />, <iref ref="2878" />, <iref ref="2879" />, <iref ref="2880" />, <iref ref="2881" />, <iref ref="2882" />, <iref ref="2883" />, <iref ref="2884" />, <iref ref="2885" />, <iref ref="2886" />, <iref ref="2887" />, <iref ref="2888" />, <iref ref="2889" />, <iref ref="2890" />, <iref ref="2891" />, <iref ref="2892" />, <iref ref="2893" />, <iref ref="2894" />, <iref ref="2895" />, <iref ref="2896" />, <iref ref="2897" />, <iref ref="2898" />, <iref ref="2899" />, <iref ref="2900" />, <iref ref="2901" />, <iref ref="2902" />, <iref ref="2903" />, <iref ref="2904" />, <iref ref="2905" />, <iref ref="2906" />, <iref ref="2907" />, <iref ref="2908" />, <iref ref="2909" />, <iref ref="2910" />, <iref ref="2911" />, <iref ref="2912" />, <iref ref="2913" />, <iref ref="2914" />, <iref ref="2915" />, <iref ref="2916" />, <iref ref="2917" />, <iref ref="2918" />, <iref ref="2919" />, <iref ref="2920" />, <iref ref="2921" />, <iref ref="2922" />, <iref ref="2923" />, <iref ref="2924" />, <iref ref="2925" />, <iref ref="2926" />, <iref ref="2927" />, <iref ref="2928" />.</li>
+<li>Added the following 3 LEWG issues: <iref ref="2831" />, <iref ref="2854" />, <iref ref="2857" />.</li>
+<li>Added the following Resolved issue: <iref ref="2830" />.</li>
+<li>Added the following NAD Editorial issue: <iref ref="2828" />.</li>
+<li>Changed the following 5 issues to Tentatively Ready (from New): <iref ref="2789" />, <iref ref="2795" />, <iref ref="2804" />, <iref ref="2812" />, <iref ref="2824" />.</li>
+<li>Changed the following 2 issues to Tentatively Ready (from Open): <iref ref="2768" />, <iref ref="2769" />.</li>
+<li>Changed the following 2 issues to Review (from New): <iref ref="2790" />, <iref ref="2796" />.</li>
+<li>Changed the following 2 issues to LEWG (from New): <iref ref="2814" />, <iref ref="2825" />.</li>
+<li>Changed the following 2 issues to WP (from New): <iref ref="2792" />, <iref ref="2793" />.</li>
+<li>Changed the following 3 issues to Resolved (from New): <iref ref="2805" />, <iref ref="2809" />, <iref ref="2810" />.</li>
+<li>Changed the following issue to Resolved (from Open): <iref ref="2754" />.</li>
+<li>Changed the following issue to NAD (from New): <iref ref="2822" />.</li>
 </ul></li>
 </ul>
 </revision>


### PR DESCRIPTION
The current history is a copy of R101's. The one in this PR is an `iref`-fied copy from commit 3201331, the last commit in the gh-pages branch before the metadata was switched to D103.