### PR TITLE
Decouple LWG 2774 from LWG 3493 and add comments

### DIFF
--- a/xml/issue2774.xml
+++ b/xml/issue2774.xml
@@ -16,16 +16,16 @@ I think there's a minor defect in the <tt>std::function</tt> interface. The cons
 template &lt;class F&gt; function(F f);
 </pre></blockquote>
 <p>
-while the assignment operator template is 
+while the assignment operator template is
 </p>
 <blockquote><pre>
 template &lt;class F&gt; function&amp; operator=(F&amp;&amp; f);
 </pre></blockquote>
 <p>
-The latter came about as a result of LWG <iref ref="1288"/>, but that one was dealing with a specific issue that 
-wouldn't have affected the constructor. I think the constructor should also take <tt>f</tt> by forwarding reference, 
-this saves a move in the lvalue/xvalue cases and is also just generally more consistent. Should just make sure 
-that it's stored as <tt>std::decay_t&lt;F&gt;</tt> instead of <tt>F</tt>. 
+The latter came about as a result of LWG <iref ref="1288"/>, but that one was dealing with a specific issue that
+wouldn't have affected the constructor. I think the constructor should also take <tt>f</tt> by forwarding reference,
+this saves a move in the lvalue/xvalue cases and is also just generally more consistent. Should just make sure
+that it's stored as <tt>std::decay_t&lt;F&gt;</tt> instead of <tt>F</tt>.
 <p/>
 Is there any reason to favor a by-value constructor over a forwarding-reference constructor?
 </p>
@@ -72,7 +72,7 @@ template&lt;class F&gt; function(F<ins>&amp;&amp;</ins> f);
 <tt>F</tt></del> <ins><i>Constraints:</i></ins></p>
 <ol style="list-style-type:none">
 <li><p><ins>(8.1) &mdash; <tt>is_same_v&lt;FD, function&gt;</tt> is <tt>false</tt>; and</ins></p></li>
-<li><p><ins>(8.2) &mdash; <tt>FD</tt></ins> is Lvalue-Callable 
+<li><p><ins>(8.2) &mdash; <tt>FD</tt></ins> is Lvalue-Callable
 (<sref ref="[func.wrap.func]"/>) for argument types <tt>ArgTypes...</tt>
 and return type <tt>R</tt>.</p>
 </li>
@@ -83,7 +83,7 @@ and return type <tt>R</tt>.</p>
 <ol style="list-style-type:none">
 <li><p>(9.1) &mdash; <tt>f</tt> is a null function pointer value.</p></li>
 <li><p>(9.2) &mdash; <tt>f</tt> is a null member pointer value.</p></li>
-<li><p>(9.3) &mdash; <del><tt>F</tt> is an instance</del> <ins><tt>remove_cvref_t&lt;F&gt;</tt> is 
+<li><p>(9.3) &mdash; <del><tt>F</tt> is an instance</del> <ins><tt>remove_cvref_t&lt;F&gt;</tt> is
 a specialization</ins> of the <tt>function</tt> class template, and <tt>!f</tt> <ins>is <tt>true</tt></ins>.
 </p></li>
 </ol>
@@ -91,11 +91,11 @@ a specialization</ins> of the <tt>function</tt> class template, and <tt>!f</tt> 
 <del>a copy of <tt>f</tt></del><ins>an object of type <tt>FD</tt>
 direct-non-list-</ins>initialized with <del><tt>std::move(f)</tt></del>
 <ins><tt>std::forward&lt;F&gt;(f)</tt></ins>. [<i>Note:</i> Implementations should
-avoid the use of dynamically allocated memory for small callable objects, for example, where <tt>f</tt> 
-<del>is</del> <ins>refers to</ins> an object holding only a pointer or reference to an object 
+avoid the use of dynamically allocated memory for small callable objects, for example, where <tt>f</tt>
+<del>is</del> <ins>refers to</ins> an object holding only a pointer or reference to an object
 and a member function pointer. &mdash; <i>end note</i>]</p>
 <p> -11- <i>Throws:</i> <del>Shall</del> <ins>Does</ins> not throw exceptions when <del><tt>f</tt></del>
-<ins><tt>FD</tt></ins> is a function pointer <ins>type</ins> or 
+<ins><tt>FD</tt></ins> is a function pointer <ins>type</ins> or
 a <ins>specialization of</ins> <tt>reference_wrapper</tt><del><tt>&lt;T&gt;</tt> for some <tt>T</tt></del>.
 Otherwise, may throw <tt>bad_alloc</tt> or any exception thrown by <del><tt>F</tt>’s copy or move constructor</del>
 <ins>the initialization of the target object</ins>.</p>
