### PR TITLE
New issue from Tim Song: "path::operator+=(single-character) misspecified"

### DIFF
--- a/xml/issue3055.xml
+++ b/xml/issue3055.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='utf-8' standalone='no'?>
+<!DOCTYPE issue SYSTEM "lwg-issue.dtd">
+
+<issue num="3055" status="New">
+<title><tt>path::operator+=(<i>single-character</i>)</tt> misspecified</title>
+<section><sref ref="[fs.path.concat]"/></section>
+<submitter>Tim Song</submitter>
+<date>24 Jan 2018</date>
+<priority>99</priority>
+
+<discussion>
+<p>
+<sref ref="[fs.path.concat]"/> uses the expression <tt>path(x).native()</tt> to specify the effects of
+concatenating a single character <tt>x</tt>. However, there is no <tt>path</tt> constructor taking a single character.
+</p>
+</discussion>
+
+<resolution>
+<p>This wording is relative to <a href="http://wg21.link/n4713">N4713</a>.</p>
+<ol>
+<li><p>Modify <sref ref="[fs.path.concat]"/> as indicated:</p>
+
+<blockquote>
+<pre>
+path&amp; operator+=(const path&amp; x);
+path&amp; operator+=(const string_type&amp; x);
+path&amp; operator+=(basic_string_view&lt;value_type&gt; x);
+path&amp; operator+=(const value_type* x);
+<del>path&amp; operator+=(value_type x);</del>
+template&lt;class Source&gt;
+  path&amp; operator+=(const Source&amp; x);
+<del>template&lt;class EcharT&gt;
+  path&amp; operator+=(EcharT x);</del>
+template&lt;class Source&gt;
+  path&amp; concat(const Source&amp; x);
+</pre>
+<blockquote>
+<p>
+-1- <i>Effects:</i> [&hellip;]
+<p/>
+-2- <i>Returns:</i> <tt>*this</tt>.
+</p>
+</blockquote>
+<pre>
+<ins>path&amp; operator+=(value_type x);
+template&lt;class EcharT&gt;
+  path&amp; operator+=(EcharT x);</ins>
+</pre>
+<blockquote>
+<p>
+<ins>-?- <i>Effects:</i> Equivalent to: <tt>return *this += path(&amp;x, &amp;x+1);</tt>.</ins>
+</p>
+</blockquote>
+</blockquote>
+</li>
+</ol>
+</resolution>
+
+</issue>


### PR DESCRIPTION
How can [fs.path.concat] not have an open issue? Heresy! 😄 