### PR TITLE
3862: jwakely's update missed one partial specialization

### DIFF
--- a/xml/issue3862.xml
+++ b/xml/issue3862.xml
@@ -10,7 +10,7 @@
 
 <discussion>
 <p>
-To make <tt>basic_const_iterator</tt> compatible with its unwrapped iterators, the standard defines the following 
+To make <tt>basic_const_iterator</tt> compatible with its unwrapped iterators, the standard defines the following
 <tt>common_type</tt> specialization:
 </p>
 <blockquote><pre>
@@ -20,13 +20,13 @@ struct common_type&lt;basic_const_iterator&lt;T&gt;, U&gt; {
 };
 </pre></blockquote>
 <p>
-For type <tt>U</tt>, when it shares a common type with the unwrapped type <tt>T</tt> of <tt>basic_const_iterator</tt>, 
+For type <tt>U</tt>, when it shares a common type with the unwrapped type <tt>T</tt> of <tt>basic_const_iterator</tt>,
 the common type of both is <tt>basic_const_iterator</tt> of the common type of <tt>T</tt> and <tt>U</tt>.
 <p/>
-However, since this specialization only constrains <tt>U</tt> and <tt>T</tt> to have a common type, 
-this allows <tt>U</tt> to be any type that satisfies such requirement, such as <tt>optional&lt;T&gt;</tt>, 
-in which case computing the common type of both would produce a hard error inside the specialization, 
-because <tt>basic_const_iterator</tt> requires the template parameter to be <tt>input_iterator</tt>, 
+However, since this specialization only constrains <tt>U</tt> and <tt>T</tt> to have a common type,
+this allows <tt>U</tt> to be any type that satisfies such requirement, such as <tt>optional&lt;T&gt;</tt>,
+in which case computing the common type of both would produce a hard error inside the specialization,
+because <tt>basic_const_iterator</tt> requires the template parameter to be <tt>input_iterator</tt>,
 while <tt>optional</tt> clearly isn't.
 </p>
 <p><strong>Previous resolution [SUPERSEDED]:</strong></p>
@@ -92,6 +92,11 @@ namespace std {
   template&lt;class T, common_with&lt;T&gt; U&gt;
     <ins>requires input_iterator&lt;common_type_t&lt;T, U&gt;&gt;</ins>
   struct common_type&lt;U, basic_const_iterator&lt;T&gt;&gt; {                                  // <i>freestanding</i>
+    using type = basic_const_iterator&lt;common_type_t&lt;T, U&gt;&gt;;
+  };
+  template&lt;class T, common_with&lt;T&gt; U&gt;
+    <ins>requires input_iterator&lt;common_type_t&lt;T, U&gt;&gt;</ins>
+  struct common_type&lt;basic_const_iterator&lt;T&gt;, basic_const_iterator&lt;U&gt;&gt; {            // <i>freestanding</i>
     using type = basic_const_iterator&lt;common_type_t&lt;T, U&gt;&gt;;
   };
   [&hellip;]


### PR DESCRIPTION
We should properly constrain all three partial specializations of `common_type` that involve `basic_const_iterator`. Thanks to hewillk for catching this.