### PR TITLE
Expand 3631 to also cover make_format_args

### DIFF
--- a/xml/issue3631.xml
+++ b/xml/issue3631.xml
@@ -21,7 +21,7 @@ they need to be removed before the checks.
 Set priority to 3 after reflector poll.
 </p>
 <p>
-Two suggestions to just change it to be <tt>T&amp;</tt> because we don't 
+Two suggestions to just change it to be <tt>T&amp;</tt> because we don't
 need forwarding references here, and only accepting lvalues prevents
 forming dangling references.
 </p>
@@ -49,8 +49,8 @@ template&lt;class T&gt; explicit basic_format_arg(T&amp;&amp; v) noexcept;
 typename Context::template formatter_type&lt;<del>remove_cvref_t&lt;T&gt;</del><ins>TD</ins>&gt;
 </pre></blockquote>
 <p>
-meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent to 
-which an implementation determines that the specialization meets the <i>BasicFormatter</i> 
+meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent to
+which an implementation determines that the specialization meets the <i>BasicFormatter</i>
 requirements is unspecified, except that as a minimum the expression
 </p>
 <blockquote><pre>
@@ -64,13 +64,13 @@ shall be well-formed when treated as an unevaluated operand (<sref ref="[expr.co
 </p>
 <ol style="list-style-type:none">
 <li><p>(5.1) &mdash; if <tt>T<ins>D</ins></tt> is <tt>bool</tt> or <tt>char_type</tt>, initializes <tt>value</tt> with <tt>v</tt>;</p></li>
-<li><p>(5.2) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>, 
+<li><p>(5.2) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;wchar_t&gt;(v)</tt>;</p></li>
-<li><p>(5.3) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type (<sref ref="[basic.fundamental]"/>) and 
+<li><p>(5.3) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type (<sref ref="[basic.fundamental]"/>) and
 <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;int&gt;(v)</tt>;</p></li>
-<li><p>(5.4) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned int)</tt>, 
+<li><p>(5.4) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned int)</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;unsigned int&gt;(v)</tt>;</p></li>
-<li><p>(5.5) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(long long int)</tt>, 
+<li><p>(5.5) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(long long int)</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;long long int&gt;(v)</tt>;</p></li>
 <li><p>(5.6) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned long long int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;unsigned long long int&gt;(v)</tt>;</p></li>
 <li><p>(5.7) &mdash; otherwise, initializes <tt>value</tt> with <tt>handle(v)</tt>.</p></li>
@@ -118,8 +118,8 @@ template&lt;class T&gt; explicit basic_format_arg(T&amp;<del>&amp;</del> v) noex
 typename Context::template formatter_type&lt;remove_cvref_t&lt;T&gt;&gt;
 </del></pre></blockquote>
 <p><del>
-meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent to 
-which an implementation determines that the specialization meets the <i>BasicFormatter</i> 
+meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent to
+which an implementation determines that the specialization meets the <i>BasicFormatter</i>
 requirements is unspecified, except that as a minimum the expression
 </del></p>
 <blockquote><pre><del>
@@ -140,13 +140,13 @@ If <tt>decay_t&lt;T&gt;</tt> is <tt>char_type*</tt> or <tt>const char_type*</tt>
 </p>
 <ol style="list-style-type:none">
 <li><p>(5.1) &mdash; if <tt>T<ins>D</ins></tt> is <tt>bool</tt> or <tt>char_type</tt>, initializes <tt>value</tt> with <tt>v</tt>;</p></li>
-<li><p>(5.2) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>, 
+<li><p>(5.2) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;wchar_t&gt;(v)</tt>;</p></li>
-<li><p>(5.3) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type (<sref ref="[basic.fundamental]"/>) and 
+<li><p>(5.3) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type (<sref ref="[basic.fundamental]"/>) and
 <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;int&gt;(v)</tt>;</p></li>
-<li><p>(5.4) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned int)</tt>, 
+<li><p>(5.4) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned int)</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;unsigned int&gt;(v)</tt>;</p></li>
-<li><p>(5.5) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(long long int)</tt>, 
+<li><p>(5.5) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(long long int)</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;long long int&gt;(v)</tt>;</p></li>
 <li><p>(5.6) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned long long int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;unsigned long long int&gt;(v)</tt>;</p></li>
 
