### PR TITLE
Retitle "Defect Report List" as "Defect Reports and Accepted Issues"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 /bin/set_status.exe
 /bin/set_status
 /mailing
+/.vscode
 .DS_Store
 R*-mailing.zip

--- a/src/report_generator.cpp
+++ b/src/report_generator.cpp
@@ -60,7 +60,7 @@ struct order_by_first_tag {
 };
 
 struct order_by_major_section {
-   explicit order_by_major_section(lwg::section_map & sections) 
+   explicit order_by_major_section(lwg::section_map & sections)
       : section_db(sections)
       {
       }
@@ -78,7 +78,7 @@ private:
 };
 
 struct order_by_section {
-   explicit order_by_section(lwg::section_map &sections) 
+   explicit order_by_section(lwg::section_map &sections)
       : section_db(sections)
       {
       }
@@ -101,7 +101,7 @@ struct order_by_status {
 
 
 struct order_by_priority {
-   explicit order_by_priority(lwg::section_map &sections) 
+   explicit order_by_priority(lwg::section_map &sections)
       : section_db(sections)
       {
       }
@@ -409,7 +409,7 @@ R"(<table>
       out << "C++ Standard Library Active Issues List (Revision ";
    }
    else if (paper == "defect") {
-      out << "C++ Standard Library Defect Report List (Revision ";
+      out << "C++ Standard Library Defect Reports and Accepted Issues (Revision ";
    }
    else if (paper == "closed") {
       out << "C++ Standard Library Closed Issues List (Revision ";
@@ -458,11 +458,11 @@ void report_generator::make_defect(std::vector<issue> const & issues, std::strin
    std::ofstream out(filename.c_str());
    if (!out)
      throw std::runtime_error{"Failed to open " + filename};
-   print_file_header(out, "C++ Standard Library Defect Report List");
+   print_file_header(out, "C++ Standard Library Defect Reports and Accepted Issues");
    print_paper_heading(out, "defect", lwg_issues_xml);
    out << lwg_issues_xml.get_intro("defect") << '\n';
    out << "<h2>Revision History</h2>\n" << lwg_issues_xml.get_revisions(issues, diff_report) << '\n';
-   out << "<h2>Defect Reports</h2>\n";
+   out << "<h2>Accepted Issues</h2>\n";
    print_issues(out, issues, section_db, [](issue const & i) {return is_defect(i.stat);} );
    print_file_trailer(out);
 }
@@ -550,7 +550,7 @@ out << R"(<h1>C++ Standard Library Issues Resolved Directly In [INSERT CURRENT M
 </tr>
 <tr>
 <td align="left">Reply to:</td>
-<td align="left">)" << maintainer_name << R"( &lt;<a href="mailto:)" << maintainer_email << R"(">)" 
+<td align="left">)" << maintainer_name << R"( &lt;<a href="mailto:)" << maintainer_email << R"(">)"
                                                                      << maintainer_email << R"(</a>&gt;</td>
 </tr>
 </table>
@@ -585,7 +585,7 @@ out << R"(<h1>C++ Standard Library Issues to be moved in [INSERT CURRENT MEETING
 </tr>
 <tr>
 <td align="left">Reply to:</td>
-<td align="left">)" << maintainer_name << R"( &lt;<a href="mailto:)" << maintainer_email << R"(">)" 
+<td align="left">)" << maintainer_name << R"( &lt;<a href="mailto:)" << maintainer_email << R"(">)"
                                                                      << maintainer_email << R"(</a>&gt;</td>
 </tr>
 </table>
@@ -623,7 +623,7 @@ R"(<h1>C++ Standard Library Issues List (Revision )" << lwg_issues_xml.get_revis
 <h1>Table of Contents</h1>
 <p>Reference ISO/IEC IS 14882:2011(E)</p>
 <p>This document is the Table of Contents for the <a href="lwg-active.html">Library Active Issues List</a>,
-<a href="lwg-defects.html">Library Defect Reports List</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
+<a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
 )";
    out << "<p>" << build_timestamp << "</p>";
 
@@ -645,7 +645,7 @@ R"(<h1>C++ Standard Library Issues List (Revision )" << lwg_issues_xml.get_revis
 <h1>Table of Contents</h1>
 <p>Reference ISO/IEC IS 14882:2011(E)</p>
 <p>This document is the Table of Contents for the <a href="lwg-active.html">Library Active Issues List</a>,
-<a href="lwg-defects.html">Library Defect Reports List</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
+<a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
 )";
    out << "<p>" << build_timestamp << "</p>";
 
@@ -687,7 +687,7 @@ R"(<h1>C++ Standard Library Issues List (Revision )" << lwg_issues_xml.get_revis
 <p>Reference ISO/IEC IS 14882:2011(E)</p>
 <p>
 This document is the Index by Status and Section for the <a href="lwg-active.html">Library Active Issues List</a>,
-<a href="lwg-defects.html">Library Defect Reports List</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.
+<a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.
 </p>
 
 )";
@@ -722,7 +722,7 @@ R"(<h1>C++ Standard Library Issues List (Revision )" << lwg_issues_xml.get_revis
 <p>Reference ISO/IEC IS 14882:2011(E)</p>
 <p>
 This document is the Index by Status and Date for the <a href="lwg-active.html">Library Active Issues List</a>,
-<a href="lwg-defects.html">Library Defect Reports List</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.
+<a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.
 </p>
 )";
    out << "<p>" << build_timestamp << "</p>";
