### PR TITLE
[LWG 2969] further improve P/R

### DIFF
--- a/xml/issue2969.xml
+++ b/xml/issue2969.xml
@@ -92,7 +92,7 @@ will be attempting to uses-allocator construct a <tt>promise&lt;int&gt;</tt> wit
 rather than a <tt>memory_resource*</tt>.
 </p>
 
-<note>2017-06-13, Daniel restores and improves the previously proposed wording</note>
+<note>2017-06-13, Daniel and Tim restores and improves the previously proposed wording</note>
 <p>
 </p>
 </discussion>
@@ -141,14 +141,14 @@ uses-allocator construction with allocator <tt><del>resource()</del><ins>*this</
 <tt>p-&gt;second</tt> using the elements of <tt>y</tt>. &mdash; <i>end note</i>]
 </p>
 <ol style="list-style-type: none">
-<li><p>(9.1) &mdash; If <tt>uses_allocator_v&lt;T1,memory_resource*&gt;</tt> is <tt>false</tt>
+<li><p>(9.1) &mdash; If <tt>uses_allocator_v&lt;T1,<del>memory_resource*</del><ins>polymorphic_allocator</ins>&gt;</tt> is <tt>false</tt>
 and <tt>is_constructible_v&lt;T1,Args1...&gt;</tt> is <tt>true</tt>, then <tt>xprime</tt> is <tt>x</tt>.</p></li>
-<li><p>(9.2) &mdash; Otherwise, if <tt>uses_allocator_v&lt;T1,memory_resource*&gt;</tt> is <tt>true</tt>
-and <tt>is_constructible_v&lt;T1,allocator_arg_t,memory_resource*,Args1...&gt;</tt> is <tt>true</tt>, then 
+<li><p>(9.2) &mdash; Otherwise, if <tt>uses_allocator_v&lt;T1,<del>memory_resource*</del><ins>polymorphic_allocator</ins>&gt;</tt> is <tt>true</tt>
+and <tt>is_constructible_v&lt;T1,allocator_arg_t,<del>memory_resource*</del><ins>polymorphic_allocator</ins>,Args1...&gt;</tt> is <tt>true</tt>, then 
 <tt>xprime</tt> is <tt>tuple_cat(make_tuple(allocator_arg, <del>resource()</del><ins>*this</ins>), 
 std::move(x))</tt>.</p></li>
-<li><p>(9.3) &mdash; Otherwise, if <tt>uses_allocator_v&lt;T1,memory_resource*&gt;</tt> is <tt>true</tt> and 
-<tt>is_constructible_v&lt;T1,Args1...,memory_resource*&gt;</tt> is <tt>true</tt>, then <tt>xprime</tt> is 
+<li><p>(9.3) &mdash; Otherwise, if <tt>uses_allocator_v&lt;T1,<del>memory_resource*</del><ins>polymorphic_allocator</ins>&gt;</tt> is <tt>true</tt> and 
+<tt>is_constructible_v&lt;T1,Args1...,<del>memory_resource*</del><ins>polymorphic_allocator</ins>&gt;</tt> is <tt>true</tt>, then <tt>xprime</tt> is 
 <tt>tuple_cat(std::move(x), make_tuple(<del>resource()</del><ins>*this</ins>))</tt>.</p></li>
 <li><p>(9.4) &mdash; Otherwise the program is ill formed.</p></li>
 </ol>
@@ -156,13 +156,13 @@ std::move(x))</tt>.</p></li>
 Let <tt>yprime</tt> be a tuple constructed from <tt>y</tt> according to the appropriate rule from the following list:
 </p>
 <ol style="list-style-type: none">
-<li><p>(9.5) &mdash; If <tt>uses_allocator_v&lt;T2,memory_resource*&gt;</tt> is <tt>false</tt>
+<li><p>(9.5) &mdash; If <tt>uses_allocator_v&lt;T2,<del>memory_resource*</del><ins>polymorphic_allocator</ins>&gt;</tt> is <tt>false</tt>
 and <tt>is_constructible_v&lt;T2,Args2...&gt;</tt> is <tt>true</tt>, then <tt>yprime</tt> is <tt>y</tt>.</p></li>
-<li><p>(9.6) &mdash; Otherwise, if <tt>uses_allocator_v&lt;T2,memory_resource*&gt;</tt> is <tt>true</tt> and 
-<tt>is_constructible_v&lt;T2,allocator_arg_t,memory_resource*,Args2...&gt;</tt> is <tt>true</tt>, then <tt>yprime</tt> 
+<li><p>(9.6) &mdash; Otherwise, if <tt>uses_allocator_v&lt;T2,<del>memory_resource*</del><ins>polymorphic_allocator</ins>&gt;</tt> is <tt>true</tt> and 
+<tt>is_constructible_v&lt;T2,allocator_arg_t,<del>memory_resource*</del><ins>polymorphic_allocator</ins>,Args2...&gt;</tt> is <tt>true</tt>, then <tt>yprime</tt> 
 is <tt>tuple_cat(make_tuple(allocator_arg, <del>resource()</del><ins>*this</ins>), std::move(y))</tt>.</p></li>
-<li><p>(9.7) &mdash; Otherwise, if <tt>uses_allocator_v&lt;T2,memory_resource*&gt;</tt> is <tt>true</tt> and 
-<tt>is_constructible_v&lt;T2,Args2...,memory_resource*&gt;</tt> is <tt>true</tt>,
+<li><p>(9.7) &mdash; Otherwise, if <tt>uses_allocator_v&lt;T2,<del>memory_resource*</del><ins>polymorphic_allocator</ins>&gt;</tt> is <tt>true</tt> and 
+<tt>is_constructible_v&lt;T2,Args2...,<del>memory_resource*</del><ins>polymorphic_allocator</ins>&gt;</tt> is <tt>true</tt>,
 then <tt>yprime</tt> is <tt>tuple_cat(std::move(y), make_tuple(<del>resource()</del><ins>*this</ins>))</tt>.</p></li>
 <li><p>(9.8) &mdash; Otherwise the program is ill formed.</p></li>
 </ol>


### PR DESCRIPTION
Replace all uses of memory_resource* in uses_allocator and is_constructible with the injected-class-name.