### PR TITLE
Issue228: Remove broken sref

### DIFF
--- a/xml/issue0228.xml
+++ b/xml/issue0228.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
-<!DOCTYPE issue SYSTEM "lwg-issue.dtd" [ 
+<!DOCTYPE issue SYSTEM "lwg-issue.dtd" [
   <!ENTITY nbsp "&#160;">
 ] >
 
@@ -11,7 +11,9 @@
 
 <discussion>
 <p>The sections <sref ref="[locale.ctype.byname]"/>, <sref ref="[locale.codecvt.byname]"/>,
-sref ref="22.2.1.6", <sref ref="[locale.numpunct.byname]"/>, <sref ref="[locale.collate.byname]"/>, <sref ref="[locale.time.put.byname]"/>, <sref ref="[locale.moneypunct.byname]"/>, and <sref ref="[locale.messages.byname]"/> overspecify the
+<sref ref="[locale.numpunct.byname]"/>, <sref ref="[locale.collate.byname]"/>,
+<sref ref="[locale.time.put.byname]"/>, <sref ref="[locale.moneypunct.byname]"/>,
+and <sref ref="[locale.messages.byname]"/> overspecify the
 definitions of the &quot;..._byname&quot; classes by listing a bunch
 of virtual functions. At the same time, no semantics of these
 functions are defined. Real implementations do not define these


### PR DESCRIPTION
The section number "22.2.1.6" is [lib.locale.codecvt.byname] in C++98, which is already referenced properly by another `sref`. Also wrap overlong lines since I'm here.