### PR TITLE
Update section references to <codecvt> sections

### DIFF
--- a/xml/issue0721.xml
+++ b/xml/issue0721.xml
@@ -5,7 +5,7 @@
 
 <issue num="721" status="NAD">
 <title><tt>wstring_convert</tt> inconsistensies</title>
-<section><sref ref="[conversions.string]"/></section>
+<section><sref ref="[depr.conversions.string]"/></section>
 <submitter>Bo Persson</submitter>
 <date>27 Aug 2007</date>
 

--- a/xml/issue0991.xml
+++ b/xml/issue0991.xml
@@ -5,7 +5,7 @@
 
 <issue num="991" status="C++11">
 <title>Provide allocator for <tt>wstring_convert</tt></title>
-<section><sref ref="[conversions.string]"/></section>
+<section><sref ref="[depr.conversions.string]"/></section>
 <submitter>P.J. Plauger</submitter>
 <date>3 Mar 2009</date>
 

--- a/xml/issue1252.xml
+++ b/xml/issue1252.xml
@@ -5,7 +5,7 @@
 
 <issue num="1252" status="C++11">
 <title><tt>wbuffer_convert::state_type</tt> inconsistency</title>
-<section><sref ref="[conversions.buffer]"/></section>
+<section><sref ref="[depr.conversions.buffer]"/></section>
 <submitter>Bo Persson </submitter>
 <date>21 Oct 2009</date>
 

--- a/xml/issue2174.xml
+++ b/xml/issue2174.xml
@@ -5,7 +5,7 @@
 
 <issue num="2174" status="C++14">
 <title><tt>wstring_convert::converted()</tt> should be <tt>noexcept</tt></title>
-<section><sref ref="[conversions.string]"/></section>
+<section><sref ref="[depr.conversions.string]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>2 Aug 2012</date>
 

--- a/xml/issue2175.xml
+++ b/xml/issue2175.xml
@@ -3,7 +3,7 @@
 
 <issue num="2175" status="C++14">
 <title><tt>wstring_convert</tt> and <tt>wbuffer_convert</tt> validity</title>
-<section><sref ref="[conversions.string]"/> <sref ref="[conversions.buffer]"/></section>
+<section><sref ref="[depr.conversions.string]"/> <sref ref="[depr.conversions.buffer]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>2 Aug 2012</date>
 

--- a/xml/issue2176.xml
+++ b/xml/issue2176.xml
@@ -3,7 +3,7 @@
 
 <issue num="2176" status="C++14">
 <title>Special members for <tt>wstring_convert</tt> and <tt>wbuffer_convert</tt></title>
-<section><sref ref="[conversions.string]"/> <sref ref="[conversions.buffer]"/></section>
+<section><sref ref="[depr.conversions.string]"/> <sref ref="[depr.conversions.buffer]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>2 Aug 2012</date>
 

--- a/xml/issue2226.xml
+++ b/xml/issue2226.xml
@@ -5,14 +5,14 @@
 
 <issue num="2226" status="LEWG">
 <title><tt>wstring_convert</tt> methods do not take allocator instance</title>
-<section><sref ref="[conversions.string]"/></section>
+<section><sref ref="[depr.conversions.string]"/></section>
 <submitter>Glen Fernandes</submitter>
 <date>14 Dec 2012</date>
 
 <discussion>
 
 <p>
-The <tt>wstring_convert</tt> class template, described in <sref ref="[conversions.string]"/>, does not 
+The <tt>wstring_convert</tt> class template, described in <sref ref="[depr.conversions.string]"/>, does not 
 support custom stateful allocators. It only supports custom stateless allocators.
 <p/>
 The <tt>to_bytes</tt> member function returns <tt>basic_string&lt;char, char_traits&lt;char&gt;, Byte_alloc&gt;</tt>  
@@ -42,7 +42,7 @@ with appropriate use of allocators with the C++11 model.
 <p>This wording is relative to N3485.</p>
 
 <ol>
-<li><p>In <sref ref="[conversions.string]"/>/2 and /6 "Class template <tt>wstring_convert</tt> synopsis" change the overloads 
+<li><p>In <sref ref="[depr.conversions.string]"/>/2 and /6 "Class template <tt>wstring_convert</tt> synopsis" change the overloads 
 of the member function <tt>from_bytes()</tt> so that all four overloads take an additional parameter
 which is an instance of <tt>Wide_alloc</tt>:</p>
 
