### PR TITLE
[3054] Tweak Casey's PR

### DIFF
--- a/xml/issue3054.xml
+++ b/xml/issue3054.xml
@@ -10,10 +10,10 @@
 
 <discussion>
 <p>
-I believe that <tt>uninitialized_copy</tt> is unable to meet its exception-safety guarantee in the 
+I believe that <tt>uninitialized_copy</tt> is unable to meet its exception-safety guarantee in the
 presence of throwing move constructors:
 <p/>
-<sref ref="[specialized.algorithms]"/>/1 has two statements of note for the specialized algorithms such 
+<sref ref="[specialized.algorithms]"/>/1 has two statements of note for the specialized algorithms such
 as <tt>uninitialized_copy</tt>:
 <p/>
 <ul>
@@ -21,38 +21,38 @@ as <tt>uninitialized_copy</tt>:
 <li><p>if an exception is thrown during the algorithm then there are no effects</p></li>
 </ul>
 <p/>
-Suppose we have an input iterator <tt>Iter</tt>. Then <tt>std::move_iterator&lt;Iter&gt;</tt> appears 
-to also be an input iterator. Notably, it still satisfies that <tt>(void)*a, *a</tt> is equivalent to 
-<tt>*a</tt> for move iterator <tt>a</tt> since the dereference only forms an rvalue reference, it 
-doesn't actually perform the move operation (<sref ref="[input.iterators]"/> Table 95 &mdash; "Input iterator requirements"). 
+Suppose we have an input iterator <tt>Iter</tt>. Then <tt>std::move_iterator&lt;Iter&gt;</tt> appears
+to also be an input iterator. Notably, it still satisfies that <tt>(void)*a, *a</tt> is equivalent to
+<tt>*a</tt> for move iterator <tt>a</tt> since the dereference only forms an rvalue reference, it
+doesn't actually perform the move operation (<sref ref="[input.iterators]"/> Table 95 &mdash; "Input iterator requirements").
 <p/>
-Suppose also that we have a type <tt>T</tt> whose move constructor can throw, a range of <tt>T</tt>'s 
-<tt>[t<sub>begin</sub>, t<sub>end</sub>)</tt>, and a pointer to an uninitialized buffer of <tt>T</tt>'s 
-<tt>buf</tt>. Then <tt>std::uninitialized_copy(std::make_move_iterator(t<sub>begin</sub>), 
-std::make_move_iterator(t<sub>end</sub>), buf)</tt> can't possibly satisfy the property that it has 
-no effects if one of the moves throws &mdash; we'll have a <tt>T</tt> left in a moved-from state with 
-no way of recovering.  
+Suppose also that we have a type <tt>T</tt> whose move constructor can throw, a range of <tt>T</tt>'s
+<tt>[t<sub>begin</sub>, t<sub>end</sub>)</tt>, and a pointer to an uninitialized buffer of <tt>T</tt>'s
+<tt>buf</tt>. Then <tt>std::uninitialized_copy(std::make_move_iterator(t<sub>begin</sub>),
+std::make_move_iterator(t<sub>end</sub>), buf)</tt> can't possibly satisfy the property that it has
+no effects if one of the moves throws &mdash; we'll have a <tt>T</tt> left in a moved-from state with
+no way of recovering.
 <p/>
 See <a href="https://wandbox.org/permlink/aYdtwlPckvXp59eJ">here</a> for an example in code.
 <p/>
-It seems like the correct specification for <tt>uninitialized_copy</tt> should be that if 
-<tt>InputIterator</tt>'s <tt>operator*</tt> returns an rvalue reference and 
-<tt>InputIterator::value_type</tt>'s move constructor is not marked <tt>noexcept</tt>, then 
-<tt>uninitialized_copy</tt> will leave the objects in the underlying range in a valid but 
+It seems like the correct specification for <tt>uninitialized_copy</tt> should be that if
+<tt>InputIterator</tt>'s <tt>operator*</tt> returns an rvalue reference and
+<tt>InputIterator::value_type</tt>'s move constructor is not marked <tt>noexcept</tt>, then
+<tt>uninitialized_copy</tt> will leave the objects in the underlying range in a valid but
 unspecified state.
 </p>
 
 <note>2018-01-24, Casey comments and provides wording</note>
 <p>
-This issue points out a particular hole in the "..if an exception is thrown in the following algorithms 
-there are no effects." wording for the "uninitialized" memory algorithms 
-(<sref ref="[specialized.algorithms]"/>/1) and suggests a PR to patch over said hole. The true problem 
-here is that "no effects" is not and never has been implementable. For example, "<tt>first != last</tt>" 
-may have observable effects that an implementation is required to somehow reverse if some later operation 
-throws an exception. 
+This issue points out a particular hole in the "..if an exception is thrown in the following algorithms
+there are no effects." wording for the "uninitialized" memory algorithms
+(<sref ref="[specialized.algorithms]"/>/1) and suggests a PR to patch over said hole. The true problem
+here is that "no effects" is not and never has been implementable. For example, "<tt>first != last</tt>"
+may have observable effects that an implementation is required to somehow reverse if some later operation
+throws an exception.
 <p/>
-Rather than finding problem case after problem case and applying individual patches, we should fix the 
-root cause. If we alter the problematic sentence from [specialized.algorithms]/1 we can fix the issue 
+Rather than finding problem case after problem case and applying individual patches, we should fix the
+root cause. If we alter the problematic sentence from [specialized.algorithms]/1 we can fix the issue
 once and for all and have implementable algorithms.
 </p>
 </discussion>
@@ -67,9 +67,9 @@ once and for all and have implementable algorithms.
 <p>
 -1- [&hellip;]
 <p/>
-Unless otherwise specified, if an exception is thrown in the following algorithms <ins>objects 
-constructed with placement <tt>new</tt> (<sref ref="[new.delete.placement]"/>) are destroyed 
-before allowing the exception to propagate</ins><del>there are no effects</del>.
+Unless otherwise specified, if an exception is thrown in the following algorithms <ins>objects
+constructed by a placement <i>new-expression<i> (<sref ref="[expr.new]"/>) are destroyed in an
+unspecified order before allowing the exception to propagate</ins><del>there are no effects</del>.
 </p>
 </blockquote>
 </li>
@@ -87,7 +87,7 @@ template&lt;class InputIterator, class ForwardIterator&gt;
 <p>
 [&hellip;]
 <p/>
-<del>-2- <i>Remarks:</i> If an exception is thrown, some objects in the range <tt>[first, last)</tt> 
+<del>-2- <i>Remarks:</i> If an exception is thrown, some objects in the range <tt>[first, last)</tt>
 are left in a valid but unspecified state.</del>
 </p>
 </blockquote>
@@ -100,7 +100,7 @@ template&lt;class InputIterator, class Size, class ForwardIterator&gt;
 <p>
 [&hellip;]
 <p/>
-<del>-4- <i>Remarks:</i> If an exception is thrown, some objects in the range <tt>[first, 
+<del>-4- <i>Remarks:</i> If an exception is thrown, some objects in the range <tt>[first,
 std::next(first, n))</tt> are left in a valid but unspecified state.</del>
 </p>
 </blockquote>


### PR DESCRIPTION
* Use the term of art "placement *new-expression*" from [expr.new]

* Make the destruction order *explicitly* unspecified

...and VS Code continues its war on trailing whitespace.