### PR TITLE
Update P/R for 2874 and 2875 after LWG review in Kona

### DIFF
--- a/xml/issue2874.xml
+++ b/xml/issue2874.xml
@@ -26,6 +26,52 @@ clause is satisfied.
 </p>
 
 <note>2017-02-23, Jonathan provides wording</note>
+ 
+<p><strong>Previous resolution [SUPERSEDED]:</strong></p>
+
+<p>
+This wording is relative to <a href="http://wg21.link/n4640">N4640</a>.
+</p>
+
+<ol>
+<li><p>Modify <sref ref="[util.smartptr.shared.const]"/> as indicated:</p>
+<blockquote class="note">
+<p>
+[<i>Drafting note:</i> This also adds a hyphen to "well defined"]
+</p>
+</blockquote>
+
+<blockquote>
+<pre>
+template&lt;class Y&gt; explicit shared_ptr(Y* p);
+</pre>
+<blockquote>
+<p>
+-4- <i>Requires:</i> <tt>Y</tt> shall be a complete type. The expression <tt>delete[] p</tt>, when <tt>T</tt> 
+is an array type, or <tt>delete p</tt>, when <tt>T</tt> is not an array type, <del>shall be well formed,</del> shall 
+have well<del> </del><ins>-</ins>defined behavior, and shall not throw exceptions. <del>When <tt>T</tt> is <tt>U[N]</tt>, 
+<tt>Y(*)[N]</tt> shall be convertible to <tt>T*</tt>; when <tt>T</tt> is <tt>U[]</tt>, <tt>Y(*)[]</tt> shall be convertible to 
+<tt>T*</tt>; otherwise, <tt>Y*</tt> shall be convertible to <tt>T*</tt>.</del>
+<p/>
+-5- <i>Effects:</i> [&hellip;]
+<p/>
+-6- <i>Postconditions:</i> [&hellip;]
+<p/>
+-7- <i>Throws:</i> [&hellip;]
+<p/>
+<ins>-?- <i>Remarks:</i> When <tt>T</tt> is an array type, this constructor shall not
+participate in overload resolution unless the expression <tt>delete[] p</tt> is
+well-formed and either <tt>T</tt> is <tt>U[N]</tt> and <tt>Y(*)[N]</tt> is convertible to <tt>T*</tt>, or
+<tt>Y(*)[]</tt> is convertible to <tt>T*</tt>. When <tt>T</tt> is not an array type, this
+constructor shall not participate in overload resolution unless the
+expression <tt>delete p</tt> is well-formed and <tt>Y*</tt> is convertible to <tt>T*</tt>.</ins>
+</p>
+</blockquote>
+</blockquote>
+</li>
+</ol>
+
+<note>Kona 2017-02-27: Jonathan updates wording after LWG review</note>
 </discussion>
 
 <resolution>
@@ -62,7 +108,7 @@ have well<del> </del><ins>-</ins>defined behavior, and shall not throw exception
 <ins>-?- <i>Remarks:</i> When <tt>T</tt> is an array type, this constructor shall not
 participate in overload resolution unless the expression <tt>delete[] p</tt> is
 well-formed and either <tt>T</tt> is <tt>U[N]</tt> and <tt>Y(*)[N]</tt> is convertible to <tt>T*</tt>, or
-<tt>Y(*)[]</tt> is convertible to <tt>T*</tt>. When <tt>T</tt> is not an array type, this
+<tt>T</tt> is <tt>U[]</tt> and <tt>Y(*)[]</tt> is convertible to <tt>T*</tt>. When <tt>T</tt> is not an array type, this
 constructor shall not participate in overload resolution unless the
 expression <tt>delete p</tt> is well-formed and <tt>Y*</tt> is convertible to <tt>T*</tt>.</ins>
 </p>

--- a/xml/issue2875.xml
+++ b/xml/issue2875.xml
@@ -31,9 +31,6 @@ See US 125: LWG <iref ref="2874"/>.
 </p>
 
 <note>2017-02-23, Jonathan provides wording</note>
-</discussion>
-
-<resolution>
 <p>
 This wording is relative to <a href="http://wg21.link/n4640">N4640</a>.
 </p>