@@ -114,9 +114,10 @@ by the recently agreed on elements.
 <p/>
 See also the related issue LWG <iref ref="3493"/>.
 </p>
-</discussion>
 
-<resolution>
+
+<p><strong>Previous resolution [SUPERSEDED]:</strong></p>
+<blockquote class="note">
 <p>This wording is relative to <a href="https://wg21.link/n4868">N4868</a>.</p>
 
 <ol>
@@ -156,10 +157,10 @@ template&lt;class F&gt; function(F<ins>&amp;&amp;</ins> f);
 <p>
 <ins>Let <tt>FD</tt> be <tt>decay_t&lt;F&gt;</tt>.</ins>
 </p>
--8- <i>Constraints:</i> 
+-8- <i>Constraints:</i>
 <ol style="list-style-type:none">
 <li><p><ins>(8.1) &mdash; <tt>is_same_v&lt;remove_cvref_t&lt;F&gt;, function&gt;</tt> is <tt>false</tt>,</ins></p></li>
-<li><p><ins>(8.2) &mdash; <tt>FD</tt></ins><del><tt>F</tt></del> is Lvalue-Callable (<sref ref="[func.wrap.func.general]"/>) 
+<li><p><ins>(8.2) &mdash; <tt>FD</tt></ins><del><tt>F</tt></del> is Lvalue-Callable (<sref ref="[func.wrap.func.general]"/>)
 for argument types <tt>ArgTypes...</tt> and return type <tt>R</tt><ins>,</ins></p></li>
 <li><p><ins>(8.3) &mdash; <tt>is_copy_constructible_v&lt;FD&gt;</tt> is <tt>true</tt>, and</ins></p></li>
 <li><p><ins>(8.4) &mdash; <tt>is_constructible_v&lt;FD, F&gt;</tt> is <tt>true</tt></ins>.</p></li>
@@ -172,19 +173,113 @@ for argument types <tt>ArgTypes...</tt> and return type <tt>R</tt><ins>,</ins></
 <ol style="list-style-type:none">
 <li><p>(10.1) &mdash; <tt>f</tt> is a null function pointer value.</p></li>
 <li><p>(10.2) &mdash; <tt>f</tt> is a null member pointer value.</p></li>
-<li><p>(10.3) &mdash; <del><tt>F</tt> is an instance</del><ins><tt>remove_cvref_t&lt;F&gt;</tt> is 
+<li><p>(10.3) &mdash; <del><tt>F</tt> is an instance</del><ins><tt>remove_cvref_t&lt;F&gt;</tt> is
 a specialization</ins> of the function class template, and <tt>!f</tt> <ins>is <tt>true</tt></ins>.</p></li>
 </ol>
 <p>
 -11- Otherwise, <tt>*this</tt> targets <del>a copy of <tt>f</tt></del><ins>an object of type <tt>FD</tt>
 direct-non-list-</ins>initialized with <tt><del>std::move(f)</del><ins>std::forward&lt;F&gt;(f)</ins></tt>.
 <p/>
--12- <i>Throws:</i> Nothing if <tt><del>f</del><ins>FD</ins></tt> is a specialization of <tt>reference_wrapper</tt> 
-or a function pointer <ins>type</ins>. Otherwise, may throw <tt>bad_alloc</tt> or any exception thrown by 
+-12- <i>Throws:</i> Nothing if <tt><del>f</del><ins>FD</ins></tt> is a specialization of <tt>reference_wrapper</tt>
+or a function pointer <ins>type</ins>. Otherwise, may throw <tt>bad_alloc</tt> or any exception thrown by
 <del><tt>F</tt>'s copy or move constructor</del><ins>the initialization of the target object</ins>.
 <p/>
 -13- <i>Recommended practice:</i> Implementations should avoid the use of dynamically allocated memory for
