### PR TITLE
3446: Casey provides updated wording per reflector discussion

### DIFF
--- a/xml/issue3446.xml
+++ b/xml/issue3446.xml
@@ -10,18 +10,18 @@
 
 <discussion>
 <p>
-Per <sref ref="[readable.traits]"/>, <tt>indirectly_readable_traits&lt;T&gt;::value_type</tt> is the same type as 
-<tt>remove_cv_t&lt;T::value_type&gt;</tt> if it denotes an object type, or <tt>remove_cv_t&lt;T::element_type&gt;</tt> 
-if it denotes an object type. If both <tt>T::value_type</tt> and <tt>T::element_type</tt> denote types,  
-<tt>indirectly_readable_traits&lt;T&gt;::value_type</tt> is ill-formed. This was perhaps not the best design, 
-given that there are iterators in the wild (Boost's unordered containers) that define both nested types. 
+Per <sref ref="[readable.traits]"/>, <tt>indirectly_readable_traits&lt;T&gt;::value_type</tt> is the same type as
+<tt>remove_cv_t&lt;T::value_type&gt;</tt> if it denotes an object type, or <tt>remove_cv_t&lt;T::element_type&gt;</tt>
+if it denotes an object type. If both <tt>T::value_type</tt> and <tt>T::element_type</tt> denote types,
+<tt>indirectly_readable_traits&lt;T&gt;::value_type</tt> is ill-formed. This was perhaps not the best design,
+given that there are iterators in the wild (Boost's unordered containers) that define both nested types.
 <tt>indirectly_readable_traits</tt> should tolerate iterators that define both nested types consistently.
 </p>
 
 <note>2020-07-17; Priority set to 2 in telecon</note>
-</discussion>
 
-<resolution>
+<strong>Previous resolution [SUPERSEDED]:</strong>
+<blockquote class="note">
 <p>This wording is relative to <a href="https://wg21.link/n4861">N4861</a>.</p>
 
 <ol>
@@ -46,12 +46,12 @@ template&lt;class T&gt;
   requires requires { typename T::value_type; }
 struct indirectly_readable_traits&lt;T&gt;
   : <i>cond-value-type</i>&lt;typename T::value_type&gt; { };
-  
+
 template&lt;class T&gt;
   requires requires { typename T::element_type; }
 struct indirectly_readable_traits&lt;T&gt;
   : <i>cond-value-type</i>&lt;typename T::element_type&gt; { };
-  
+
 <ins>template&lt;class T&gt;</ins>
   <ins>requires requires {</ins>
     <ins>typename T::element_type;</ins>
@@ -62,7 +62,62 @@ struct indirectly_readable_traits&lt;T&gt;
   <ins>}</ins>
 <ins>struct indirectly_readable_traits&lt;T&gt;</ins>
   <ins>: <i>cond-value-type</i>&lt;typename T::value_type&gt; { };</ins>
-  
+
+[&hellip;]
+</pre>
+</blockquote>
+</li>
+
+</ol>
+</blockquote>
+
+<note>2020-07-23; Casey improves wording per reflector discussion</note>
+
+</discussion>
+
+<resolution>
+<p>This wording is relative to <a href="https://wg21.link/n4861">N4861</a>.</p>
+
+<ol>
+<li><p>Modify <sref ref="[readable.traits]"/> as indicated:</p>
+
+<blockquote>
+<pre>
+[&hellip;]
+template&lt;class&gt; struct <i>cond-value-type</i> { }; <i>// exposition only</i>
+
+template&lt;class T&gt;
+  requires is_object_v&lt;T&gt;
+struct <i>cond-value-type</i>&lt;T&gt; {
+  using value_type = remove_cv_t&lt;T&gt;;
+};
+
+<ins>template&lt;class T&gt;</ins>
+<ins>concept <i>has-member-value-type</i> = requires { typename T::value_type; }; <i>// exposition only</i></ins>
+
+<ins>template&lt;class T&gt;</ins>
+<ins>concept <i>has-member-element-type</i> = requires { typename T::element_type; }; <i>// exposition only</i></ins>
+
+template&lt;class&gt; struct indirectly_readable_traits { };
+
+[&hellip;]
+
+template&lt;<del>class</del><ins><i>has-member-value-type</i></ins> T&gt;
+  <del>requires requires { typename T::value_type; }</del>
+struct indirectly_readable_traits&lt;T&gt;
+  : <i>cond-value-type</i>&lt;typename T::value_type&gt; { };
+
+template&lt;<del>class</del><ins><i>has-member-element-type</i></ins> T&gt;
+  <del>requires requires { typename T::element_type; }</del>
+struct indirectly_readable_traits&lt;T&gt;
+  : <i>cond-value-type</i>&lt;typename T::element_type&gt; { };
+
+<ins>template&lt;<del>class</del><ins><i>has-member-value-type</i></ins> T&gt;</ins>
+  <ins>requires <i>has-member-element-type</i>&lt;T&gt; &amp;&amp;</ins>
+           <ins>same_as&lt;remove_cv_t&lt;typename T::element_type&gt;, remove_cv_t&lt;typename T::value_type&gt;&gt;</ins>
+<ins>struct indirectly_readable_traits&lt;T&gt;</ins>
+  <ins>: <i>cond-value-type</i>&lt;typename T::value_type&gt; { };</ins>
+
 [&hellip;]
 </pre>
 </blockquote>


### PR DESCRIPTION
I chose to define exposition-only concepts. It's a bit wordier than the `!requires { typename the_other_thing; }` formulation, but I think more readable.

Rendered screenshot:
![image](https://user-images.githubusercontent.com/456873/88323074-808ccc00-ccd6-11ea-85b1-e9747ed858d0.png)
