### PR TITLE
Indexing fixes

### DIFF
--- a/xml/issue0073.xml
+++ b/xml/issue0073.xml
@@ -5,7 +5,7 @@
 
 <issue num="73" status="NAD">
 <title><tt>is_open</tt> should be const</title>
-<section><sref ref="[fstreams]"/></section>
+<section><sref ref="[file.streams]"/></section>
 <submitter>Matt Austern</submitter>
 <date>27 Aug 1998</date>
 

--- a/xml/issue0201.xml
+++ b/xml/issue0201.xml
@@ -5,7 +5,7 @@
 
 <issue num="201" status="CD1">
 <title>Numeric limits terminology wrong</title>
-<section><sref ref="[limits]"/></section>
+<section><sref ref="[support.limits]"/></section>
 <submitter>Stephen Cleary</submitter>
 <date>21 Dec 1999</date>
 

--- a/xml/issue0416.xml
+++ b/xml/issue0416.xml
@@ -5,7 +5,7 @@
 >
 <issue num="416" status="CD1">
     <title>definitions of XXX_MIN and XXX_MAX macros in climits</title>
-    <section><sref ref="[c.limits]"/></section>
+    <section><sref ref="[climits.syn]"/></section>
     <submitter>Martin Sebor</submitter>
     <date>18 Sep 2003</date>
     <discussion>

--- a/xml/issue0420.xml
+++ b/xml/issue0420.xml
@@ -5,7 +5,7 @@
 >
 <issue num="420" status="CD1">
     <title>is std::FILE a complete type?</title>
-    <section><sref ref="[fstreams]"/></section>
+    <section><sref ref="[file.streams]"/></section>
     <submitter>Martin Sebor</submitter>
     <date>18 Sep 2003</date>
 

--- a/xml/issue0425.xml
+++ b/xml/issue0425.xml
@@ -5,7 +5,7 @@
 >
 <issue num="425" status="CD1">
     <title>return value of std::get_temporary_buffer</title>
-    <section><sref ref="[temporary.buffer]"/></section>
+    <section><sref ref="[depr.temporary.buffer]"/></section>
     <submitter>Martin Sebor</submitter>
     <date>18 Sep 2003</date>
 

--- a/xml/issue0444.xml
+++ b/xml/issue0444.xml
@@ -5,7 +5,7 @@
 
 <issue num="444" status="CD1">
 <title>Bad use of casts in fstream</title>
-<section><sref ref="[fstreams]"/></section>
+<section><sref ref="[file.streams]"/></section>
 <submitter>Vincent Leloup</submitter>
 <date>20 Nov 2003</date>
 

--- a/xml/issue0460.xml
+++ b/xml/issue0460.xml
@@ -5,7 +5,7 @@
 
 <issue num="460" status="CD1">
 <title>Default modes missing from basic_fstream member specifications</title>
-<section><sref ref="[fstreams]"/></section>
+<section><sref ref="[file.streams]"/></section>
 <submitter>Ben Hutchings</submitter>
 <date>1 Apr 2004</date>
 

--- a/xml/issue0551.xml
+++ b/xml/issue0551.xml
@@ -5,7 +5,7 @@
 
 <issue num="551" status="CD1">
 <title>&lt;ccomplex&gt;</title>
-<section><sref ref="[cmplxh]"/><sref ref="[tr.c99.cmplxh]"/></section>
+<section><sref ref="[depr.c.headers]"/></section>
 <submitter>Howard Hinnant</submitter>
 <date>23 Jan 2006</date>
 

--- a/xml/issue0559.xml
+++ b/xml/issue0559.xml
@@ -5,7 +5,7 @@
 
 <issue num="559" status="CD1">
 <title>numeric_limits&lt;const T&gt;</title>
-<section><sref ref="[limits]"/></section>
+<section><sref ref="[numeric.limits]"/></section>
 <submitter>Martin Sebor</submitter>
 <date>19 Feb 2006</date>
 

