### PR TITLE
Spelling fixes

### DIFF
--- a/xml/issue2104.xml
+++ b/xml/issue2104.xml
@@ -75,7 +75,7 @@ the move-assignment operator, because using it correctly shall not throw an
 exception.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate after SG1 review</note>
+<note>Issaquah 2014-02-11: Move to Immediate after SG1 review</note>
 
 </discussion>
 

--- a/xml/issue2156.xml
+++ b/xml/issue2156.xml
@@ -68,7 +68,7 @@ Howard to provide rationale and potentally revised wording.
 
 <note>2012-02-12 Issaquah : recategorize as P3</note>
 <p>
-Jonathon Wakely: submitter is Boost.Hash maintainer. Think it's right.
+Jonathan Wakely: submitter is Boost.Hash maintainer. Think it's right.
 </p>
 
 <p>

--- a/xml/issue2182.xml
+++ b/xml/issue2182.xml
@@ -75,7 +75,7 @@ Matt will file a new issue for some additional concerns with regex <tt>match_res
 The new issue opened by Matt is LWG <iref ref="2306"/>.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 <p>
 Issue should have been Ready in pre-meeting mailing.
 </p>

--- a/xml/issue2186.xml
+++ b/xml/issue2186.xml
@@ -30,7 +30,7 @@ Hans: we should redraft to factor out the proposed text outside the two bullets.
 Moved to open
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate after SG1 review</note>
+<note>Issaquah 2014-02-11: Move to Immediate after SG1 review</note>
 
 </discussion>
 

--- a/xml/issue2193.xml
+++ b/xml/issue2193.xml
@@ -321,7 +321,7 @@ explicit unordered_multiset(size_type n<del> = <i>see below</i></del>,
 
 </blockquote>
 
-<note>Issaquah 20014-10-11: Move to Immediate after final review</note>
+<note>Issaquah 2014-02-11: Move to Immediate after final review</note>
 
 </discussion>
 

--- a/xml/issue2205.xml
+++ b/xml/issue2205.xml
@@ -29,7 +29,7 @@ there is an explicit description for <tt>n == 0</tt>, this qualification should 
 in all 6 places.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2213.xml
+++ b/xml/issue2213.xml
@@ -20,7 +20,7 @@ original value of "out" (i.e. they have to keep a copy of the iterator for no re
 really what was intended?
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2293.xml
+++ b/xml/issue2293.xml
@@ -16,7 +16,7 @@ At the end of <sref ref="[facet.num.put.virtuals]"/> (in p6), the return value i
 <tt>truename</tt> or <tt>falsename</tt> on the wrong facet: <tt>ctype</tt> should be replaced by <tt>numpunct</tt>.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2304.xml
+++ b/xml/issue2304.xml
@@ -18,7 +18,7 @@ count of elements in each group of equivalent keys, something which hardly looks
 (known by the submitter) stdlib implementation is currently doing.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2306.xml
+++ b/xml/issue2306.xml
@@ -54,7 +54,7 @@ Given the fact that <tt>std::initializer_list</tt> doesn't meet the container re
 type) I recommend to stick with the current state.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2308.xml
+++ b/xml/issue2308.xml
@@ -21,7 +21,7 @@ Since <tt>std::array</tt> obtains no memory, there is none to deallocate,
 arguably  making it unclear what the requirement means for <tt>std::array::~array()</tt>.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2313.xml
+++ b/xml/issue2313.xml
@@ -54,7 +54,7 @@ system. It would be far simpler and perfectly reasonable to expect that user-def
 should have <tt>tuple_sizes</tt> of <tt>size_t</tt>.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2314.xml
+++ b/xml/issue2314.xml
@@ -25,7 +25,7 @@ references to tuples.  Using <tt>remove_reference_t</tt> would avoid this proble
 significantly shorter name. (The additional transformations that <tt>decay_t</tt> does are neither beneficial nor harmful here.)
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2316.xml
+++ b/xml/issue2316.xml
@@ -29,7 +29,7 @@ We all know what <tt>weak_ptr::lock()</tt> should do, the Standardese just doesn
 <sref ref="[util.smartptr.shared.const]"/>/23-27 describes the behavior with English instead of code.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2317.xml
+++ b/xml/issue2317.xml
@@ -24,7 +24,7 @@ be chosen, with <tt>size_t</tt> being a reasonable choice. (Another choice would
 template parameter <tt>I</tt>.)
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2320.xml
+++ b/xml/issue2320.xml
@@ -19,7 +19,7 @@
 the allocator belonging to the container being moved." so we can follow that wording.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2322.xml
+++ b/xml/issue2322.xml
@@ -20,7 +20,7 @@ The unordered associative containers are similarly affected, although they have 
 containers are correctly depicted with the desired constructors, their behavior just isn't specified.)
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2323.xml
+++ b/xml/issue2323.xml
@@ -24,7 +24,7 @@ non-<tt>CopyInsertable</tt> <tt>T</tt> there are no effects." This is confusing 
 requires only <tt>MoveInsertable</tt> and <tt>DefaultInsertable</tt>.)
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2324.xml
+++ b/xml/issue2324.xml
@@ -15,7 +15,7 @@ say "Initializes container with <tt>&amp;x</tt>", which doesn't defend against c
 Containers are now required to have such defenses for their elements, so we may as well be consistent here.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2330.xml
+++ b/xml/issue2330.xml
@@ -20,7 +20,7 @@ This "exactly one" wording technically forbids passing <tt>icase</tt> by itself!
 is completely irrelevant, as regex construction is so much more expensive.)
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2339.xml
+++ b/xml/issue2339.xml
@@ -41,7 +41,7 @@ and every iterator <tt>j</tt> in the range <tt>[nth,last)</tt> it holds that: <t
 </p>
 </blockquote>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2341.xml
+++ b/xml/issue2341.xml
@@ -50,7 +50,7 @@ Note that the description of <tt>basic_istream&lt;charT,traits&gt;&amp; seekg(of
 <sref ref="[istream.unformatted]"/> p43 <em>does</em> require setting <tt>failbit</tt>.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2346.xml
+++ b/xml/issue2346.xml
@@ -15,7 +15,7 @@
 Obvious.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2357.xml
+++ b/xml/issue2357.xml
@@ -37,7 +37,7 @@ Given the fact that <tt>partition_copy</tt> never touches any input value twice,
 The below suggested primary resolution does not respond to the second part of this question.
 </p>
 
-<note>Issaquah 20014-10-11: Move to Immediate</note>
+<note>Issaquah 2014-02-11: Move to Immediate</note>
 
 </discussion>
 

--- a/xml/issue2935.xml
+++ b/xml/issue2935.xml
@@ -18,7 +18,7 @@ and change the result if so" &mdash; but it seems unfortunate to require both Wi
 system calls in this case.
 <p/>
 In email discussion Davis Herring and Billy O'Neal discussed this issue and agreed that this was probably 
-unintentional. Special thanks for Johnathan Wakely's suggested change to <tt>create_directories</tt>' 
+unintentional. Special thanks for Jonathan Wakely's suggested change to <tt>create_directories</tt>' 
 <em>Returns</em> clause.
 </p>
 


### PR DESCRIPTION
For the Issaquah issues, they were neither moved 18 millennia in the future nor in October (see, e.g., bb441ec0c419c803fe6bf9d2dfb2dfb7ce6d66df)