### PR TITLE
3161: Correct copy pasta in new P/R

### DIFF
--- a/xml/issue3161.xml
+++ b/xml/issue3161.xml
@@ -105,7 +105,7 @@ template&lt;class... Args&gt;
 template&lt;class... Args&gt;
   decltype(auto) emplace(Args&amp;&amp;... args) {
     <ins>if constexpr (requires { c.emplace_back(std::forward&lt;Args&gt;(args)...); }) {</ins>
-      return c.emplace<del>_back</del>(<ins>c.end(), </ins>std::forward&lt;Args&gt;(args)...);
+      return c.emplace_back(std::forward&lt;Args&gt;(args)...);
     <ins>} else {</ins>
       <ins>return c.emplace(c.end(), std::forward&lt;Args&gt;(args)...);</ins>
     <ins>}</ins>


### PR DESCRIPTION
I failed to remove the old change markup from one line copied from the prior P/R.