### PR TITLE
rebase 3088 to current WP

### DIFF
--- a/xml/issue3088.xml
+++ b/xml/issue3088.xml
@@ -3,7 +3,7 @@
 
 <issue num="3088" status="New">
 <title><tt>forward_list::merge</tt> behavior unclear when passed <tt>*this</tt></title>
-<section><sref ref="[forwardlist.ops]"/></section>
+<section><sref ref="[forward.list.ops]"/></section>
 <submitter>Tim Song</submitter>
 <date>19 Mar 2018</date>
 <priority>3</priority>
@@ -66,10 +66,10 @@ comparisons <ins>if <tt>addressof(x) != this</tt>; otherwise, no comparisons are
 </discussion>
 
 <resolution>
-<p>This wording is relative to <paper num="N4885"/>.</p>
+<p>This wording is relative to <paper num="N4901"/>.</p>
 
 <ol>
-<li><p>Edit <sref ref="[forwardlist.ops]"/> as indicated:</p>
+<li><p>Edit <sref ref="[forward.list.ops]"/> as indicated:</p>
 <blockquote>
 <pre>
 void merge(forward_list&amp; x);
@@ -81,12 +81,12 @@ template&lt;class Compare&gt; void merge(forward_list&amp;&amp; x, Compare comp)
 <p>
 <ins>-?- Let <tt>comp</tt> be <tt>less&lt;&gt;{}</tt> for the first two overloads.</ins>
 <p/>
--22- <i>Preconditions:</i> <tt>*this</tt> and <tt>x</tt> are both sorted with respect to the comparator
+-24- <i>Preconditions:</i> <tt>*this</tt> and <tt>x</tt> are both sorted with respect to the comparator
 <del><tt>operator&lt;</tt> (for the first two overloads) or</del> <tt>comp</tt>
 <del> (for the last two overloads)</del>,
 and <tt>get_allocator() == x.get_allocator()</tt> is <tt>true</tt>.
 <p/>
--23- <i>Effects:</i> <ins>If <tt>addressof(x) == this</tt>, there are no effects. Otherwise,
+-25- <i>Effects:</i> <ins>If <tt>addressof(x) == this</tt>, there are no effects. Otherwise,
 m</ins><del>M</del>erges the two sorted ranges <tt>[begin(), end())</tt> and <tt>[x.begin(), x.end())</tt>.
 <ins>The result is a range that is sorted with respect to the comparator <tt>comp</tt>.</ins> <del><tt>x</tt> is
 empty after the merge. If an exception is thrown other than by a comparison there are no effects.</del>
@@ -94,10 +94,10 @@ Pointers and references to the moved elements of <tt>x</tt> now refer to those s
 as members of <tt>*this</tt>. Iterators referring to the moved elements will continue to refer to
 their elements, but they now behave as iterators into <tt>*this</tt>, not into <tt>x</tt>.
 <p/>
--24- <i>Complexity:</i> At most <tt>distance(begin(), end()) + distance(x.begin(), x.end()) - 1</tt>
+-26- <i>Complexity:</i> At most <tt>distance(begin(), end()) + distance(x.begin(), x.end()) - 1</tt>
 comparisons <ins>if <tt>addressof(x) != this</tt>; otherwise, no comparisons are performed</ins>.
 <p/>
--25- <i>Remarks:</i> Stable (<sref ref="[algorithm.stable]"/>). <ins>If <tt>addressof(x) != this</tt>,
+-27- <i>Remarks:</i> Stable (<sref ref="[algorithm.stable]"/>). <ins>If <tt>addressof(x) != this</tt>,
 <tt>x</tt> is empty after the merge. No elements are copied by this operation.
 If an exception is thrown other than by a comparison there are no effects.</ins>
 </p>
@@ -116,12 +116,12 @@ template&lt;class Compare&gt; void merge(list&amp;&amp; x, Compare comp);
 <p>
 <ins>-?- Let <tt>comp</tt> be <tt>less&lt;&gt;{}</tt> for the first two overloads.</ins>
 <p/>
--24- <i>Preconditions:</i> <del>Both the list and the argument list shall be</del><ins><tt>*this</tt> and <tt>x</tt> are both</ins>
+-26- <i>Preconditions:</i> <del>Both the list and the argument list shall be</del><ins><tt>*this</tt> and <tt>x</tt> are both</ins>
 sorted with respect to the comparator <del><tt>operator&lt;</tt>
 (for the first two overloads) or </del><tt>comp</tt><del> (for the last two overloads)</del>, and
-<tt>get_allocator() != x.get_allocator()</tt> is <tt>true</tt>.
+<tt>get_allocator() == x.get_allocator()</tt> is <tt>true</tt>.
 <p/>
--25- <i>Effects:</i> If <tt>addressof(x) == this</tt>, <del>does nothing; o</del><ins>there are no effects. O</ins>therwise,
+-27- <i>Effects:</i> If <tt>addressof(x) == this</tt>, <del>does nothing; o</del><ins>there are no effects. O</ins>therwise,
 merges the two sorted ranges <tt>[begin(), end())</tt> and <tt>[x.begin(), x.end())</tt>.
 The result is a range <del>in which the elements will be sorted in non-decreasing order according to the ordering
 defined by <tt>comp</tt>; that is, for every iterator <tt>i</tt>, in the range other than the first, the condition
@@ -130,10 +130,10 @@ defined by <tt>comp</tt>; that is, for every iterator <tt>i</tt>, in the range o
 but as members of <tt>*this</tt>. Iterators referring to the moved elements will continue to refer to their elements,
 but they now behave as iterators into <tt>*this</tt>, not into <tt>x</tt>.
 <p/>
--26- <i>Complexity:</i> At most <tt>size() + x.size() - 1</tt> <del>applications of <tt>comp</tt></del><ins>comparisons</ins>
+-28- <i>Complexity:</i> At most <tt>size() + x.size() - 1</tt> <del>applications of <tt>comp</tt></del><ins>comparisons</ins>
 if <tt>addressof(x) != this</tt>; otherwise, no <del>applications of <tt>comp</tt></del><ins>comparisons</ins> are performed.
 <del>If an exception is thrown other than by a comparison there are no effects.</del><p/>
--27- <i>Remarks:</i> Stable (<sref ref="[algorithm.stable]"/>). If <tt>addressof(x) != this</tt>, <del>the range
+-29- <i>Remarks:</i> Stable (<sref ref="[algorithm.stable]"/>). If <tt>addressof(x) != this</tt>, <del>the range
 <tt>[x.begin(), x.end())</tt></del><ins><tt>x</tt></ins> is empty after the merge. No elements are copied by this operation.
 <ins>If an exception is thrown other than by a comparison there are no effects.</ins>
 </p>


### PR DESCRIPTION
Only changes are
- stable name
- paragraph numbers
- fix a typo in unchanged text.