### PR TITLE
Make set_status insert a dated note for major status changes.

### DIFF
--- a/bin/build_pgms.bat
+++ b/bin/build_pgms.bat
@@ -1,7 +1,7 @@
 echo "Use -m32 switch to force 32-bit build"
-g++ %* -std=c++14 -DNDEBUG -O2 -o bin/lists.exe  src/date.cpp src/issues.cpp src/sections.cpp src/mailing_info.cpp src/report_generator.cpp src/lists.cpp
+g++ %* -std=c++14 -DNDEBUG -O2 -o bin/lists.exe  src/date.cpp src/issues.cpp src/status.cpp src/sections.cpp src/mailing_info.cpp src/report_generator.cpp src/lists.cpp
 g++ %* -std=c++14 -o bin/section_data.exe src/section_data.cpp
 g++ %* -std=c++14 -o bin/toc_diff.exe src/toc_diff.cpp
-g++ %* -std=c++14 -DNDEBUG -O2 -o bin/list_issues.exe src/date.cpp src/issues.cpp src/sections.cpp src/list_issues.cpp
+g++ %* -std=c++14 -DNDEBUG -O2 -o bin/list_issues.exe src/date.cpp src/issues.cpp src/status.cpp src/sections.cpp src/list_issues.cpp
 g++ %* -std=c++14 -DNDEBUG -O2 -o bin/set_status.exe  src/set_status.cpp
 

--- a/bin/build_pgms.bat
+++ b/bin/build_pgms.bat
@@ -3,5 +3,5 @@ g++ %* -std=c++14 -DNDEBUG -O2 -o bin/lists.exe  src/date.cpp src/issues.cpp src
 g++ %* -std=c++14 -o bin/section_data.exe src/section_data.cpp
 g++ %* -std=c++14 -o bin/toc_diff.exe src/toc_diff.cpp
 g++ %* -std=c++14 -DNDEBUG -O2 -o bin/list_issues.exe src/date.cpp src/issues.cpp src/status.cpp src/sections.cpp src/list_issues.cpp
-g++ %* -std=c++14 -DNDEBUG -O2 -o bin/set_status.exe  src/set_status.cpp
+g++ %* -std=c++14 -DNDEBUG -O2 -o bin/set_status.exe  src/set_status.cpp src/status.cpp
 

--- a/bin/build_pgms.sh
+++ b/bin/build_pgms.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 echo '"Use -m32 switch to force 32-bit build"'
-g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/lists src/date.cpp src/issues.cpp src/sections.cpp src/mailing_info.cpp src/report_generator.cpp src/lists.cpp
+g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/lists src/date.cpp src/issues.cpp src/status.cpp src/sections.cpp src/mailing_info.cpp src/report_generator.cpp src/lists.cpp
 g++ $* -std=c++14 -Wall -o bin/section_data src/section_data.cpp
 g++ $* -std=c++14 -Wall -o bin/toc_diff src/toc_diff.cpp
-g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/list_issues src/date.cpp src/issues.cpp src/sections.cpp src/list_issues.cpp
+g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/list_issues src/date.cpp src/issues.cpp src/status.cpp src/sections.cpp src/list_issues.cpp
 g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/set_status  src/set_status.cpp
 

--- a/bin/build_pgms.sh
+++ b/bin/build_pgms.sh
@@ -4,5 +4,5 @@ g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/lists src/date.cpp src/issues.cpp sr
 g++ $* -std=c++14 -Wall -o bin/section_data src/section_data.cpp
 g++ $* -std=c++14 -Wall -o bin/toc_diff src/toc_diff.cpp
 g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/list_issues src/date.cpp src/issues.cpp src/status.cpp src/sections.cpp src/list_issues.cpp
-g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/set_status  src/set_status.cpp
+g++ $* -std=c++14 -Wall -DNDEBUG -O2 -o bin/set_status  src/set_status.cpp src/status.cpp
 

--- a/src/issues.cpp
+++ b/src/issues.cpp
@@ -3,8 +3,8 @@
 #endif
 
 #include "issues.h"
-
 #include "sections.h"
+#include "status.h"
 
 #include <algorithm>
 #include <cassert>