-small callable objects, for example, where <tt>f</tt> <del>is</del><ins>refers to</ins> an object holding 
+small callable objects, for example, where <tt>f</tt> <del>is</del><ins>refers to</ins> an object holding
+only a pointer or reference to an object and a member function pointer.
+</p>
+</blockquote>
+</blockquote>
+</li>
+</ol>
+</blockquote>
+
+<note>2021-05-17; Tim comments and revises the wording</note>
+<p>
+The additional constraints added in the previous wording can induce
+constraint recursion, as noted in the discussion of LWG <iref ref="3493"/>.
+The wording below changes them to <i>Mandates:</i> instead to allow this issue
+to make progress independently of that issue.
+<p/>
+The proposed resolution below has been implemented and tested on top of
+libstdc++.
+</p>
+</discussion>
+
+<resolution>
+<p>This wording is relative to <a href="https://wg21.link/n4885">N4885</a>.</p>
+
+<ol>
+<li><p>Edit <sref ref="[func.wrap.func.general]"/>, class template <tt>function</tt> synopsis, as indicated:</p>
+
+<blockquote>
+<pre>
+namespace std {
+  template&lt;class&gt; class function; <i>// not defined</i>
+
+  template&lt;class R, class... ArgTypes&gt; {
+  public:
+    using result_type = R;
+
+    // <sref ref="[func.wrap.func.con]" />, construct/copy/destroy
+    function() noexcept;
+    function(nullptr_t) noexcept;
+    function(const function&amp;);
+    function(function&amp;&amp;) noexcept;
+    template&lt;class F&gt; function(F<ins>&amp;&amp;</ins>);
+
+    [&hellip;]
+  };
+
+  [&hellip;]
+}
+</pre>
+</blockquote>
+</li>
+
+<li><p>Edit <sref ref="[func.wrap.func.con]"/> as indicated:</p>
+<blockquote>
+<pre>
+template&lt;class F&gt; function(F<ins>&amp;&amp;</ins> f);
+</pre>
+<blockquote>
+<p>
+<ins>Let <tt>FD</tt> be <tt>decay_t&lt;F&gt;</tt>.</ins>
+</p>
+-8- <i>Constraints:</i>
+<ol style="list-style-type:none">
+<li><p><ins>(8.1) &mdash; <tt>is_same_v&lt;remove_cvref_t&lt;F&gt;, function&gt;</tt> is <tt>false</tt>, and</ins></p></li>
+<li><p><ins>(8.2) &mdash; <tt>FD</tt></ins><del><tt>F</tt></del> is Lvalue-Callable (<sref ref="[func.wrap.func.general]"/>)
+for argument types <tt>ArgTypes...</tt> and return type <tt>R</tt>.</p></li>
+</ol>
+<p>
+<ins>-?- <i>Mandates:</i></ins>
+</p>
+<ol style="list-style-type:none">
+<li><p><ins>(?.1) &mdash; <tt>is_copy_constructible_v&lt;FD&gt;</tt> is <tt>true</tt>, and</ins></p></li>
+<li><p><ins>(?.2) &mdash; <tt>is_constructible_v&lt;FD, F&gt;</tt> is <tt>true</tt>.</ins></p></li>
+</ol>
+<p>
+-9- <i>Preconditions:</i> <tt><del>F</del><ins>FD</ins></tt> meets the <i>Cpp17CopyConstructible</i> requirements.
+<p/>
+-10- <i>Postconditions:</i> <tt>!*this</tt> <ins>is <tt>true</tt></ins> if any of the following hold:
+</p>
+<ol style="list-style-type:none">
+<li><p>(10.1) &mdash; <tt>f</tt> is a null function pointer value.</p></li>
+<li><p>(10.2) &mdash; <tt>f</tt> is a null member pointer value.</p></li>
+<li><p>(10.3) &mdash; <del><tt>F</tt> is an instance</del><ins><tt>remove_cvref_t&lt;F&gt;</tt> is
+a specialization</ins> of the <tt>function</tt> class template, and <tt>!f</tt> <ins>is <tt>true</tt></ins>.</p></li>
+</ol>
+<p>
+-11- Otherwise, <tt>*this</tt> targets <del>a copy of <tt>f</tt></del><ins>an object of type <tt>FD</tt>
+direct-non-list-</ins>initialized with <tt><del>std::move(f)</del><ins>std::forward&lt;F&gt;(f)</ins></tt>.
+<p/>
+-12- <i>Throws:</i> Nothing if <tt><del>f</del><ins>FD</ins></tt> is a specialization of <tt>reference_wrapper</tt>
+or a function pointer <ins>type</ins>. Otherwise, may throw <tt>bad_alloc</tt> or any exception thrown by
+<del><tt>F</tt>'s copy or move constructor</del><ins>the initialization of the target object</ins>.
+<p/>
+-13- <i>Recommended practice:</i> Implementations should avoid the use of dynamically allocated memory for
+small callable objects, for example, where <tt>f</tt> <del>is</del><ins>refers to</ins> an object holding
 only a pointer or reference to an object and a member function pointer.
 </p>
 </blockquote>
@@ -194,4 +289,3 @@ only a pointer or reference to an object and a member function pointer.
 </resolution>
 
 </issue>
-

--- a/xml/issue3493.xml
+++ b/xml/issue3493.xml
@@ -10,7 +10,7 @@
 
 <discussion>
 <p>
