### PR TITLE
Linkify standard section references

### DIFF
--- a/src/lists.cpp
+++ b/src/lists.cpp
@@ -351,14 +351,9 @@ void format_issue_as_html(lwg::issue & is,
                    //std::cout << "section_tag=\"" << tag.prefix << "\", \"" << tag.name << "\"\n";
                  }    
                }
- 
-               {
-                  std::ostringstream t;
-                  t << section_db[tag] << ' ';
-                  r.insert(0, t.str());
-               }
 
                j -= i - 1;
+               r = lwg::format_section_tag_as_link(section_db, tag);
                s.replace(i, j, r);
                i += r.size() - 1;
                continue;

--- a/src/report_generator.cpp
+++ b/src/report_generator.cpp
@@ -279,9 +279,9 @@ void print_issue(std::ostream & out, lwg::issue const & iss, lwg::section_map & 
 
          // Section, Status, Submitter, Date
          out << "<p><b>Section:</b> ";
-         out << section_db[iss.tags[0]] << " " << iss.tags[0];
+         out << lwg::format_section_tag_as_link(section_db, iss.tags[0]);
          for (unsigned k = 1; k < iss.tags.size(); ++k) {
-            out << ", " << section_db[iss.tags[k]] << " " << iss.tags[k];
+            out << ", " << lwg::format_section_tag_as_link(section_db, iss.tags[k]);
          }
 
          out << " <b>Status:</b> <a href=\"lwg-active.html#" << lwg::remove_qualifier(iss.stat) << "\">" << iss.stat << "</a>\n";

--- a/src/sections.cpp
+++ b/src/sections.cpp
@@ -193,3 +193,16 @@ auto lwg::read_section_db(std::istream & infile) -> section_map {
    return section_db;
 }
 
+auto lwg::format_section_tag_as_link(section_map & section_db, section_tag const & tag) -> std::string {
+   std::ostringstream o;
+   const auto& num = section_db[tag];
+   o << num << ' ';
+   if(num.num.empty() || num.num.front() == 99 || !tag.prefix.empty()) {
+      o << tag;
+   }
+   else {
+      o << "<a href=\"https://wg21.link/" << tag.name << "\">[" << tag.name << "]</a>";
+   }
+   return o.str();
+}
+

--- a/src/sections.h
+++ b/src/sections.h
@@ -48,6 +48,8 @@ auto read_section_db(std::istream & stream) -> section_map;
    // from the specified 'stream', and return it as a new
    // 'section_map' object.
 
+auto format_section_tag_as_link(section_map & section_db, section_tag const & tag) -> std::string;
+
 } // close namespace lwg
 
 


### PR DESCRIPTION
This renders standard section references in issue text and in the "Section:" header as links to `https://wg21.link/section.tag.here` when it is known to refer to a section in the C++ WP.