@@ -54,7 +54,7 @@ wide_string from_bytes(const char *first, const char *last<ins>, const Wide_allo
 </pre></blockquote>
 </li>
 
-<li><p>In <sref ref="[conversions.string]"/> /8 specify that this <tt>Wide_alloc</tt> allocator parameter is used to
+<li><p>In <sref ref="[depr.conversions.string]"/> /8 specify that this <tt>Wide_alloc</tt> allocator parameter is used to
 construct the <tt>wide_string</tt> object returned from the function:</p>
 
 <p>
@@ -76,7 +76,7 @@ from the function.</ins></p></li>
 </ul>
 </li>
 
-<li><p>In <sref ref="[conversions.string]"/>/2 and /12 "Class template <tt>wstring_convert</tt> synopsis" change the overloads 
+<li><p>In <sref ref="[depr.conversions.string]"/>/2 and /12 "Class template <tt>wstring_convert</tt> synopsis" change the overloads 
 of the member function <tt>to_bytes()</tt> so that all four overloads take an additional parameter
 which is an instance of <tt>Byte_alloc</tt>:</p>
 
@@ -88,7 +88,7 @@ byte_string to_bytes(const Elem *first, const Elem *last<ins>, const Byte_alloc&
 </pre></blockquote>
 </li>
 
-<li><p>In <sref ref="[conversions.string]"/> /13 specify that this <tt>Byte_alloc</tt> allocator parameter is used to
+<li><p>In <sref ref="[depr.conversions.string]"/> /13 specify that this <tt>Byte_alloc</tt> allocator parameter is used to
 construct the <tt>byte_string</tt> object returned from the function:</p>
 
 <p>

--- a/xml/issue2229.xml
+++ b/xml/issue2229.xml
@@ -5,7 +5,7 @@
 
 <issue num="2229" status="C++14">
 <title>Standard code conversion facets underspecified</title>
-<section><sref ref="[locale.stdcvt]"/></section>
+<section><sref ref="[depr.locale.stdcvt]"/></section>
 <submitter>Beman Dawes</submitter>
 <date>30 Dec 2012</date>
 

--- a/xml/issue2392.xml
+++ b/xml/issue2392.xml
@@ -16,7 +16,7 @@ The term "character type" is used in <sref ref="[defns.ntcts]"/>, <sref ref="[lo
 <sref ref="[ostream.inserters.character]"/>, but the core language only defines
 "narrow character types" (<sref ref="[basic.fundamental]"/>).
 <p/>
-"wide-character type" is used in <sref ref="[locale.stdcvt]"/>, but the core
+"wide-character type" is used in <sref ref="[depr.locale.stdcvt]"/>, but the core
 language only defines a "wide-character set" and "wide-character literal".
 </p>
 </discussion>

--- a/xml/issue2478.xml
+++ b/xml/issue2478.xml
@@ -3,7 +3,7 @@
 
 <issue num="2478" status="New">
 <title>Unclear how <tt>wstring_convert</tt> uses <tt>cvtstate</tt></title>
-<section><sref ref="[conversions.string]"/></section>
+<section><sref ref="[depr.conversions.string]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>4 Mar 2015</date>
 <priority>4</priority>

--- a/xml/issue2479.xml
+++ b/xml/issue2479.xml
@@ -3,7 +3,7 @@
 
 <issue num="2479" status="New">
 <title>Unclear how <tt>wbuffer_convert</tt> uses <tt>cvtstate</tt></title>
-<section><sref ref="[conversions.buffer]"/></section>
+<section><sref ref="[depr.conversions.buffer]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>4 Mar 2015</date>
 <priority>4</priority>

--- a/xml/issue2480.xml
+++ b/xml/issue2480.xml
@@ -3,7 +3,7 @@
 
 <issue num="2480" status="New">
 <title>Error handling of <tt>wbuffer_convert</tt> unclear</title>
-<section><sref ref="[conversions.buffer]"/></section>
+<section><sref ref="[depr.conversions.buffer]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>4 Mar 2015</date>
 <priority>4</priority>

--- a/xml/issue2481.xml
+++ b/xml/issue2481.xml
@@ -3,14 +3,14 @@
 
 <issue num="2481" status="New">
 <title><tt>wstring_convert</tt> should be more precise regarding "byte-error string" etc.</title>
-<section><sref ref="[conversions.string]"/></section>
+<section><sref ref="[depr.conversions.string]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>4 Mar 2015</date>
 <priority>4</priority>
 
 <discussion>
 <p>
-Paragraph 4 of <sref ref="[conversions.string]"/> introduces <tt>byte_err_string</tt> 
+Paragraph 4 of <sref ref="[depr.conversions.string]"/> introduces <tt>byte_err_string</tt> 
 as "a byte string to display on errors". What does display mean? The string is returned 
 on error, it's not displayed anywhere.
 <p/>

--- a/xml/issue2507.xml
+++ b/xml/issue2507.xml
@@ -6,7 +6,7 @@
 
 <issue num="2507" status="New">
 <title><tt>codecvt_mode</tt> should be a bitmask type</title>
-<section><sref ref="[locale.stdcvt]"/></section>
+<section><sref ref="[depr.locale.stdcvt]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>8 Jun 2015</date>
 <priority>3</priority>

--- a/xml/issue2854.xml
+++ b/xml/issue2854.xml
@@ -3,7 +3,7 @@
 
 <issue num="2854" status="LEWG">
 <title><tt>wstring_convert</tt> provides no indication of incomplete input or output</title>
-<section><sref ref="[conversions.string]"/></section>
+<section><sref ref="[depr.conversions.string]"/></section>
 <submitter>PowerGamer</submitter>
 <date>8 Jan 2017</date>
 <priority>3</priority>

--- a/xml/issue2869.xml
+++ b/xml/issue2869.xml
@@ -3,7 +3,7 @@
 
 <issue num="2869" status="Resolved">
 <title>Deprecate sub-clause [locale.stdcvt]</title>
-<section><sref ref="[locale.stdcvt]"/></section>
+<section><sref ref="[depr.locale.stdcvt]"/></section>
 <submitter>Great Britain</submitter>
 <date>3 Feb 2017</date>
 <priority>99</priority>

--- a/xml/issue2896.xml
+++ b/xml/issue2896.xml
@@ -3,7 +3,7 @@
 
 <issue num="2896" status="Dup">
 <title>The contents of <tt>&lt;codecvt&gt;</tt> are underspecified</title>
-<section><sref ref="[locale.stdcvt]"/></section>
+<section><sref ref="[depr.locale.stdcvt]"/></section>
 <submitter>Great Britain</submitter>
 <date>3 Feb 2017</date>
 <priority>99</priority>


### PR DESCRIPTION
For closed issues, only `<section>` was updated to point to the new section tag so that they index correctly. For open issues, also updated references elsewhere.