### PR TITLE
[3058] Cleanup wording around the issue.

### DIFF
--- a/xml/issue3058.xml
+++ b/xml/issue3058.xml
@@ -10,10 +10,10 @@
 
 <discussion>
 <p>
-Parallel <tt>adjacent_difference</tt> is presently specified to "create a temporary object whose 
-type is <tt>ForwardIterator1</tt>'s value type". Serial <tt>adjacent_difference</tt> does that 
-because it needs to work with input iterators, and needs to work when the destination range 
-exactly overlaps the input range. The parallel version requires forward iterators and doesn't 
+Parallel <tt>adjacent_difference</tt> is presently specified to "create a temporary object whose
+type is <tt>ForwardIterator1</tt>'s value type". Serial <tt>adjacent_difference</tt> does that
+because it needs to work with input iterators, and needs to work when the destination range
+exactly overlaps the input range. The parallel version requires forward iterators and doesn't
 allow overlap, so it can avoid making these temporaries.
 </p>
 </discussion>
@@ -33,7 +33,7 @@ template&lt;class ExecutionPolicy, class ForwardIterator1, class ForwardIterator
   ForwardIterator2
     adjacent_difference(ExecutionPolicy&amp;&amp; exec,
                         ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result);
-                        
+
 template&lt;class InputIterator, class OutputIterator, class BinaryOperation&gt;
   OutputIterator
     adjacent_difference(InputIterator first, InputIterator last,
@@ -47,28 +47,48 @@ template&lt;class ExecutionPolicy, class ForwardIterator1, class ForwardIterator
 </pre>
 <blockquote>
 <p>
+<ins>-?- Let <tt>T</tt> be the value type of <tt>decltype(first)</tt>. For the overloads that do not
+take an argument <tt>binary_op</tt>, let <tt>binary_op</tt> be an lvalue that denotes an object of
+type <tt>const minus&lt;&gt;</tt>.</ins>
+</p><p>
 -1- <i>Requires:</i>
 <ol style="list-style-type: none">
-<li><p>(1.1) &mdash; [&hellip;]</p></li>
-<li><p>(1.2) &mdash; For the overloads with an <tt>ExecutionPolicy</tt>, the <del>value type of 
-<tt>ForwardIterator1</tt> shall be <tt>CopyConstructible</tt> (Table 24), constructible from the 
-expression <tt>*first - *first</tt> or <tt>binary_op(*first, *first)</tt>, and assignable to 
-the value type of <tt>ForwardIterator2</tt></del><ins>result of the expressions <tt>*first - *first</tt> 
-(for the first overload) or <tt>binary_op(*first, *first)</tt> (for the second overload) and 
-<tt>*first</tt> shall be writable to <tt>result</tt></ins>.</p></li>
+<li><p>(1.1) &mdash; For the overloads with no <tt>ExecutionPolicy</tt>,
+<del><tt>InputIterator</tt>’s value type</del> <ins><tt>T</tt></ins> shall be
+<tt>MoveAssignable</tt> (Table 25) and shall be constructible from the type of <tt>*first</tt>.
+<tt>acc</tt> (defined below) shall be writable (<sref ref="[iterator.requirements.general]" />) to
+the <tt>result</tt> output iterator. The result of the expression <del><tt>val - std::move(acc)</tt>
+or</del> <tt>binary_op(val, std::move(acc))</tt> shall be writable to the <tt>result</tt> output
+iterator.</p></li>
+
+<li><p>(1.2) &mdash; For the overloads with an <tt>ExecutionPolicy</tt>, the <del>value type of
+<tt>ForwardIterator1</tt> shall be <tt>CopyConstructible</tt> (Table 24), constructible from the
+expression <tt>*first - *first</tt> or <tt>binary_op(*first, *first)</tt>, and assignable to the
+value type of <tt>ForwardIterator2</tt></del><ins>result of the expressions
+<tt>binary_op(*first, *first)</tt> and <tt>*first</tt> shall be writable to
+<tt>result</tt></ins>.</p></li>
+
 <li><p>(1.3) &mdash; [&hellip;]</p></li>
 </ol>
 <p/>
--2- <i>Effects:</i> [&hellip;]
+-2- <i>Effects:</i> For the overloads with no <tt>ExecutionPolicy</tt> and a non-empty range, the
+function creates an accumulator <tt>acc</tt> <del>whose type is <tt>InputIterator</tt>’s value
+type</del> <ins>of type <tt>T</tt></ins>, initializes it with <tt>*first</tt>, and assigns the
+result to <tt>*result</tt>. For every iterator <tt>i</tt> in <tt>[first + 1, last)</tt> in order,
+creates an object <tt>val</tt> whose type is <del><tt>InputIterator</tt>’s value type</del>
+<ins><tt>T</tt></ins>, initializes it with <tt>*i</tt>, computes <del><tt>val - std::move(acc)</tt>
+or</del> <tt>binary_op(val, std::move(acc))</tt>, assigns the result to
+<tt>*(result + (i - first))</tt>, and move assigns from <tt>val</tt> to <tt>acc</tt>.
 <p/>
--3- For the overloads with an <tt>ExecutionPolicy</tt> and a non-empty range, <del>first the function 
-creates an object whose type is <tt>ForwardIterator1</tt>'s value type, initializes it with <tt>*first</tt>, 
-and assigns the result to <tt>*result</tt>. Then for every <tt>d</tt> in <tt>[1, last - first - 1]</tt>, 
-creates an object <tt>val</tt> whose type is <tt>ForwardIterator1</tt>'s value type, initializes it 
-with <tt>*(first + d) - *(first + d - 1)</tt> or <tt>binary_op(*(first + d), *(first + d - 1))</tt>, 
-and assigns the result to <tt>*(result + d)</tt></del><ins>performs <tt>*result = *first</tt>. Then, 
-for every <tt>d</tt> in <tt>[1, last - first - 1]</tt>, performs <tt>*(result + d) = *(first + d) - 
-*(first + d - 1)</tt> or <tt>*(result + d) = binary_op(*(first + d), *(first + d - 1))</tt></ins>.
+-3- For the overloads with an <tt>ExecutionPolicy</tt> and a non-empty range, <del>first the function
+creates an object whose type is <tt>ForwardIterator1</tt>'s value type, initializes it with
+<tt>*first</tt>, and assigns the result to <tt>*result</tt>. Then for every <tt>d</tt> in
+<tt>[1, last - first - 1]</tt>, creates an object <tt>val</tt> whose type is
+<tt>ForwardIterator1</tt>'s value type, initializes it with <tt>*(first + d) - *(first + d - 1)</tt>
+or <tt>binary_op(*(first + d), *(first + d - 1))</tt>, and assigns the result to
+<tt>*(result + d)</tt></del><ins>performs <tt>*result = *first</tt>. Then, for every <tt>d</tt> in
+<tt>[1, last - first - 1]</tt>, performs <tt>*(result + d) = *(first + d) - *(first + d - 1)</tt>
+or <tt>*(result + d) = binary_op(*(first + d), *(first + d - 1))</tt></ins>.
 </p>
 </blockquote>
 </blockquote>


### PR DESCRIPTION
This PR simplifies the `adjacent_difference` wording by:

1. Defining `binary_op` for the overloads that don't accept `binary_op` so the wording need not have two cases everywhere "`foo - bar` or `binary_op(foo, bar)`"

2. Defining `T` to be the value type of either `InputIterator` or `ForwardIterator1` again for consistency, and simply to shorten the description of the effects.
