### PR TITLE
Mark several issues as resolved by papers adopted at the June 2021 plenary

### DIFF
--- a/xml/issue3478.xml
+++ b/xml/issue3478.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3478" status="New">
+<issue num="3478" status="Resolved">
 <title><tt>views::split</tt> drops trailing empty range</title>
 <section><sref ref="[range.split]"/></section>
 <submitter>Barry Revzin</submitter>
@@ -17,39 +17,39 @@ From <a href="https://stackoverflow.com/q/63497978/2069064">StackOverflow</a>, t
 #include &lt;string&gt;
 #include &lt;ranges&gt;
 
-int main() 
+int main()
 {
   std::string s = " text ";
-  auto sv = std::ranges::views::split(s, ' ');                    
+  auto sv = std::ranges::views::split(s, ' ');
   std::cout &lt;&lt; std::ranges::distance(sv.begin(), sv.end());
 }
 </pre></blockquote>
 <p>
-prints 2 (as specified), but it really should print 3. If a range has <tt>N</tt> delimiters in it, 
-splitting should produce <tt>N+1</tt> pieces. If the <tt>N</tt><sup>th</sup> delimiter is the last 
-element in the input range, <tt>views::split</tt> produces only <tt>N</tt> pieces &mdash; it doesn't 
+prints 2 (as specified), but it really should print 3. If a range has <tt>N</tt> delimiters in it,
+splitting should produce <tt>N+1</tt> pieces. If the <tt>N</tt><sup>th</sup> delimiter is the last
+element in the input range, <tt>views::split</tt> produces only <tt>N</tt> pieces &mdash; it doesn't
 emit a trailing empty range.
 <p/>
-Going through a bunch of languages gets a sense of what they all do here. There are basically two 
+Going through a bunch of languages gets a sense of what they all do here. There are basically two
 groups (and Haskell goes in both because it has several different split functions)
 </p>
 <ol>
-<li><p>Rust, Python, Javascript, Go, Kotlin, Haskell's <tt>"splitOn"</tt> all provide <tt>N+1</tt> parts 
+<li><p>Rust, Python, Javascript, Go, Kotlin, Haskell's <tt>"splitOn"</tt> all provide <tt>N+1</tt> parts
 if there were <tt>N</tt> delimiters.</p></li>
-<li><p>APL, D, Elixir, Haskell's <tt>"words"</tt>, Ruby, and Clojure all compress all empty words. 
-Splitting <tt>" x "</tt> on <tt>" "</tt> would give <tt>["x"]</tt> here, whereas the languages in the 
+<li><p>APL, D, Elixir, Haskell's <tt>"words"</tt>, Ruby, and Clojure all compress all empty words.
+Splitting <tt>" x "</tt> on <tt>" "</tt> would give <tt>["x"]</tt> here, whereas the languages in the
 above group would give <tt>["", "x", ""]</tt></p></li>
 </ol>
 <p>
-Java is distinct from both groups in that it is mostly a first category language, except that by default 
-it removes all trailing empty strings (but it keeps all leading and intermediate empty strings, unlike 
+Java is distinct from both groups in that it is mostly a first category language, except that by default
+it removes all trailing empty strings (but it keeps all leading and intermediate empty strings, unlike
 the second category languages) &mdash; although it has a parameter that lets you keep the trailing ones too.
 <p/>
-C++20's behavior is closest to Java's default, except that it only removes one trailing empty string 
-instead of every trailing empty string &mdash; and this behavior is not parameterizeable. But I think the 
+C++20's behavior is closest to Java's default, except that it only removes one trailing empty string
+instead of every trailing empty string &mdash; and this behavior is not parameterizeable. But I think the
 intent is to be squarely in the first category, so I think the current behavior is just a specification error.
 <p/>
-Many of these languages also provide an additional extra parameter to limit how many splits happen (e.g. 
+Many of these languages also provide an additional extra parameter to limit how many splits happen (e.g.
 Java, Kotlin, Python, Rust, JavaScript), but that's a separate design question.
 </p>
 
@@ -57,6 +57,7 @@ Java, Kotlin, Python, Rust, JavaScript), but that's a separate design question.
 <p>
 Set priority to 2 as result of reflector discussions.
 </p>
+<note>2021-06-13 Resolved by the adoption of <paper num="P2210R2"/> at the June 2021 plenary. Status changed: New &rarr; Resolved.</note>
 </discussion>
 
 <resolution>

--- a/xml/issue3479.xml
+++ b/xml/issue3479.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3479" status="New">
+<issue num="3479" status="Resolved">
 <title><tt><i>semiregular-box</i></tt> mishandles self-assignment</title>
 <section><sref ref="[range.semi.wrap]"/></section>
 <submitter>Casey Carter</submitter>
@@ -10,16 +10,16 @@
 
 <discussion>
 <p>
-The exposition-only wrapper type <tt><i>semiregular-box</i></tt> &mdash; specified in <sref ref="[range.semi.wrap]"/> 
-&mdash; layers behaviors onto <tt>std::optional</tt> so <tt><i>semiregular-box</i>&lt;T&gt;</tt> is 
-semiregular even when <tt>T</tt> is only copy constructible. It provides copy and move assignment 
+The exposition-only wrapper type <tt><i>semiregular-box</i></tt> &mdash; specified in <sref ref="[range.semi.wrap]"/>
+&mdash; layers behaviors onto <tt>std::optional</tt> so <tt><i>semiregular-box</i>&lt;T&gt;</tt> is
+semiregular even when <tt>T</tt> is only copy constructible. It provides copy and move assignment
 operators when <tt>optional&lt;T&gt;</tt>'s are deleted:
 </p>
 <blockquote><p>
 <ol style="list-style-type: none">
 <li><p>(1.1) &mdash; [&hellip;]</p></li>
 <li><p>(1.2) &mdash; [&hellip;]</p></li>
-<li><p>(1.3) &mdash; If <tt>assignable_from&lt;T&amp;, const T&amp;&gt;</tt> 
+<li><p>(1.3) &mdash; If <tt>assignable_from&lt;T&amp;, const T&amp;&gt;</tt>
 is not modeled, the copy assignment operator is equivalent to:</p>
 <pre>
 <i>semiregular-box</i>&amp; operator=(const <i>semiregular-box</i>&amp; that)
@@ -31,7 +31,7 @@ is not modeled, the copy assignment operator is equivalent to:</p>
 }
 </pre>
 </li>