--- a/xml/issue0863.xml
+++ b/xml/issue0863.xml
@@ -5,7 +5,7 @@
 
 <issue num="863" status="NAD">
 <title>What is the state of a stream after close() succeeds</title>
-<section><sref ref="[fstreams]"/></section>
+<section><sref ref="[file.streams]"/></section>
 <submitter>Steve Clamage</submitter>
 <date>8 Jul 2008</date>
 

--- a/xml/issue0902.xml
+++ b/xml/issue0902.xml
@@ -5,7 +5,7 @@
 
 <issue num="902" status="NAD Concepts">
 <title>Regular is the wrong concept to constrain numeric_limits</title>
-<section><sref ref="[limits]"/></section>
+<section><sref ref="[numeric.limits]"/></section>
 <submitter>Alisdair Meredith</submitter>
 <date>24 Sep 2008</date>
 

--- a/xml/issue1028.xml
+++ b/xml/issue1028.xml
@@ -5,7 +5,7 @@
 
 <issue num="1028" status="NAD Concepts">
 <title><tt>raw_storage_iterator</tt> needs to be a concept-constrained template</title>
-<section><sref ref="[storage.iterator]"/></section>
+<section><sref ref="[depr.storage.iterator]"/></section>
 <submitter>Alisdair Meredith</submitter>
 <date>11 Mar 2009</date>
 

--- a/xml/issue1076.xml
+++ b/xml/issue1076.xml
@@ -5,7 +5,7 @@
 
 <issue num="1076" status="NAD Concepts">
 <title>unary/binary_negate need constraining and move support</title>
-<section><sref ref="[negators]"/></section>
+<section><sref ref="[depr.negators]"/></section>
 <submitter>Alisdair Meredith</submitter>
 <date>20 Mar 2009</date>
 

--- a/xml/issue1134.xml
+++ b/xml/issue1134.xml
@@ -4,7 +4,7 @@
 <issue num="1134" status="C++11">
 <title>Redundant specification of <tt>&lt;stdint.h&gt;</tt>, <tt>&lt;fenv.h&gt;</tt>, <tt>&lt;tgmath.h&gt;</tt>, 
        and maybe <tt>&lt;complex.h&gt;</tt></title>
-<section><sref ref="[stdinth]"/><sref ref="[fenv]"/><sref ref="[c.math]"/><sref ref="[cmplxh]"/></section>
+<section><sref ref="[c.math]"/><sref ref="[stdinth]"/><sref ref="[fenv]"/><sref ref="[cmplxh]"/></section>
 <submitter>Robert Klarer</submitter>
 <date>26 May 2009</date>
 

--- a/xml/issue1339.xml
+++ b/xml/issue1339.xml
@@ -5,7 +5,7 @@
 
 <issue num="1339" status="C++11">
 <title><tt>uninitialized_fill_n</tt> should return the end of its range</title>
-<section><sref ref="[uninitialized.fill.n]"/></section>
+<section><sref ref="[uninitialized.fill]"/></section>
 <submitter>Jared Hoberock</submitter>
 <date>14 Jul 2010</date>
 

--- a/xml/issue1368.xml
+++ b/xml/issue1368.xml
@@ -5,7 +5,7 @@
 
 <issue num="1368" status="C++11">
 <title>Thread safety of <tt>std::uncaught_exception()</tt></title>
-<section><sref ref="[uncaught]"/></section>
+<section><sref ref="[depr.uncaught]"/></section>
 <submitter>BSI</submitter>
 <date>25 Aug 2010</date>
 

--- a/xml/issue1474.xml
+++ b/xml/issue1474.xml
@@ -5,7 +5,7 @@
 
 <issue num="1474" status="C++11">
 <title>weak compare-and-exchange confusion</title>
