### PR TITLE
Add wording for LWG 2936.

### DIFF
--- a/xml/issue2936.xml
+++ b/xml/issue2936.xml
@@ -10,24 +10,24 @@
 
 <discussion>
 <p>
-Currently, path comparison is defined elementwise, which implies a conversion from the native format (implied by 
-<tt>native()</tt> returning <tt>const string&amp;</tt>). However, the conversion from the native format to the generic 
-format might not be information preserving. This would allow two paths <tt>a</tt> and <tt>b</tt> to say 
-<tt>a.compare(b) == 0</tt>, but <tt>a.native().compare(b.native()) != 0</tt> as a result of this missing information, 
-which is undesirable. We only want that condition to happen if there are redundant directory separators. We also don't 
-want to change the path comparison to be in terms of the native format, due to Peter Dimov's example where we want 
+Currently, path comparison is defined elementwise, which implies a conversion from the native format (implied by
+<tt>native()</tt> returning <tt>const string&amp;</tt>). However, the conversion from the native format to the generic
+format might not be information preserving. This would allow two paths <tt>a</tt> and <tt>b</tt> to say
+<tt>a.compare(b) == 0</tt>, but <tt>a.native().compare(b.native()) != 0</tt> as a result of this missing information,
+which is undesirable. We only want that condition to happen if there are redundant directory separators. We also don't
+want to change the path comparison to be in terms of the native format, due to Peter Dimov's example where we want
 <tt>path("a/b")</tt> to sort earlier than <tt>path("a.b")</tt>, and we want <tt>path("a/b") == path("a//////b")</tt>.
 <p/>
-Citing a Windows example, conversion to the generic format is going to have to drop alternate data streams. This might 
-give <tt>path("a/b:ads") == path("a/b")</tt>. I think I should consider the alternate data streams as part of the path 
-element though, so this case might be fine, so long as I make <tt>path("b:ads").native()</tt> be <tt>"b:ads"</tt>. 
+Citing a Windows example, conversion to the generic format is going to have to drop alternate data streams. This might
+give <tt>path("a/b:ads") == path("a/b")</tt>. I think I should consider the alternate data streams as part of the path
+element though, so this case might be fine, so long as I make <tt>path("b:ads").native()</tt> be <tt>"b:ads"</tt>.
 This might not work for our z/OS friends though, or for folks where the native format looks nothing like the generic format.
 <p/>
-Additionally, this treats root-directory specially. For example, the current spec wants <tt>path("c:/a/b") == path("c:/a////b")</tt>, 
-but <tt>path("c:/a/b") != path("c:///a/b")</tt>, because <tt>native()</tt> for the root-directory path element will literally 
+Additionally, this treats root-directory specially. For example, the current spec wants <tt>path("c:/a/b") == path("c:/a////b")</tt>,
+but <tt>path("c:/a/b") != path("c:///a/b")</tt>, because <tt>native()</tt> for the root-directory path element will literally
 be the slashes or preferred separators.
 <p/>
-This addresses similar issues to those raised in US 57 &mdash; it won't make absolute paths sort at the beginning or end 
+This addresses similar issues to those raised in US 57 &mdash; it won't make absolute paths sort at the beginning or end
 but it will make paths of the same kind sort together.
 </p>
 
@@ -39,9 +39,9 @@ but it will make paths of the same kind sort together.
 
 <note>2016-07, Toronto Saturday afternoon issues processing</note>
 <p>Billy to reword after Davis researches history about ordering. Status to Open.</p>
-</discussion>
 
-<resolution>
+<p><strong>Previous resolution [SUPERSEDED]:</strong></p>
+<blockquote class="note">
 <p>This wording is relative to <a href="http://wg21.link/n4640">N4640</a>.</p>
 
 <ol>
@@ -83,7 +83,7 @@ int compare(const path&amp; p) const noexcept;
 <ins>&mdash; <i>end note</i>]</ins>
 </p>
 <p>
-<del>-2- <em>Remarks</em>: The elements are determined as if by iteration over the half-open range <tt>[begin(), end())</tt> 
+<del>-2- <em>Remarks</em>: The elements are determined as if by iteration over the half-open range <tt>[begin(), end())</tt>
 for <tt>*this</tt> and <tt>p</tt>.</del>
 </p>
 </blockquote>
@@ -106,7 +106,78 @@ int compare(const value_type* s) const
 </pre>
 <blockquote>
 <p>
