### PR TITLE
3141: oops - bad markup

### DIFF
--- a/xml/issue3141.xml
+++ b/xml/issue3141.xml
@@ -77,7 +77,7 @@ template&lt;class T&gt;
 <tt>T</tt> or an rvalue of type <tt>const T</tt>. <tt>T</tt> models <tt>copy_constructible</tt> only if
 </p><p>
 (1.1) &mdash; After the definition <tt>T u = v;</tt>, <tt>u</tt> is equal to <tt>v</tt> <ins>(<sref ref="[concepts.equality]"/>) and
-<tt>v</tt> is <ins>not modified</ins><del>unmodified</del></ins>.
+<tt>v</tt> is not modified</ins>.
 </p><p>
 (1.2) &mdash; <tt>T(v)</tt> is equal to <tt>v</tt> <ins>and does not modify <tt>v</tt></ins>.
 </p>


### PR DESCRIPTION
I marked up "unmodified" => "not modified", despite that the latter was already an addition.