-<section><sref ref="[atomics.types.operations.req]"/></section>
+<section><sref ref="[atomics.types.operations]"/></section>
 <submitter>INCITS</submitter>
 <date>25 Aug 2010</date>
 

--- a/xml/issue2072.xml
+++ b/xml/issue2072.xml
@@ -5,7 +5,7 @@
 
 <issue num="2072" status="WP">
 <title>Unclear wording about capacity of temporary buffers</title>
-<section><sref ref="[temporary.buffer]"/></section>
+<section><sref ref="[depr.temporary.buffer]"/></section>
 <submitter>Kazutoshi Satoda</submitter>
 <date>10 Aug 2011</date>
 <priority>3</priority>

--- a/xml/issue2127.xml
+++ b/xml/issue2127.xml
@@ -5,7 +5,7 @@
 
 <issue num="2127" status="WP">
 <title>Move-construction with <tt>raw_storage_iterator</tt></title>
-<section><sref ref="[storage.iterator]"/></section>
+<section><sref ref="[depr.storage.iterator]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>23 Jan 2012</date>
 <priority>3</priority>

--- a/xml/issue2300.xml
+++ b/xml/issue2300.xml
@@ -3,7 +3,7 @@
 
 <issue num="2300" status="C++14">
 <title>[CD] Redundant sections for <tt>map</tt> and <tt>multimap</tt> members should be removed</title>
-<section><sref ref="[map.ops]"/> <sref ref="[multimap.ops]"/></section>
+<section><sref ref="[map]"/> <sref ref="[multimap]"/></section>
 <submitter>Daniel Kr&uuml;gler</submitter>
 <date>25 Sep 2013</date>
 

--- a/xml/issue2376.xml
+++ b/xml/issue2376.xml
@@ -5,7 +5,7 @@
 
 <issue num="2376" status="WP">
 <title><tt>bad_weak_ptr::what()</tt> overspecified</title>
-<section><sref ref="[util.smartptr.weakptr]"/></section>
+<section><sref ref="[util.smartptr.weak.bad]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>27 Mar 2014</date>
 <priority>99</priority>

--- a/xml/issue2426.xml
+++ b/xml/issue2426.xml
@@ -5,7 +5,7 @@
 
 <issue num="2426" status="WP">
 <title>Issue about <tt>compare_exchange</tt></title>
-<section><sref ref="[atomics.types.operations.req]"/></section>
+<section><sref ref="[atomics.types.operations]"/></section>
 <submitter>Hans Boehm</submitter>
 <date>25 Aug 2014</date>
 <priority>1</priority>

--- a/xml/issue2438.xml
+++ b/xml/issue2438.xml
@@ -5,7 +5,7 @@
 
 <issue num="2438" status="WP">
 <title><tt>std::iterator</tt> inheritance shouldn't be mandated</title>
-<section><sref ref="[iterator.basic]"/></section>
+<section><sref ref="[depr.iterator.basic]"/></section>
 <submitter>Stephan T. Lavavej</submitter>
 <date>1 Oct 2014</date>
 <priority>3</priority>

--- a/xml/issue2454.xml
+++ b/xml/issue2454.xml
@@ -5,7 +5,7 @@
 
 <issue num="2454" status="WP">
 <title>Add <tt>raw_storage_iterator::base()</tt> member</title>
-<section><sref ref="[storage.iterator]"/></section>
+<section><sref ref="[depr.storage.iterator]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>11 Nov 2014</date>
 <priority>0</priority>

--- a/xml/issue2666.xml
+++ b/xml/issue2666.xml
@@ -3,7 +3,7 @@
 
 <issue num="2666" status="NAD Editorial">
 <title>Bitmask operations should use bitmask terms</title>
-<section><sref ref="[fs.scope]"/></section>
+<section><sref ref="[filesystems]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>30 Jun 2014</date>
 <priority>3</priority>

--- a/xml/issue2701.xml
+++ b/xml/issue2701.xml
@@ -3,7 +3,7 @@
 
 <issue num="2701" status="NAD Editorial">
 <title>Unclear requirement in [memory.resource.private]</title>
