### PR TITLE
Travis CI: meta-updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-sudo: false
+dist: xenial
 language: cpp
 os: linux
 
@@ -21,11 +20,11 @@ matrix:
         apt:
           packages:
             - clang++-5.0
-            - g++-6
+            - libstdc++-6-dev
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty
-            - llvm-toolchain-trusty-5.0
+            - llvm-toolchain-xenial
+            - llvm-toolchain-xenial-5.0
 
 script:
   - |


### PR DESCRIPTION
* The clang config only needs libstdc++, not all of g++

* Remove `sudo: false` per announcement that Travis is killing their
container-based CI: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

* Update distribution to Xenial while I'm here.