-In <a href="https://wg21.link/p0288">P0288</a>, <tt>any_invocable</tt> is (correctly) constraining 
+In <a href="https://wg21.link/p0288">P0288</a>, <tt>any_invocable</tt> is (correctly) constraining
 its constructor that takes an <tt>F</tt>:
 </p>
 <blockquote>
@@ -31,13 +31,13 @@ Let <tt>VT</tt> be <tt>decay_t&lt;F&gt;</tt>.
 </blockquote>
 </blockquote>
 <p>
-<tt>std::function</tt> doesn't do that. According to <a href="https://wg21.link/n4868">N4868</a>, 
-<sref ref="[func.wrap.func.con]"/> p8 has a constraint for Lvalue-Callable, but not for 
-copy-constructibility. There is a precondition in p9, but that's not enough for portable 
+<tt>std::function</tt> doesn't do that. According to <a href="https://wg21.link/n4868">N4868</a>,
+<sref ref="[func.wrap.func.con]"/> p8 has a constraint for Lvalue-Callable, but not for
+copy-constructibility. There is a precondition in p9, but that's not enough for portable
 well/ill-formedness.
 <p/>
-Since this is a constructor, and we want to give the right answer to 
-<tt>is_constructible</tt>/<tt>constructible_from</tt> queries, we should 
+Since this is a constructor, and we want to give the right answer to
+<tt>is_constructible</tt>/<tt>constructible_from</tt> queries, we should
 add the relevant constraint.
 </p>
 
@@ -51,11 +51,46 @@ This issue has some overlap with LWG <iref ref="2774"/>.
 Set priority to 3 following reflector and telecon discussions.
 </p>
 
+<note>2021-05-17; Tim comments</note>
+<p>
+The new constraint causes constraint recursion in an example like:
+</p>
+<blockquote>
+<pre>
+struct C {
+    explicit C(std::function&lt;void()&gt;); // #1
+    void operator()() {}
+};
+static_assert(std::is_constructible_v&lt;C, const C&amp;&gt;);
+</pre>
+</blockquote>
+<p>
+Here, to determine whether a <tt>C</tt> can be constructed from a <tt>const C</tt>
+lvalue, the overload resolution will attempt to determine whether the constructor
+marked <tt>#1</tt> is a viable candidate, which involves a determination of
+whether that lvalue can be implicitly converted to a <tt>std::function&lt;void()&gt;</tt>,
+which, with the new constraint, requires a determination whether
+<tt>C</tt> is copy-constructible &mdash; in other words, whether it can be constructed
+from a <tt>C</tt> lvalue.
+<p/>
+This is similar to LWG <iref ref="3420"/>: in both cases we have a class
+(<tt>filesystem::path</tt> there, <tt>function</tt> here) that is
+convertible from every type that are, <i>inter alia</i>, copy constructible,
+and this then results in constraint recursion when we ask whether a different
+type that is constructible from such a class is copy constructible.
+<p/>
+The <tt>C</tt> above is reduced from an internal helper type in libstdc++. Given
+the ubiquity of call wrappers &mdash; types that are callable in their own right
+and therefore may not be able to be ruled out by the Lvalue-Callable constraint,
+and can also naturally have a constructor that take the wrapped function object
+as the argument, triggering the recursion scenario &mdash; it is not clear that
+there is a good way to add this constraint without causing undue breakage.
+</p>
 </discussion>
 
 <resolution>
 <p>
-This wording is relative to <a href="https://wg21.link/n4868">N4868</a>. 
+This wording is relative to <a href="https://wg21.link/n4868">N4868</a>.
 </p>
 
 <ol>
@@ -70,8 +105,8 @@ template&lt;class F&gt; function(F f);
 </pre>
 <blockquote>
 <p>
--8- <i>Constraints:</i> <tt>F</tt> is Lvalue-Callable (<sref ref="[func.wrap.func.general]"/>) for 
-argument types <tt>ArgTypes...</tt> and return type <tt>R</tt><ins>, and 
+-8- <i>Constraints:</i> <tt>F</tt> is Lvalue-Callable (<sref ref="[func.wrap.func.general]"/>) for
+argument types <tt>ArgTypes...</tt> and return type <tt>R</tt><ins>, and
 <tt>is_copy_constructible_v&lt;F&gt;</tt> is <tt>true</tt></ins>.
 <p/>
 -9- <i>Preconditions:</i> <tt>F</tt> meets the <i>Cpp17CopyConstructible</i> requirements.


### PR DESCRIPTION
I'd like to decouple LWG 2774 from LWG 3493 now that we know that the latter isn't a no-brainer, so that I can try to propose 2774 for tentatively ready (since it is a performance improvement).

@Dani-Hub Please let me know if you disagree with this approach.