### PR TITLE
3283: Remove std:: occurrences from P/R

### DIFF
--- a/xml/issue3283.xml
+++ b/xml/issue3283.xml
@@ -58,8 +58,8 @@ This fix has been implemented in range-v3.
 <li><p>(3.3) &mdash; Otherwise, if <tt>I</tt> satisfies the exposition-only concept 
 <tt><i>cpp17-iterator</i></tt> <ins>and either</ins></p>
 <ol style="list-style-type:lower-alpha">
-<li><p><ins><tt>I::iterator_category</tt> is valid and denotes <tt>std::output_iterator_tag</tt> or a 
-type publicly and unambiguously derived from <tt>std::output_iterator_tag</tt>, or</ins></p></li>
+<li><p><ins><tt>I::iterator_category</tt> is valid and denotes <tt>output_iterator_tag</tt> or a 
+type publicly and unambiguously derived from <tt>output_iterator_tag</tt>, or</ins></p></li>
 <li><p><ins>there is no type <tt>I::iterator_category</tt></ins></p></li>
 </ol> 
 <p>then <tt>iterator_traits&lt;I&gt;</tt> has the following publicly accessible members:</p></li>


### PR DESCRIPTION
We conventionally only `std::`-qualify `move` and `forward`.