@@ -251,7 +251,7 @@ and <tt>TD</tt> otherwise.
 <tt><del><i>const-formattable</i></del>
 <ins><tt>formattable&lt;const TD, char_type&gt;</tt></ins>
 ||
-!is_const_v&lt;<del>remove_reference_t&lt;</del>T<del>&gt;</del></tt> 
+!is_const_v&lt;<del>remove_reference_t&lt;</del>T<del>&gt;</del></tt>
 is <tt>true</tt>.
 </p>
 <p>-19- <i>Effects</i>:
@@ -274,6 +274,8 @@ Initializes <tt>ptr_</tt> with <tt>addressof(val)</tt> and <tt>format_</tt> with
 </blockquote>
 
 <note>2022-11-10; Jonathan provides improved wording</note>
+
+<note>2022-11-29; Casey expands the issue to also cover <tt>make_format_args</tt></note>
 
 </discussion>
 
@@ -335,8 +337,8 @@ template&lt;class T&gt; explicit basic_format_arg(T&amp;<del>&amp;</del> v) noex
 typename Context::template formatter_type&lt;remove_cvref_t&lt;T&gt;&gt;
 </del></pre></blockquote>
 <p><del>
-meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent to 
-which an implementation determines that the specialization meets the <i>BasicFormatter</i> 
+meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent to
+which an implementation determines that the specialization meets the <i>BasicFormatter</i>
 requirements is unspecified, except that as a minimum the expression
 </del></p>
 <blockquote><pre><del>
@@ -357,13 +359,13 @@ If <tt>decay_t&lt;T&gt;</tt> is <tt>char_type*</tt> or <tt>const char_type*</tt>
 </p>
 <ol style="list-style-type:none">
 <li><p>(5.1) &mdash; if <tt>T<ins>D</ins></tt> is <tt>bool</tt> or <tt>char_type</tt>, initializes <tt>value</tt> with <tt>v</tt>;</p></li>
-<li><p>(5.2) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>, 
+<li><p>(5.2) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;wchar_t&gt;(v)</tt>;</p></li>
-<li><p>(5.3) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type (<sref ref="[basic.fundamental]"/>) and 
+<li><p>(5.3) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type (<sref ref="[basic.fundamental]"/>) and
 <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;int&gt;(v)</tt>;</p></li>
-<li><p>(5.4) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned int)</tt>, 
+<li><p>(5.4) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned int)</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;unsigned int&gt;(v)</tt>;</p></li>
-<li><p>(5.5) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(long long int)</tt>, 
+<li><p>(5.5) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is a signed integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(long long int)</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;long long int&gt;(v)</tt>;</p></li>
 <li><p>(5.6) &mdash; otherwise, if <tt>T<ins>D</ins></tt> is an unsigned integer type and <tt>sizeof(T<ins>D</ins>) &lt;= sizeof(unsigned long long int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;unsigned long long int&gt;(v)</tt>;</p></li>
 
@@ -483,6 +485,24 @@ Initializes <tt>ptr_</tt> with <tt>addressof(val)</tt> and <tt>format_</tt> with
 </p>
 </blockquote>
 </blockquote>
+</li>
+
+<li><p>Modify <sref ref="[format.arg.store]"/> p2 as indicated:</p>
+
+<blockquote>
+<pre>
+template&lt;class Context = format_context, class... Args&gt;
+  <i>format-arg-store</i>&lt;Context, Args...&gt; make_format_args(Args&amp;&amp;... fmt_args);
+</pre>
+<blockquote>
+<p>-2- <i>Preconditions</i>: The type
+<tt>typename Context::template formatter_type&lt;<ins>remove_cvref_t&lt;</ins>T</tt><sub>i</sub><tt><ins>&gt;</ins>&gt;</tt>
+meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>) for each <tt>T</tt><sub>i</sub>
+in <tt>Args</tt>.
+</p>
+</blockquote>
+</blockquote>
+
 </li>
 </ol>
 


### PR DESCRIPTION
... and fire another salvo in the war on trailing whitespace. The latest proposed resolution is relatively recent - provided by Jonathan on November 10 - so I assume that LWG hasn't yet looked at it and it's safe to amend rather than replace. Shout if I'm misunderstanding the process and I'll do a full replacement instead.