-<li><p>(1.4) &mdash; If <tt>assignable_from&lt;T&amp;, T&gt;</tt> 
+<li><p>(1.4) &mdash; If <tt>assignable_from&lt;T&amp;, T&gt;</tt>
 is not modeled, the move assignment operator is equivalent to:</p>
 <pre>
 <i>semiregular-box</i>&amp; operator=(<i>semiregular-box</i>&amp;&amp; that)
@@ -46,17 +46,17 @@ is not modeled, the move assignment operator is equivalent to:</p>
 </ol>
 </p></blockquote>
 <p>
-How do these assignment operators handle self-assignment? When <tt>*this</tt> is empty, <tt>that</tt> 
-will test as <tt>false</tt> and <tt>reset()</tt> has no effect, so the result state of the object is 
-the same. No problems so far. When <tt>*this</tt> isn't empty, <tt>that</tt> will test as <tt>true</tt>, 
-and we evaluate <tt>optional::emplace(**this)</tt> (resp. <tt>optional::emplace(std::move(**this)))</tt>. 
-This outcome is not as pretty: <tt>emplace</tt> is specified in <sref ref="[optional.assign]"/>/30: 
-"<i>Effects:</i> Calls <tt>*this = nullopt</tt>. Then initializes the contained value as if 
-direct-non-list-initializing an object of type <tt>T</tt> with the arguments 
-<tt>std::forward&lt;Args&gt;(args)...</tt>." When the sole argument is an lvalue (resp. xvalue) of type 
-<tt>T</tt> that denotes the <tt>optional</tt>'s stored value, <tt>emplace</tt> will destroy that 
-stored value and then try to copy/move construct a new object at the same address from the dead object 
-that used to live there resulting in undefined behavior. Mandatory undefined behavior does <em>not</em> 
+How do these assignment operators handle self-assignment? When <tt>*this</tt> is empty, <tt>that</tt>
+will test as <tt>false</tt> and <tt>reset()</tt> has no effect, so the result state of the object is
+the same. No problems so far. When <tt>*this</tt> isn't empty, <tt>that</tt> will test as <tt>true</tt>,
+and we evaluate <tt>optional::emplace(**this)</tt> (resp. <tt>optional::emplace(std::move(**this)))</tt>.
+This outcome is not as pretty: <tt>emplace</tt> is specified in <sref ref="[optional.assign]"/>/30:
+"<i>Effects:</i> Calls <tt>*this = nullopt</tt>. Then initializes the contained value as if
+direct-non-list-initializing an object of type <tt>T</tt> with the arguments
+<tt>std::forward&lt;Args&gt;(args)...</tt>." When the sole argument is an lvalue (resp. xvalue) of type
+<tt>T</tt> that denotes the <tt>optional</tt>'s stored value, <tt>emplace</tt> will destroy that
+stored value and then try to copy/move construct a new object at the same address from the dead object
+that used to live there resulting in undefined behavior. Mandatory undefined behavior does <em>not</em>
 meet the semantic requirements for the <tt>copyable</tt> or <tt>movable</tt> concepts, we should do better.
 </p>
 
@@ -64,9 +64,8 @@ meet the semantic requirements for the <tt>copyable</tt> or <tt>movable</tt> con
 <p>
 Set priority to 3 during reflector discussions.
 </p>
