### PR TITLE
2116: Fix typo

### DIFF
--- a/xml/issue2116.xml
+++ b/xml/issue2116.xml
@@ -27,10 +27,10 @@ the constraints  in the library because you did not need to add
 <tt>Destructible</tt> all the time. It often was implied but never spoken out
 in C++03.
 <p/>
-Pure construction semantics was considered as useful as well, so <tt>HasConstructor</tt> 
+Pure construction semantics was considered as useful as well, so <tt>HasConstructor</tt>
 did also exist and would surely be useful as trait as well.
 <p/>
-Another example that is often overlooked: This also affects wrapper types like <tt>pair</tt>, 
+Another example that is often overlooked: This also affects wrapper types like <tt>pair</tt>,
 <tt>tuple</tt>, <tt>array</tt> that contain potentially more than one type:
 This is easy to understand if you think of <tt>T1</tt> having a deleted destructor
 and <tt>T2</tt> having a constructor that may throw: Obviously the compiler has
@@ -41,7 +41,7 @@ are satisfied (All previous fully constructed sub-objects must be destructed).
 The core language also honors this fact in <sref ref="[class.copy]"/> p11:
 </p>
 <blockquote><p>
-A defaulted copy&#47;move constructor for a class <tt>X</tt> is defined as deleted (<sref ref="[dcl.fct.def.delete]"/>) 
+A defaulted copy&#47;move constructor for a class <tt>X</tt> is defined as deleted (<sref ref="[dcl.fct.def.delete]"/>)
 if <tt>X</tt> has:<br/>
 [&hellip;]<br/>
 &mdash; any direct or virtual base class or non-static data member of a type with a destructor that is deleted
@@ -50,7 +50,7 @@ or inaccessible from the defaulted constructor,<br/>
 </p></blockquote>
 <p>
 Dave:<br/>
-This is about <tt>is_nothrow_constructible</tt> in particular. The fact that it is 
+This is about <tt>is_nothrow_constructible</tt> in particular. The fact that it is
 foiled by not having a <tt>noexcept</tt> dtor is a defect.
 </p>
 
@@ -80,7 +80,7 @@ does not throw. (Remembering the title of this issue... What does this imply for
 If we accept this resolution, do we need any changes to <tt>swap</tt>?
 </p>
 <p> STL argues: no, because you are already forbidden from passing anything with a throwing
-desturctor to <tt>swap</tt>.
+destructor to <tt>swap</tt>.
 </p>
 <p>
 Dietmar argues: no, not true. Maybe statically the destructor can conceivably throw for some


### PR DESCRIPTION
STL has verified for me that he did not in fact use the non-word "desturctor" in discussion of this issue in Kona in 2012.