@@ -771,7 +771,7 @@ void report_generator::make_sort_by_section(std::vector<issue>& issues, std::str
    out << "<p>Reference ISO/IEC IS 14882:2011(E)</p>\n";
    out << "<p>This document is the Index by Section for the <a href=\"lwg-active.html\">Library Active Issues List</a>";
    if(!active_only) {
-      out << ", <a href=\"lwg-defects.html\">Library Defect Reports List</a>, and <a href=\"lwg-closed.html\">Library Closed Issues List</a>";
+      out << ", <a href=\"lwg-defects.html\">Library Defect Reports and Accepted Issues</a>, and <a href=\"lwg-closed.html\">Library Closed Issues List</a>";
    }
    out << ".</p>\n";
    out << "<h2>Index by Section";
@@ -839,4 +839,3 @@ void report_generator::make_individual_issues(std::vector<issue> const & issues,
    }
 }
 } // close namespace lwg
-

--- a/xml/lwg-issues.xml
+++ b/xml/lwg-issues.xml
@@ -15,7 +15,7 @@
       <li><a href="lwg-toc.html">Table of Contents</a> for all library issues.</li>
       <li><a href="lwg-index.html">Index by Section</a> for all library issues.</li>
       <li><a href="lwg-status.html">Index by Status</a> for all library issues.</li>
-      <li><a href="lwg-defects.html">Library Defect Reports List</a></li>
+      <li><a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a></li>
       <li><a href="lwg-closed.html">Library Closed Issues List</a></li>
   </ul>
   <p>The purpose of this document is to record the status of issues
@@ -28,7 +28,7 @@
   considered by the Library Working Group, i.e., issues which have a
   status of <a href="lwg-active.html#New">New</a>, <a href="lwg-active.html#Open">Open</a>,
   <a href="lwg-active.html#Ready">Ready</a>, or <a href="lwg-active.html#Review">Review</a>.
-  See <a href="lwg-defects.html">Library Defect Reports List</a> for issues considered defects
+  See <a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a> for issues considered defects
   and <a href="lwg-closed.html">Library Closed Issues List</a> for issues considered closed.</p>
 
   <p>The issues in these lists are not necessarily formal ISO Defect
@@ -136,7 +136,7 @@ ownership of it.
   by the Library Working Group (LWG) after being found to be defects
   in the standard.  That is, issues which have a status of <a href="lwg-active.html#DR">DR</a>,
   <a href="lwg-active.html#TC1">TC1</a>, <a href="lwg-active.html#C++11">C++11</a>,
-  <a href="lwg-active.html#C++14">C++14</a>, <a href="lwg-active.html#C++17">C++17</a>, 
+  <a href="lwg-active.html#C++14">C++14</a>, <a href="lwg-active.html#C++17">C++17</a>,
   or <a href="lwg-active.html#Resolved">Resolved</a>. See
   the <a href="lwg-closed.html">Library Closed Issues List</a> for issues closed as non-defects.  See
   the <a href="lwg-active.html">Library Active Issues List</a> for active issues and more information.
@@ -151,14 +151,14 @@ ownership of it.
       <li><a href="lwg-index.html">Index by Section</a> for all library issues.</li>
       <li><a href="lwg-status.html">Index by Status</a> for all library issues.</li>
       <li><a href="lwg-active.html">Library Active Issues List</a></li>
-      <li><a href="lwg-defects.html">Library Defect Reports List</a></li>
+      <li><a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a></li>
     </ul>
 
   <p>This document contains only library issues which have been closed
   by the Library Working Group as duplicates or not defects. That is,
   issues which have a status of <a href="lwg-active.html#Dup">Dup</a> or
   <a href="lwg-active.html#NAD">NAD</a>.
-  See the <a href="lwg-defects.html">Library Defect Reports List</a> for issues considered defects.
+  See the <a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a> for issues considered defects.
   See the <a href="lwg-active.html">Library Active Issues List</a> for active issues and more information.
   The introductory material in that document also applies to this document.</p>
 </intro>
@@ -167,7 +167,7 @@ ownership of it.
   <p>Reference ISO/IEC IS 14882:2014(E)</p>
 
   <p>This document is the Table of Contents for the <a href="lwg-active.html">Library Active Issues List</a>,
-  <a href="lwg-defects.html">Library Defect Reports List</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
+  <a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
 
   <p>Also see:</p>
     <ul>
@@ -180,7 +180,7 @@ ownership of it.
   <p>Reference ISO/IEC IS 14882:2014(E)</p>
 
   <p>This document is the Index by Section for the <a href="lwg-active.html">Library Active Issues List</a>,
-  <a href="lwg-defects.html">Library Defect Reports List</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
+  <a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
 
   <p>Also see:</p>
     <ul>
@@ -193,7 +193,7 @@ ownership of it.
   <p>Reference ISO/IEC IS 14882:2014(E)</p>
 
   <p>This document is the Index by Status for the <a href="lwg-active.html">Library Active Issues List</a>,
-  <a href="lwg-defects.html">Library Defect Reports List</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
+  <a href="lwg-defects.html">Library Defect Reports and Accepted Issues</a>, and <a href="lwg-closed.html">Library Closed Issues List</a>.</p>
 
   <p>Also see:</p>
     <ul>


### PR DESCRIPTION
... to avoid confusion since not all issues on this list have status DR. This is consistent with the titling of Core's similar list.

Drive-by:
* Tell git to ignore VS Code's byproducts
* Continue the war on trailing whitespace and trailing empty lines