--4- <em><del>Returns</del><ins>Effects</ins></em>: <ins>Equivalent to <tt>return 
+-4- <em><del>Returns</del><ins>Effects</ins></em>: <ins>Equivalent to <tt>return
+</tt></ins><tt>compare(path(s))<ins>;</ins><del>.</del></tt>
+</p>
+</blockquote>
+</blockquote>
+
+</li>
+</ol>
+</blockquote>
+
+</discussion>
+
+<resolution>
+<p>This wording is relative to <a href="http://wg21.link/n4659">N4659</a>.</p>
+
+<ol>
+<li><p>Make the following edits to <sref ref="[fs.path.compare]"/>:</p>
+
+<blockquote>
+<pre>
+int compare(const path&amp; p) const noexcept;
+</pre>
+<blockquote>
+<p>
+-1- <em>Returns</em>:
+</p>
+<blockquote>
+<p>
+<ins>&mdash; Let <tt>rootNameComparison</tt> be the result of <tt>this-&gt;root_name().native().compare(p.root_name().native())</tt>. If <tt>rootNameComparison</tt> is not <tt>0</tt>, <tt>rootNameComparison</tt>; otherwise,</ins>
+</p>
+<p>
+<ins>&mdash; If <tt>this-&gt;has_root_directory()</tt> and <tt>!p.has_root_directory()</tt>, a value less than <tt>0</tt>; otherwise,</ins>
+</p>
+<p>
+<ins>&mdash; If <tt>!this-&gt;has_root_directory()</tt> and <tt>p.has_root_directory()</tt>, a value greater than <tt>0</tt>; otherwise,</ins>
+</p>
+<p>&mdash; <del>a value less than <tt>0</tt>, i</del><ins>I</ins>f <tt>native()</tt> for the elements of <tt><del>*</del>this<ins>-&gt;relative_path()</ins></tt> are lexicographically less than <tt>native()</tt> for the elements of <tt>p<ins>.relative_path()</ins></tt><ins>, a value less than <tt>0</tt></ins>; otherwise,</p>
+<p>&mdash; <del>a value greater than <tt>0</tt>, i</del><ins>I</ins>f <tt>native()</tt> for the elements of <tt><del>*</del>this<ins>-&gt;relative_path()</ins></tt> are lexicographically greater than <tt>native()</tt> for the elements of <tt>p<ins>.relative_path()</ins></tt><ins>, a value greater than <tt>0</tt></ins>; otherwise,</p>
+<p>
+<ins>&mdash; If an implementation requires additional tiebreakers to disambiguate distinct native paths with identical generic decompositions, an implementation defined value; otherwise,</ins>
+</p>
+<p>
+&mdash; <tt>0</tt>.</p>
+</blockquote>
+<p>
+<ins>-?- [<i>Note:</i> For POSIX and Windows platforms, no additional tiebreakers are required &mdash; <i>end note</i>]</ins>
+</p>
+<p>
+<del>-2- <em>Remarks</em>: The elements are determined as if by iteration over the half-open range <tt>[begin(), end())</tt>
+for <tt>*this</tt> and <tt>p</tt>.</del>
+</p>
+</blockquote>
+<pre>
+int compare(const string_type&amp; s) const
+int compare(basic_string_view&lt;value_type&gt; s) const;
+</pre>
+<blockquote>
+<p>
+<del>-3- <em>Returns</em>: <tt>compare(path(s))</tt></del>
+</p>
+<blockquote class="note">
+<p>
+[Editor's note: Delete paragraph 3 entirely and merge the <tt>value_type</tt> overload with those above.]
+</p>
+</blockquote>
+</blockquote>
+<pre>
+int compare(const value_type* s) const
+</pre>
+<blockquote>
+<p>
+-4- <em><del>Returns</del><ins>Effects</ins></em>: <ins>Equivalent to <tt>return
 </tt></ins><tt>compare(path(s))<ins>;</ins><del>.</del></tt>
 </p>
 </blockquote>

--- a/xml/issue2936.xml
+++ b/xml/issue2936.xml
@@ -145,14 +145,8 @@ int compare(const path&amp; p) const noexcept;
 <p>&mdash; <del>a value less than <tt>0</tt>, i</del><ins>I</ins>f <tt>native()</tt> for the elements of <tt><del>*</del>this<ins>-&gt;relative_path()</ins></tt> are lexicographically less than <tt>native()</tt> for the elements of <tt>p<ins>.relative_path()</ins></tt><ins>, a value less than <tt>0</tt></ins>; otherwise,</p>
 <p>&mdash; <del>a value greater than <tt>0</tt>, i</del><ins>I</ins>f <tt>native()</tt> for the elements of <tt><del>*</del>this<ins>-&gt;relative_path()</ins></tt> are lexicographically greater than <tt>native()</tt> for the elements of <tt>p<ins>.relative_path()</ins></tt><ins>, a value greater than <tt>0</tt></ins>; otherwise,</p>
 <p>
-<ins>&mdash; If an implementation requires additional tiebreakers to disambiguate distinct native paths with identical generic decompositions, an implementation defined value; otherwise,</ins>
-</p>
-<p>
 &mdash; <tt>0</tt>.</p>
 </blockquote>
-<p>
-<ins>-?- [<i>Note:</i> For POSIX and Windows platforms, no additional tiebreakers are required &mdash; <i>end note</i>]</ins>
-</p>
 <p>
 <del>-2- <em>Remarks</em>: The elements are determined as if by iteration over the half-open range <tt>[begin(), end())</tt>
 for <tt>*this</tt> and <tt>p</tt>.</del>


### PR DESCRIPTION
LWG didn't feel the "depth first order" wording I supplied previously was sufficiently constraining or clear for implementations, so I'm supplying updated wording which makes the note in my previous wording normative.

I did a bad thing when I reported LWG 2936 and mixed two issues together. They are:

1. Path comparison uses the generic format -- which I believe becomes NAD after all of Davis' wordsmithing in this area in Kona and after feedback from z/OS folks.
2. Path comparison treats the root_directory directory_separator different than other directory_separators, which leads to bizarre behavior

This PR updates wording to resolve (2) but the issue is named after (1) which may be confusing.