@@ -122,6 +119,70 @@ participate in overload resolution unless <tt>is_move_constructible_v&lt;D&gt;</
 is <tt>true</tt>, the expression <tt>d(p)</tt> is well-formed, and either <tt>T</tt> 
 is <tt>U[N]</tt> and <tt>Y(*)[N]</tt> is convertible to <tt>T*</tt>, or
 <tt>Y(*)[]</tt> is convertible to <tt>T*</tt>. When <tt>T</tt> is not an array type, this
+constructor shall not participate in overload resolution unless
+<tt>is_move_constructible_v&lt;D&gt;</tt> is <tt>true</tt>, the
+expression <tt>d(p)</tt> is well-formed, and <tt>Y*</tt> is convertible to <tt>T*</tt>.</ins>
+</p>
+</blockquote>
+</blockquote>
+</li>
+</ol>
+
+<note>Kona 2017-02-27: Jonathan updates wording after LWG review</note>
+</discussion>
+
+<resolution>
+<p>
+This wording is relative to <a href="http://wg21.link/n4640">N4640</a>
+as modified by the proposed resolution of LWG <iref ref="2802"/>.
+</p>
+
+<ol>
+<li><p>Modify <sref ref="[util.smartptr.shared.const]"/> as indicated:</p>
+
+<blockquote>
+<pre>
+template&lt;class Y, class D&gt; shared_ptr(Y* p, D d);
+template&lt;class Y, class D, class A&gt; shared_ptr(Y* p, D d, A a);
+template &lt;class D&gt; shared_ptr(nullptr_t p, D d);
+template &lt;class D, class A&gt; shared_ptr(nullptr_t p, D d, A a);
+</pre>
+<blockquote>
+<p>
+-8- <i>Requires:</i> <del><tt>D</tt> shall be <tt>MoveConstructible</tt> and c</del><ins>C</ins>onstruction of 
+<tt>d</tt> and a deleter of type 
+<tt>D</tt> initialized with <tt>std::move(d)</tt> shall not throw exceptions. The expression <tt>d(p)</tt> 
+<del>shall be well formed,</del> shall have well-defined behavior, and shall not throw exceptions. <tt>A</tt> 
+shall be an allocator (17.5.3.5). <del>When <tt>T</tt> is <tt>U[N]</tt>, <tt>Y(*)[N]</tt> shall be convertible to <tt>T*</tt>;
+when <tt>T</tt> is <tt>U[]</tt>, <tt>Y(*)[]</tt> shall be convertible to <tt>T*</tt>; otherwise, <tt>Y*</tt> shall 
+be convertible to <tt>T*</tt>.</del>
+</p>
+</blockquote>
+</blockquote>
+</li>
+
+<li><p>Add a <i>Remarks</i> paragraph after p11:</p>
+
+<blockquote>
+<pre>
+template&lt;class Y, class D&gt; shared_ptr(Y* p, D d);
+template&lt;class Y, class D, class A&gt; shared_ptr(Y* p, D d, A a);
+template &lt;class D&gt; shared_ptr(nullptr_t p, D d);
+template &lt;class D, class A&gt; shared_ptr(nullptr_t p, D d, A a);
+</pre>
+<blockquote>
+<p>
+-8- <i>Requires:</i> [&hellip;]
+<p/>
+[&hellip;]
+<p/>
+-11- <i>Throws:</i> [&hellip;]
+<p/>
+<ins>-?- <i>Remarks:</i> When <tt>T</tt> is an array type, this constructor shall not
+participate in overload resolution unless <tt>is_move_constructible_v&lt;D&gt;</tt>
+is <tt>true</tt>, the expression <tt>d(p)</tt> is well-formed, and either <tt>T</tt> 
+is <tt>U[N]</tt> and <tt>Y(*)[N]</tt> is convertible to <tt>T*</tt>, or <tt>T</tt> 
+is <tt>U[]</tt> and <tt>Y(*)[]</tt> is convertible to <tt>T*</tt>. When <tt>T</tt> is not an array type, this
 constructor shall not participate in overload resolution unless
 <tt>is_move_constructible_v&lt;D&gt;</tt> is <tt>true</tt>, the
 expression <tt>d(p)</tt> is well-formed, and <tt>Y*</tt> is convertible to <tt>T*</tt>.</ins>


### PR DESCRIPTION
Simply moves the previous resolution to the discussion as SUPERSEDED and removes the "if 2802 is not accepted" alternatives, and adds "T is U[] and " to both _Remarks_ paragraphs.