@@ -21,10 +21,6 @@
 #include <sys/stat.h>  // plan to factor this dependency out
 
 namespace {
-static constexpr char const * LWG_ACTIVE {"lwg-active.html" };
-static constexpr char const * LWG_CLOSED {"lwg-closed.html" };
-static constexpr char const * LWG_DEFECTS{"lwg-defects.html"};
-
 // date utilites may factor out again
 auto parse_month(std::string const & m) -> gregorian::month {
    // This could be turned into an efficient map lookup with a suitable indexed container
@@ -73,87 +69,6 @@ auto report_date_file_last_modified(std::string const & filename) -> gregorian::
 }
 
 } // close unnamed namespace
-
-// functions to relate the status of an issue to its relevant published list document
-auto lwg::filename_for_status(std::string stat) -> std::string {
-   // Tentative issues are always active
-   if(0 == stat.find("Tentatively")) {
-      return LWG_ACTIVE;
-   }
-
-   stat = remove_qualifier(stat);
-   return (stat == "TC1")           ? LWG_DEFECTS
-        : (stat == "CD1")           ? LWG_DEFECTS
-        : (stat == "TS")            ? LWG_DEFECTS
-        : (stat == "C++11")         ? LWG_DEFECTS
-        : (stat == "C++14")         ? LWG_DEFECTS
-        : (stat == "C++17")         ? LWG_DEFECTS
-        : (stat == "C++20")         ? LWG_DEFECTS
-        : (stat == "WP")            ? LWG_DEFECTS
-        : (stat == "Resolved")      ? LWG_DEFECTS
-        : (stat == "DR")            ? LWG_DEFECTS
-        : (stat == "TRDec")         ? LWG_DEFECTS
-        : (stat == "Dup")           ? LWG_CLOSED
-        : (stat == "NAD")           ? LWG_CLOSED
-        : (stat == "NAD Future")    ? LWG_CLOSED
-        : (stat == "NAD Editorial") ? LWG_CLOSED
-        : (stat == "NAD Concepts")  ? LWG_CLOSED
-        : (stat == "NAD Arrays")    ? LWG_CLOSED
-        : (stat == "Voting")        ? LWG_ACTIVE
-        : (stat == "Immediate")     ? LWG_ACTIVE
-        : (stat == "Ready")         ? LWG_ACTIVE
-        : (stat == "Review")        ? LWG_ACTIVE
-        : (stat == "New")           ? LWG_ACTIVE
-        : (stat == "Open")          ? LWG_ACTIVE
-        : (stat == "EWG")           ? LWG_ACTIVE
-        : (stat == "LEWG")          ? LWG_ACTIVE
-        : (stat == "Core")          ? LWG_ACTIVE
-        : (stat == "SG1")           ? LWG_ACTIVE
-        : (stat == "Deferred")      ? LWG_ACTIVE
-        : throw std::runtime_error("unknown status " + stat);
-}
-
-auto lwg::is_active(std::string const & stat) -> bool {
-   return filename_for_status(stat) == LWG_ACTIVE;
-}
-
-auto lwg::is_active_not_ready(std::string const & stat) -> bool {
-   return is_active(stat)  and  stat != "Ready";
-}
-
-auto lwg::is_defect(std::string const & stat) -> bool {
-   return filename_for_status(stat) == LWG_DEFECTS;
-}
-
-auto lwg::is_closed(std::string const & stat) -> bool {
-   return filename_for_status(stat) == LWG_CLOSED;
-}
-
-auto lwg::is_tentative(std::string const & stat) -> bool {
-   // a more efficient implementation will use some variation of strcmp
-   return 0 == stat.find("Tentatively");
-}
-
-auto lwg::is_assigned_to_another_group(std::string const & stat) -> bool {
-   for( auto s : {"Core", "EWG", "LEWG", "SG1" }) { if(s == stat) return true; }
-   return false;
-}
-
-auto lwg::is_not_resolved(std::string const & stat) -> bool {
-   if (is_assigned_to_another_group(stat)) return true;
-   for( auto s : {"Deferred", "New", "Open", "Review"}) { if(s == stat) return true; }
-   return false;
-}
-
-auto lwg::is_votable(std::string stat) -> bool {
-   stat = remove_tentatively(stat);
-   for( auto s : {"Immediate", "Voting"}) { if(s == stat) return true; }
-   return false;
-}
-
-auto lwg::is_ready(std::string stat) -> bool {
-   return "Ready" == remove_tentatively(stat);
-}
 
 auto lwg::parse_issue_from_file(std::string tx, std::string const & filename,
   lwg::section_map & section_db) -> issue {
@@ -312,84 +227,4 @@ auto lwg::parse_issue_from_file(std::string tx, std::string const & filename,
 
    is.text = std::move(tx);
    return is;
-}
-
-// Functions to "normalize" a status string
-auto lwg::remove_pending(std::string stat) -> std::string {
-   using size_type = std::string::size_type;
-   if(0 == stat.find("Pending")) {
-      stat.erase(size_type{0}, size_type{8});
-   }
-   return stat;
-}
-
-auto lwg::remove_tentatively(std::string stat) -> std::string {
-   using size_type = std::string::size_type;
-   if(0 == stat.find("Tentatively")) {
-      stat.erase(size_type{0}, size_type{12});
-   }
-   return stat;
-}
-
-auto lwg::remove_qualifier(std::string const & stat) -> std::string {
-   return remove_tentatively(remove_pending(stat));
-}
-
-auto lwg::get_status_priority(std::string const & stat) noexcept -> std::ptrdiff_t {
-   static char const * const status_priority[] {
-      "Voting",
-      "Tentatively Voting",
-      "Immediate",
-      "Ready",
-      "Tentatively Ready",
-      "Tentatively NAD Editorial",
-      "Tentatively NAD Future",
-      "Tentatively NAD",
-      "Review",
-      "New",
-      "Open",
-      "LEWG",
-      "EWG",
-      "Core",
-      "SG1",
-      "Deferred",
-      "Tentatively Resolved",
-      "Pending DR",
-      "Pending WP",
-      "Pending Resolved",
-      "Pending NAD Future",
-      "Pending NAD Editorial",
-      "Pending NAD",
-      "NAD Future",
-      "DR",
-      "WP",
-      "C++20",
-      "C++17",
-      "C++14",
-      "C++11",
-      "CD1",
-      "TC1",
-      "Resolved",
-      "TRDec",
-      "NAD Editorial",
-      "NAD",
-      "Dup",
-      "NAD Concepts"
-   };
-
-
-#if !defined(DEBUG_SUPPORT)
-   static auto const first = std::begin(status_priority);
-   static auto const last  = std::end(status_priority);
-   return std::find_if( first, last, [&](char const * str){ return str == stat; } ) - first;
-#else
-   // Diagnose when unknown status strings are passed
-   static auto const first = std::begin(status_priority);
-   static auto const last  = std::end(status_priority);
-   auto const i = std::find_if( first, last, [&](char const * str){ return str == stat; } );
-   if(last == i) {
-      std::cout << "Unknown status: " << stat << std::endl;
-   }
-   return i - first;
-#endif
 }

--- a/src/issues.h
+++ b/src/issues.h
@@ -10,6 +10,7 @@
 // solution specific headers
 #include "date.h"
 #include "sections.h"
+#include "status.h"
 
 namespace lwg
 {
@@ -45,31 +46,6 @@ auto parse_issue_from_file(std::string file_contents, std::string const & filena
   // since been removed, replaced or merged.
   //
   // The filename is passed only to improve diagnostics.
-
-
-// status string utilities - should probably factor into yet another file.
-
-auto filename_for_status(std::string stat) -> std::string;
-
-auto get_status_priority(std::string const & stat) noexcept -> std::ptrdiff_t;
-
-// this predicate API should probably switch to 'std::experimental::string_view'
-auto is_active(std::string const & stat) -> bool;
-auto is_active_not_ready(std::string const & stat) -> bool;
-auto is_defect(std::string const & stat) -> bool;
-auto is_closed(std::string const & stat) -> bool;
-auto is_tentative(std::string const & stat) -> bool;
-auto is_not_resolved(std::string const & stat) -> bool;
-auto is_assigned_to_another_group(std::string const & stat) -> bool;
-auto is_votable(std::string stat) -> bool;
-auto is_ready(std::string stat) -> bool;
-
-// Functions to "normalize" a status string
-// Might profitable switch to 'experimental/string_view'
-auto remove_pending(std::string stat) -> std::string;
-auto remove_tentatively(std::string stat) -> std::string;
-auto remove_qualifier(std::string const & stat) -> std::string;
-
 
 } // close namespace lwg
 

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -1,0 +1,175 @@
+#ifdef _MSC_VER
+# define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#include "status.h"
+
+#include <string>
+#include <iostream>  // eases debugging
+#include <algorithm>
+
+namespace {
+static constexpr char const * LWG_ACTIVE {"lwg-active.html" };
+static constexpr char const * LWG_CLOSED {"lwg-closed.html" };
+static constexpr char const * LWG_DEFECTS{"lwg-defects.html"};
+}
+
+auto lwg::filename_for_status(std::string stat) -> std::string {
+   // Tentative issues are always active
+   if(0 == stat.find("Tentatively")) {
+      return LWG_ACTIVE;
+   }
+
+   stat = remove_qualifier(stat);
+   return (stat == "TC1")           ? LWG_DEFECTS
+        : (stat == "CD1")           ? LWG_DEFECTS
+        : (stat == "TS")            ? LWG_DEFECTS
+        : (stat == "C++11")         ? LWG_DEFECTS
+        : (stat == "C++14")         ? LWG_DEFECTS
+        : (stat == "C++17")         ? LWG_DEFECTS
+        : (stat == "C++20")         ? LWG_DEFECTS
+        : (stat == "WP")            ? LWG_DEFECTS
+        : (stat == "Resolved")      ? LWG_DEFECTS
+        : (stat == "DR")            ? LWG_DEFECTS
+        : (stat == "TRDec")         ? LWG_DEFECTS
+        : (stat == "Dup")           ? LWG_CLOSED
+        : (stat == "NAD")           ? LWG_CLOSED
+        : (stat == "NAD Future")    ? LWG_CLOSED
+        : (stat == "NAD Editorial") ? LWG_CLOSED
+        : (stat == "NAD Concepts")  ? LWG_CLOSED
+        : (stat == "NAD Arrays")    ? LWG_CLOSED
+        : (stat == "Voting")        ? LWG_ACTIVE
+        : (stat == "Immediate")     ? LWG_ACTIVE
+        : (stat == "Ready")         ? LWG_ACTIVE
+        : (stat == "Review")        ? LWG_ACTIVE
+        : (stat == "New")           ? LWG_ACTIVE
+        : (stat == "Open")          ? LWG_ACTIVE
+        : (stat == "EWG")           ? LWG_ACTIVE
+        : (stat == "LEWG")          ? LWG_ACTIVE
+        : (stat == "Core")          ? LWG_ACTIVE
+        : (stat == "SG1")           ? LWG_ACTIVE
+        : (stat == "Deferred")      ? LWG_ACTIVE
+        : throw std::runtime_error("unknown status " + stat);
+}
+
+auto lwg::is_active(std::string const & stat) -> bool {
+   return filename_for_status(stat) == LWG_ACTIVE;
+}
+
+auto lwg::is_active_not_ready(std::string const & stat) -> bool {
+   return is_active(stat)  and  stat != "Ready";
+}
+
+auto lwg::is_defect(std::string const & stat) -> bool {
+   return filename_for_status(stat) == LWG_DEFECTS;
+}
+
+auto lwg::is_closed(std::string const & stat) -> bool {
+   return filename_for_status(stat) == LWG_CLOSED;
+}
+
+auto lwg::is_tentative(std::string const & stat) -> bool {
+   // a more efficient implementation will use some variation of strcmp
+   return 0 == stat.find("Tentatively");
+}
+
+auto lwg::is_assigned_to_another_group(std::string const & stat) -> bool {
+   for( auto s : {"Core", "EWG", "LEWG", "SG1" }) { if(s == stat) return true; }
+   return false;
+}
+
+auto lwg::is_not_resolved(std::string const & stat) -> bool {
+   if (is_assigned_to_another_group(stat)) return true;
+   for( auto s : {"Deferred", "New", "Open", "Review"}) { if(s == stat) return true; }
+   return false;
+}
+
+auto lwg::is_votable(std::string stat) -> bool {
+   stat = remove_tentatively(stat);
+   for( auto s : {"Immediate", "Voting"}) { if(s == stat) return true; }
+   return false;
+}
+
+auto lwg::is_ready(std::string stat) -> bool {
+   return "Ready" == remove_tentatively(stat);
+}
+
+// Functions to "normalize" a status string
+auto lwg::remove_pending(std::string stat) -> std::string {
+   using size_type = std::string::size_type;
+   if(0 == stat.find("Pending")) {
+      stat.erase(size_type{0}, size_type{8});
+   }
+   return stat;
+}
+
+auto lwg::remove_tentatively(std::string stat) -> std::string {
+   using size_type = std::string::size_type;
+   if(0 == stat.find("Tentatively")) {
+      stat.erase(size_type{0}, size_type{12});
+   }
+   return stat;
+}
+
+auto lwg::remove_qualifier(std::string const & stat) -> std::string {
+   return remove_tentatively(remove_pending(stat));
+}
+
+auto lwg::get_status_priority(std::string const & stat) noexcept -> std::ptrdiff_t {
+   static char const * const status_priority[] {
+      "Voting",
+      "Tentatively Voting",
+      "Immediate",
+      "Ready",
+      "Tentatively Ready",
+      "Tentatively NAD Editorial",
+      "Tentatively NAD Future",
+      "Tentatively NAD",
+      "Review",
+      "New",
+      "Open",
+      "LEWG",
+      "EWG",
+      "Core",
+      "SG1",
+      "Deferred",
+      "Tentatively Resolved",
+      "Pending DR",
+      "Pending WP",
+      "Pending Resolved",
+      "Pending NAD Future",
+      "Pending NAD Editorial",
+      "Pending NAD",
+      "NAD Future",
+      "DR",
+      "WP",
+      "C++20",
+      "C++17",
+      "C++14",
+      "C++11",
+      "CD1",
+      "TC1",
+      "Resolved",
+      "TRDec",
+      "NAD Editorial",
+      "NAD",
+      "Dup",
+      "NAD Concepts"
+   };
+
+
+#if !defined(DEBUG_SUPPORT)
+   static auto const first = std::begin(status_priority);
+   static auto const last  = std::end(status_priority);
+   return std::find_if( first, last, [&](char const * str){ return str == stat; } ) - first;
+#else
+   // Diagnose when unknown status strings are passed
+   static auto const first = std::begin(status_priority);
+   static auto const last  = std::end(status_priority);
+   auto const i = std::find_if( first, last, [&](char const * str){ return str == stat; } );
+   if(last == i) {
+      std::cout << "Unknown status: " << stat << std::endl;
+   }
+   return i - first;
+#endif
+}

--- a/src/status.h
+++ b/src/status.h
@@ -1,0 +1,34 @@
+#ifndef INCLUDE_LWG_STATUS_H
+#define INCLUDE_LWG_STATUS_H
+
+// standard headers
+#include <string>
+#include <cstddef>
+
+namespace lwg
+{
+auto filename_for_status(std::string stat) -> std::string;
+
+auto get_status_priority(std::string const & stat) noexcept -> std::ptrdiff_t;
+
+// this predicate API should probably switch to 'std::experimental::string_view'
+auto is_active(std::string const & stat) -> bool;
+auto is_active_not_ready(std::string const & stat) -> bool;
+auto is_defect(std::string const & stat) -> bool;
+auto is_closed(std::string const & stat) -> bool;
+auto is_tentative(std::string const & stat) -> bool;
+auto is_not_resolved(std::string const & stat) -> bool;
+auto is_assigned_to_another_group(std::string const & stat) -> bool;
+auto is_votable(std::string stat) -> bool;
+auto is_ready(std::string stat) -> bool;
+
+// Functions to "normalize" a status string
+// Might profitable switch to 'experimental/string_view'
+auto remove_pending(std::string stat) -> std::string;
+auto remove_tentatively(std::string stat) -> std::string;
+auto remove_qualifier(std::string const & stat) -> std::string;
+
+
+} // close namespace lwg
+
+#endif // INCLUDE_LWG_STATUS_H


### PR DESCRIPTION
Where "major status changes" means those that cause the issue to be placed in a different primary list (e.g., Ready -> WP, Open -> NAD, etc.). This should make it easier to figure out when an issue is adopted... assuming that `set_status` is used to change the issue status instead of manual edits.

Incidentally, this also means that `set_status` will check that the new status is known to the system (because it needs to determine which file the new status maps to), which mitigates [this cautionary note in `how-to-docs.html`](https://github.com/cplusplus/LWG/blob/ab0d3b1b0fb960f399e75b54aca2607e06e93322/how-to-docs.html#L201).