### PR TITLE
Fix introductory text in closed issues list

### DIFF
--- a/xml/lwg-issues.xml
+++ b/xml/lwg-issues.xml
@@ -157,10 +157,10 @@ ownership of it.
   <p>This document contains only library issues which have been closed
   by the Library Working Group as duplicates or not defects. That is,
   issues which have a status of <a href="lwg-active.html#Dup">Dup</a> or
-  <a href="lwg-active.html#NAD">NAD</a>. See the <a href="lwg-active.html">Library Active Issues List</a> active issues and more
-  information. See the <a href="lwg-defects.html">Library Defect Reports List</a> for issues considered
-  defects.  The introductory material in that document also applies to
-  this document.</p>
+  <a href="lwg-active.html#NAD">NAD</a>.
+  See the <a href="lwg-defects.html">Library Defect Reports List</a> for issues considered defects.
+  See the <a href="lwg-active.html">Library Active Issues List</a> for active issues and more information.
+  The introductory material in that document also applies to this document.</p>
 </intro>
 
 <intro list="TOC">


### PR DESCRIPTION
The sentence "The introductory material in that document ..." refers to
the active issues list, but comes after the sentence about the defects
list.