### PR TITLE
More section fixes

### DIFF
--- a/xml/issue0013.xml
+++ b/xml/issue0013.xml
@@ -3,7 +3,7 @@
 
 <issue num="13" status="TC1">
 <title>Eos refuses to die</title>
-<section><sref ref="[istream::extractors]"/></section>
+<section><sref ref="[istream.extractors]"/></section>
 <submitter>William M. Miller</submitter>
 <date>3 Mar 1998</date>
 

--- a/xml/issue0058.xml
+++ b/xml/issue0058.xml
@@ -5,7 +5,7 @@
 
 <issue num="58" status="NAD">
 <title>Extracting a char from a wide-oriented stream</title>
-<section><sref ref="[istream::extractors]"/></section>
+<section><sref ref="[istream.extractors]"/></section>
 <submitter>Matt Austern</submitter>
 <date>1 Jul 1998</date>
 

--- a/xml/issue0064.xml
+++ b/xml/issue0064.xml
@@ -5,7 +5,7 @@
 
 <issue num="64" status="TC1">
 <title>Exception handling in <tt>basic_istream::operator&gt;&gt;(basic_streambuf*)</tt></title>
-<section><sref ref="[istream::extractors]"/></section>
+<section><sref ref="[istream.extractors]"/></section>
 <submitter>Matt Austern</submitter>
 <date>11 Aug 1998 </date>
 

--- a/xml/issue0068.xml
+++ b/xml/issue0068.xml
@@ -5,7 +5,7 @@
 
 <issue num="68" status="TC1">
 <title>Extractors for char* should store null at end</title>
-<section><sref ref="[istream::extractors]"/></section>
+<section><sref ref="[istream.extractors]"/></section>
 <submitter>Angelika Langer</submitter>
 <date>14 Jul 1998</date>
 

--- a/xml/issue0162.xml
+++ b/xml/issue0162.xml
@@ -5,7 +5,7 @@
 
 <issue num="162" status="Dup">
 <title>Really &quot;formatted input functions&quot;?</title>
-<section><sref ref="[istream::extractors]"/></section>
+<section><sref ref="[istream.extractors]"/></section>
 <submitter>Dietmar K&uuml;hl</submitter>
 <date>20 Jul 1999</date>
 

--- a/xml/issue0413.xml
+++ b/xml/issue0413.xml
@@ -5,7 +5,7 @@
 
 <issue num="413" status="CD1">
 <title>Proposed resolution to LDR#64 still wrong</title>
-<section><sref ref="[istream::extractors]"/></section>
+<section><sref ref="[istream.extractors]"/></section>
 <submitter>Bo Persson</submitter>
 <date>13 Jul 2003</date>
 

--- a/xml/issue0639.xml
+++ b/xml/issue0639.xml
@@ -3,7 +3,7 @@
 
 <issue num="639" status="NAD">
 <title>Still problems with exceptions during streambuf IO</title>
-<section><sref ref="[istream::extractors]"/><sref ref="[ostream.inserters]"/></section>
+<section><sref ref="[istream.extractors]"/><sref ref="[ostream.inserters]"/></section>
 <submitter>Daniel Kr&uuml;gler</submitter>
 <date>17 Feb 2007</date>
 

--- a/xml/issue1235.xml
+++ b/xml/issue1235.xml
@@ -5,7 +5,7 @@
 
 <issue num="1235" status="LEWG">
 <title>Issue with C++0x random number proposal</title>
-<section><sref ref="[rand.concept.dist]"/></section>
+<section><sref ref="[rand.req.dist]"/></section>
 <submitter>Matthias Troyer</submitter>
 <date>12 Oct 2009</date>
 

--- a/xml/issue2334.xml
+++ b/xml/issue2334.xml
@@ -5,7 +5,7 @@
 
 <issue num="2334" status="SG1">
 <title><tt>atomic</tt>'s default constructor requires "uninitialized" state even for types with non-trivial default-constructor</title>
-<section><sref ref="[atomics.types.operations.req]"/></section>
+<section><sref ref="[atomics.types.operations]"/></section>
 <submitter>Daniel Kr&uuml;gler</submitter>
 <date>3 Oct 2013</date>
 

--- a/xml/issue2714.xml
+++ b/xml/issue2714.xml
@@ -88,7 +88,7 @@ operator>>(basic_istream&lt;charT, traits&gt;&amp; is, complex&lt;T&gt;&amp; x);
 <li> Otherwise, returns the character to <tt>is</tt>, extracts an object <tt>u</tt> of type <tt>T</tt> from <tt>is</tt>, and assigns <tt>complex&lt;T&gt;(u)</tt> to <tt>x</tt>.
 </li>
 </ul>
-In the description above, characters are extracted from <tt>is</tt> as if by <tt>operator&gt;&gt;</tt> (<sref ref="[istream::extractors]"/>), and returned
+In the description above, characters are extracted from <tt>is</tt> as if by <tt>operator&gt;&gt;</tt> (<sref ref="[istream.extractors]"/>), and returned
 to the stream as if by <tt>basic_istream::putback</tt> (<sref ref="[istream.unformatted]" />). Character equality is determined using <tt>traits::eq</tt>.
 An object <tt>t</tt> of type <tt>T</tt> is extracted from <tt>is</tt> as if by <tt> is &gt;&gt; t</tt>.
 <p/>

--- a/xml/issue2886.xml
+++ b/xml/issue2886.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
 <issue num="2886" status="New">
-<title>Keep the <tt>empty()</tt> functions in <tt>variant</tt></title>
-<section><sref ref="[section.ref.here]"/></section>
+<title>Keep the <tt>empty()</tt> functions in <tt>any</tt></title>
+<section><sref ref="[any.observers]"/></section>
 <submitter>Finland</submitter>
 <date>3 Feb 2017</date>
 <priority>99</priority>

--- a/xml/issue2887.xml
+++ b/xml/issue2887.xml
@@ -3,7 +3,7 @@
 
 <issue num="2887" status="Resolved">
 <title>Revert the changes from P0156R0: variadic <tt>lock_guard</tt></title>
-<section><sref ref="[section.ref.here]"/></section>
+<section><sref ref="[thread.lock.guard]"/></section>
 <submitter>Finland, Great Britain</submitter>
 <date>3 Feb 2017</date>
 <priority>99</priority>


### PR DESCRIPTION
Issue 1235 is about distribution requirements, so [rand.req.dist] seems like the correct target post-deconceptification.

I only updated `<section>` to point to the current section in issue 2334; additional references in the discussion and PR weren't updated since they refer to a previous working draft.

For issue 2886, I changed a reference to `variant` in the title to `any`, as the text of the NB comment was talking about `any::empty`, and no version of `variant` in the working draft had an `empty` member. Only `any` did.