### PR TITLE
Improvements for sref parsing

### DIFF
--- a/src/sections.cpp
+++ b/src/sections.cpp
@@ -139,7 +139,7 @@ auto lwg::read_section_db(std::istream & infile) -> section_map {
       std::string line;
       getline(infile, line);
       if (!line.empty()) {
-         // get [x.x....] symbolic tag 
+         // get [x.x....] symbolic tag
          assert(line.back() == ']');
          auto p = line.rfind('[');
          assert(p != std::string::npos);
@@ -193,7 +193,7 @@ auto lwg::read_section_db(std::istream & infile) -> section_map {
    return section_db;
 }
 
-auto lwg::format_section_tag_as_link(section_map & section_db, section_tag const & tag) -> std::string {
+auto lwg::format_section_tag_as_link(section_map & section_db, section_tag const & tag, int para) -> std::string {
    std::ostringstream o;
    const auto& num = section_db[tag];
    o << num << ' ';
@@ -201,8 +201,15 @@ auto lwg::format_section_tag_as_link(section_map & section_db, section_tag const
       o << tag;
    }
    else {
-      o << "<a href=\"https://wg21.link/" << tag.name << "\">[" << tag.name << "]</a>";
+      o << "<a href=\"https://wg21.link/" << tag.name;
+      if (para > 0) {
+         o << '#' << para;
+      }
+      o << "\">[" << tag.name << ']';
+      if (para > 0) {
+         o << '/' << para;
+      }
+      o << "</a>";
    }
    return o.str();
 }
-

--- a/src/sections.h
+++ b/src/sections.h
@@ -11,12 +11,12 @@ namespace lwg
 
 struct section_tag
 {
-  std::string  prefix;        // example: fund.ts.v2 
+  std::string  prefix;        // example: fund.ts.v2
   std::string  name;          // example: meta.logical
 };
 
 struct section_num {
-  std::string       prefix;    // example: fund.ts.v2 
+  std::string       prefix;    // example: fund.ts.v2
   std::vector<int>  num;       // sequence of numbers corresponding to section number
                                // in relevant doc, e.g,, 17.5.2.1.4.2
 };
@@ -48,7 +48,8 @@ auto read_section_db(std::istream & stream) -> section_map;
    // from the specified 'stream', and return it as a new
    // 'section_map' object.
 
-auto format_section_tag_as_link(section_map & section_db, section_tag const & tag) -> std::string;
+auto format_section_tag_as_link(section_map & section_db,
+  section_tag const & tag, int para = 0) -> std::string;
 
 } // close namespace lwg
 


### PR DESCRIPTION
* Add optional trailing paragraph numbers, separated from the stable name by `/`. Paragraph numbers are displayed, and used in the wg21.link anchors to link directly to paragraphs.
* Make the leading `[` and trailing `]` optional around stable names.

Validated that the only differences in the generated files before and after are fixed links for `sref`s that were omitting the brackets.