-<section><sref ref="[memory.resource.private]"/></section>
+<section><sref ref="[mem.res.private]"/></section>
 <submitter>Jonathan Wakely</submitter>
 <date>4 May 2016</date>
 <priority>3</priority>

--- a/xml/issue2724.xml
+++ b/xml/issue2724.xml
@@ -3,7 +3,7 @@
 
 <issue num="2724" status="WP">
 <title>The protected virtual member functions of <tt>memory_resource</tt> should be private</title>
-<section><sref ref="[memory.resource.class]"/></section>
+<section><sref ref="[mem.res.class]"/></section>
 <submitter>Ville Voutilainen</submitter>
 <date>4 Jun 2016</date>
 <priority>4</priority>

--- a/xml/issue2740.xml
+++ b/xml/issue2740.xml
@@ -3,7 +3,7 @@
 
 <issue num="2740" status="WP">
 <title><tt>constexpr optional&lt;T&gt;::operator-&gt;</tt></title>
-<section><sref ref="[optional.object.observe]"/></section>
+<section><sref ref="[optional.observe]"/></section>
 <submitter>Agust&iacute;n K-ballo Berg&eacute;</submitter>
 <date>2 Jul 2016</date>
 <priority>0</priority>

--- a/xml/issue2748.xml
+++ b/xml/issue2748.xml
@@ -3,7 +3,7 @@
 
 <issue num="2748" status="WP">
 <title><tt>swappable</tt> traits for <tt>optional</tt>s</title>
-<section><sref ref="[optional.object.swap]"/><sref ref="[optional.specalg]"/></section>
+<section><sref ref="[optional.swap]"/><sref ref="[optional.specalg]"/></section>
 <submitter>Agust&iacute;n K-ballo Berg&eacute;</submitter>
 <date>19 Jul 2016</date>
 <priority>0</priority>

--- a/xml/issue2753.xml
+++ b/xml/issue2753.xml
@@ -3,7 +3,7 @@
 
 <issue num="2753" status="Resolved">
 <title>Optional's constructors and assignments need constraints</title>
-<section><sref ref="[optional.object.ctor]"/><sref ref="[optional.object.assign]"/></section>
+<section><sref ref="[optional.ctor]"/><sref ref="[optional.assign]"/></section>
 <submitter>Casey Carter</submitter>
 <date>22 Jul 2016</date>
 <priority>0</priority>

--- a/xml/issue2835.xml
+++ b/xml/issue2835.xml
@@ -3,7 +3,7 @@
 
 <issue num="2835" status="WP">
 <title>LWG 2536 seems to misspecify <tt>&lt;tgmath.h&gt;</tt></title>
-<section><sref ref="[ctgmath.syn]"/><sref ref="[depr.c.headers]"/></section>
+<section><sref ref="[depr.c.headers]"/><sref ref="[depr.ctgmath.syn]"/></section>
 <submitter>Thomas Koeppe</submitter>
 <date>29 Nov 2016</date>
 <priority>0</priority>

--- a/xml/issue2976.xml
+++ b/xml/issue2976.xml
@@ -3,7 +3,7 @@
 
 <issue num="2976" status="New">
 <title>Dangling <tt>uses_allocator</tt> specialization for <tt>packaged_task</tt></title>
-<section><sref ref="[future.syn]"/><sref ref="[futures.task]"/><sref ref="[futures.task.nonmembers]"/></section>
+<section><sref ref="[futures.task]"/><sref ref="[future.syn]"/><sref ref="[futures.task.nonmembers]"/></section>
 <submitter>Tim Song</submitter>
 <date>13 Jun 2017</date>
 <priority>99</priority>


### PR DESCRIPTION
This changes a bunch of "section 99" issues so that they are indexed under the rough counterpart of the specified section in current WP.