### PR TITLE
3508: Correct thinko in discussion

### DIFF
--- a/xml/issue3508.xml
+++ b/xml/issue3508.xml
@@ -10,7 +10,7 @@
 
 <discussion>
 <p>
-<tt>atomic_ref&lt;T&gt;</tt> requires only that its template parameter <tt>T</tt> is trivially copyable, 
+<tt>atomic_ref&lt;T&gt;</tt> requires only that its template parameter <tt>T</tt> is trivially copyable,
 which is not sufficient to implement many of the class template's member functions. Consider, for example:
 </p>
 <blockquote><pre>
@@ -22,19 +22,19 @@ int main() {
 }
 </pre></blockquote>
 <p>
-Since <tt>const int</tt> is trivially copyable, this is a well-formed C++20 program that returns <tt>0</tt>. 
-That said, the <tt>store</tt> call that mutates the value of a constant object is (a) not implementable with 
-library technology, and (b) pure madness that violates the language semantics. <tt>atomic_ref::store</tt> 
-should presumably require <tt>is_copy_constructible_v&lt;T&gt;</tt>, and other operations need to have their 
-requirements audited as well. (Related: LWG <iref ref="3012"/> made similar changes to atomic.)
+Since <tt>const int</tt> is trivially copyable, this is a well-formed C++20 program that returns <tt>0</tt>.
+That said, the <tt>store</tt> call that mutates the value of a constant object is (a) not implementable with
+library technology, and (b) pure madness that violates the language semantics. <tt>atomic_ref::store</tt>
+should presumably require <tt>is_copy_assignable_v&lt;T&gt;</tt>, and other operations need to have their
+requirements audited as well. (Related: LWG <iref ref="3012"/> made similar changes to <tt>atomic</tt>.)
 <p/>
-As a related issue, <tt>volatile atomic&lt;T&gt;</tt> recently had its member functions deprecated when they 
-are not lock-free. Presumably <tt>atomic_ref&lt;volatile T&gt;</tt> should require that atomic operations on 
+As a related issue, <tt>volatile atomic&lt;T&gt;</tt> recently had its member functions deprecated when they
+are not lock-free. Presumably <tt>atomic_ref&lt;volatile T&gt;</tt> should require that atomic operations on
 <tt>T</tt> be lock-free for consistency.
 <p/>
-<b>Jonathan:</b> 
+<b>Jonathan:</b>
 <p/>
-The last point is related to LWG <iref ref="3417"/> (another case where we screwed up the <tt>volatile</tt> 
+The last point is related to LWG <iref ref="3417"/> (another case where we screwed up the <tt>volatile</tt>
 deprecations).
 </p>
 </discussion>


### PR DESCRIPTION
`is_copy_constructible_v` should be `is_copy_assignable_v` for `store`. (Also trim trailing whitespace, and format `atomic` as monospace.)