### PR TITLE
Add dark mode CSS, driven by prefers-color-scheme

### DIFF
--- a/src/report_generator.cpp
+++ b/src/report_generator.cpp
@@ -175,6 +175,28 @@ R"(<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
   ins {background-color:#A0FFA0}
   del {background-color:#FFA0A0}
   table {border-collapse: collapse;}
+  @media (prefers-color-scheme: dark) {
+     html {
+        color: #ddd;
+        background-color: black;
+     }
+     ins {
+        background-color: #225522
+     }
+     del {
+        background-color: #662222
+     }
+     a {
+        color: #6af
+     }
+     a:visited {
+        color: #6af
+     }
+     blockquote.note
+     {
+        background-color: rgba(255, 255, 255, .10)
+     }
+  }
 </style>
 </head>
 <body>


### PR DESCRIPTION
In my browser (which is set to dark mode), [this](https://timsong-cpp.github.io/lwg-issues/3474) renders like

![image](https://user-images.githubusercontent.com/10905931/99891680-368b0700-2c32-11eb-999a-111664247d00.png)