-</discussion>
-
-<resolution>
+<p><strong>Previous resolution [SUPERSEDED]:</strong></p>
+<blockquote class="note">
 <p>
 This wording is relative to <a href="https://wg21.link/n4861">N4861</a>.
 </p>
@@ -76,14 +75,14 @@ This wording is relative to <a href="https://wg21.link/n4861">N4861</a>.
 
 <blockquote>
 <p>
--1- Many types in this subclause are specified in terms of an exposition-only class template 
-<tt><i>semiregular-box</i></tt>. <tt><i>semiregular-box</i>&lt;T&gt;</tt> behaves exactly like 
+-1- Many types in this subclause are specified in terms of an exposition-only class template
+<tt><i>semiregular-box</i></tt>. <tt><i>semiregular-box</i>&lt;T&gt;</tt> behaves exactly like
 <tt>optional&lt;T&gt;</tt> with the following differences:
 </p>
 <ol style="list-style-type: none">
 <li><p>(1.1) &mdash; [&hellip;]</p></li>
 <li><p>(1.2) &mdash; [&hellip;]</p></li>
-<li><p>(1.3) &mdash; If <tt>assignable_from&lt;T&amp;, const T&amp;&gt;</tt> 
+<li><p>(1.3) &mdash; If <tt>assignable_from&lt;T&amp;, const T&amp;&gt;</tt>
 is not modeled, the copy assignment operator is equivalent to:</p>
 <pre>
 <i>semiregular-box</i>&amp; operator=(const <i>semiregular-box</i>&amp; that)
@@ -97,7 +96,7 @@ is not modeled, the copy assignment operator is equivalent to:</p>
 }
 </pre>
 </li>
-<li><p>(1.4) &mdash; If <tt>assignable_from&lt;T&amp;, T&gt;</tt> 
+<li><p>(1.4) &mdash; If <tt>assignable_from&lt;T&amp;, T&gt;</tt>
 is not modeled, the move assignment operator is equivalent to:</p>
 <pre>
 <i>semiregular-box</i>&amp; operator=(<i>semiregular-box</i>&amp;&amp; that)
@@ -113,8 +112,13 @@ is not modeled, the move assignment operator is equivalent to:</p>
 </ol>
 </blockquote>
 </li>
-
 </ol>
+</blockquote>
+
+<note>2021-06-13 Resolved by the adoption of <paper num="P2325R3"/> at the June 2021 plenary. Status changed: New &rarr; Resolved.</note>
+</discussion>
+
+<resolution>
 </resolution>
 
 </issue>

--- a/xml/issue3509.xml
+++ b/xml/issue3509.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3509" status="New">
+<issue num="3509" status="Resolved">
 <title>Range adaptor objects are underspecified</title>
 <section><sref ref="[range.adaptor.object]"/></section>
 <submitter>Tim Song</submitter>
@@ -46,6 +46,7 @@ move from <tt>f</tt>).
 <p>
 Set priority to 2 following reflector and telecon discussions.
 </p>
+<note>2021-06-13 Resolved by the adoption of <paper num="P2281R1"/> at the June 2021 plenary. Status changed: New &rarr; Resolved.</note>
 </discussion>
 
 <resolution>

--- a/xml/issue3510.xml
+++ b/xml/issue3510.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3510" status="New">
+<issue num="3510" status="Resolved">
 <title>Customization point objects should be invocable as non-<tt>const</tt> too</title>
 <section><sref ref="[customization.point.object]"/></section>
 <submitter>Tim Song</submitter>
@@ -26,6 +26,7 @@ has since clarified that this formulation doesn't do that.
 Set priority to 3 following reflector and telecon discussions.
 </p>
 
+<note>2021-06-13 Resolved by the adoption of <paper num="P2281R1"/> at the June 2021 plenary. Status changed: New &rarr; Resolved.</note>
 </discussion>
 
 <resolution>

--- a/xml/issue3524.xml
+++ b/xml/issue3524.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3524" status="New">
+<issue num="3524" status="Resolved">
 <title>Unimplementable narrowing and evaluation order requirements for range adaptors</title>
 <section><sref ref="[range.adaptors]"/></section>
 <submitter>Tim Song</submitter>
@@ -31,6 +31,7 @@ is required to be ill-formed. This seems unlikely to be the intent either.
 Set priority to 3 following reflector poll.
 </p>
 
+<note>2021-06-13 Resolved by the adoption of <paper num="P2367R0"/> at the June 2021 plenary. Status changed: New &rarr; Resolved.</note>
 </discussion>
 
 <resolution>


### PR DESCRIPTION
- LWG 3478 is resolved by P2210R2.
- LWG 3479 is resolved by P2325R3. Also marked the previous resolution as superseded.
- LWG 3509 and LWG 3510 are resolved by P2281R1.
- LWG 3524 is resolved by P2367R0.