### PR TITLE
3424: Improve resolution, expand to cover expected::value_or

### DIFF
--- a/xml/issue3424.xml
+++ b/xml/issue3424.xml
@@ -10,17 +10,17 @@
 
 <discussion>
 <p>
-The <tt>optional&lt;T&gt;::value_or</tt> overloads are specified to return <tt>T</tt>. This seems silly when 
-<tt>T</tt> is <tt>const</tt> or <tt>volatile</tt> qualified &mdash; return types should never be <i>cv</i>-qualified. 
-(In the <tt>volatile</tt> case, it is even deprecated since merging <a href="https://wg21.link/p1152r4">P1152R4</a> 
+The <tt>optional&lt;T&gt;::value_or</tt> overloads are specified to return <tt>T</tt>. This seems silly when
+<tt>T</tt> is <tt>const</tt> or <tt>volatile</tt> qualified &mdash; return types should never be <i>cv</i>-qualified.
+(In the <tt>volatile</tt> case, it is even deprecated since merging <a href="https://wg21.link/p1152r4">P1152R4</a>
 "Deprecating volatile" into the working draft.) We should strip <i>cv</i>-qualifiers from these return types.
 </p>
 
 <note>2020-04-18 Issue Prioritization</note>
 <p>Priority to 3 after reflector discussion.</p>
-</discussion>
 
-<resolution>
+<p><strong>Previous resolution [SUPERSEDED]:</strong></p>
+<blockquote class="note">
 <p>
 This wording is relative to <a href="https://wg21.link/n4861">N4861</a>.
 </p>
@@ -40,13 +40,6 @@ template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> val
 
 <li><p>Modify <sref ref="[optional.observe]"/> as indicated:</p>
 
-<blockquote class="note">
-<p>
-[<i>Drafting note:</i> The two removals of the <tt>&amp;&amp;</tt> in 
-<tt>is_convertible_v&lt;U&amp;&amp;, T&gt;</tt> below is just a drive-by simplification]
-</p>
-</blockquote>
-
 <blockquote>
 <pre>
 template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp; v) const&amp;;
@@ -55,7 +48,7 @@ template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> val
 <p>
 <ins>-?- Let <tt>R</tt> be <tt>remove_cv_t&lt;T&gt;</tt>.</ins>
 <p/>
--17- <i>Mandates:</i> <tt><del>is_copy_constructible_v&lt;T&gt;</del><ins>is_convertible_v&lt;const T&amp;, R&gt;</ins> 
+-17- <i>Mandates:</i> <tt><del>is_copy_constructible_v&lt;T&gt;</del><ins>is_convertible_v&lt;const T&amp;, R&gt;</ins>
 &amp;&amp; is_convertible_v&lt;U<del>&amp;&amp;</del>, T&gt;</tt> is <tt>true</tt>.
 <p/>
 -18- <i>Effects:</i> Equivalent to:
@@ -71,13 +64,135 @@ template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> val
 <p>
 <ins>-?- Let <tt>R</tt> be <tt>remove_cv_t&lt;T&gt;</tt>.</ins>
 <p/>
--19- <i>Mandates:</i> <tt><del>is_move_constructible_v&lt;T&gt;</del><ins>is_convertible_v&lt;T, R&gt;</ins> 
+-19- <i>Mandates:</i> <tt><del>is_move_constructible_v&lt;T&gt;</del><ins>is_convertible_v&lt;T, R&gt;</ins>
 &amp;&amp; is_convertible_v&lt;U<del>&amp;&amp;</del>, T&gt;</tt> is <tt>true</tt>.
 <p/>
 -20- <i>Effects:</i> Equivalent to:
 <blockquote><pre>
 return bool(*this) ? std::move(**this) : static_cast&lt;<del>T</del><ins>R</ins>&gt;(std::forward&lt;U&gt;(v));
 </pre></blockquote>
+</p>
+</blockquote>
+</blockquote>
+</li>
+</ol>
+</blockquote>
+
+<note>2023-02-09 Casey improves wording and expands to cover <tt>expected::value_or</tt></note>
+<p>Since <tt>expected</tt> was modeled on <tt>optional</tt>, it has the same issue.</p>
+</discussion>
+
+<resolution>
+<p>This wording is relative to <a href="https://wg21.link/n4928">N4928</a>.</p>
+
+<ol>
+<li><p>Modify <sref ref="[optional.optional.general]"/> as indicated:</p>
+
+<blockquote>
+<pre>
+[&hellip;]
+template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp;) const&amp;;
+template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp;) &amp;&amp;;
+[&hellip;]
+</pre>
+</blockquote>
+</li>
+
+<li><p>Modify <sref ref="[optional.observe]"/> as indicated:</p>
+
+<blockquote class="note">
+<p>
+[<i>Drafting note:</i> The two removals of the <tt>&amp;&amp;</tt> in
+<tt>is_convertible_v&lt;U&amp;&amp;, T&gt;</tt> below is a simplification to restore consistency
+with the wording for <tt>expected::value_or</tt>.]
+</p>
+</blockquote>
+
+<blockquote>
+<pre>
+template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp; v) const &amp;;
+</pre>
+<blockquote>
+<p>
+<ins>-?- Let <tt>R</tt> be <tt>remove_cv_t&lt;T&gt;</tt>.</ins>
+<p/>
+-15- <i>Mandates:</i> <tt>
+<del>is_copy_constructible_v&lt;T&gt;</del> <ins>is_convertible_v&lt;const T&amp;, R&gt;</ins> &amp;&amp;
+is_convertible_v&lt;U<del>&amp;&amp;</del>, <del>T</del><ins>R</ins>&gt;
+</tt> is <tt>true</tt>.
+<p/>
+-16- <i>Effects:</i> Equivalent to:
+<blockquote><pre>
+return bool(*this) ? **this : static_cast&lt;<del>T</del><ins>R</ins>&gt;(std::forward&lt;U&gt;(v));
+</pre></blockquote>
+</p>
+</blockquote>
+<pre>
+template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp; v) &amp;&amp;;
+</pre>
+<blockquote>
+<p>
+<ins>-?- Let <tt>R</tt> be <tt>remove_cv_t&lt;T&gt;</tt>.</ins>
+<p/>
+-17- <i>Mandates:</i> <tt>
+<del>is_move_constructible_v&lt;T&gt;</del> <ins>is_convertible_v&lt;T, R&gt;</ins> &amp;&amp;
+is_convertible_v&lt;U<del>&amp;&amp;</del>, <del>T</del><ins>R</ins>&gt;
+</tt> is <tt>true</tt>.
+<p/>
+-18- <i>Effects:</i> Equivalent to:
+<blockquote><pre>
+return bool(*this) ? std::move(**this) : static_cast&lt;<del>T</del><ins>R</ins>&gt;(std::forward&lt;U&gt;(v));
+</pre></blockquote>
+</p>
+</blockquote>
+</blockquote>
+</li>
+
+<li><p>Modify <sref ref="[expected.object.general]"/> as indicated:</p>
+
+<blockquote>
+<pre>
+[&hellip;]
+template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp;) const &amp;;
+template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp;) &amp;&amp;;
+[&hellip;]
+</pre>
+</blockquote>
+</li>
+
+<li><p>Modify <sref ref="[expected.object.obs]"/> as indicated:</p>
+
+<blockquote>
+<pre>
+template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp; v) const &amp;;
+</pre>
+<blockquote>
+<p>
+<ins>-?- Let <tt>R</tt> be <tt>remove_cv_t&lt;T&gt;</tt>.</ins>
+<p/>
+-16- <i>Mandates:</i> <tt>
+<del>is_copy_constructible_v&lt;T&gt;</del> <ins>is_convertible_v&lt;const T&amp;, R&gt;</ins> &amp;&amp;
+is_convertible_v&lt;U, <del>T</del><ins>R</ins>&gt;
+</tt> is <tt>true</tt>.
+<p/>
+-17- <i>Returns:</i>
+<tt>has_value() ? **this : static_cast&lt;<del>T</del><ins>R</ins>&gt;(std::forward&lt;U&gt;(v))</tt>.
+</p>
+</blockquote>
+<pre>
+template&lt;class U&gt; constexpr <ins>remove_cv_t&lt;</ins>T<ins>&gt;</ins> value_or(U&amp;&amp; v) &amp;&amp;;
+</pre>
+<blockquote>
+<p>
+<ins>-?- Let <tt>R</tt> be <tt>remove_cv_t&lt;T&gt;</tt>.</ins>
+<p/>
+-18- <i>Mandates:</i> <tt>
+<del>is_move_constructible_v&lt;T&gt;</del> <ins>is_convertible_v&lt;T, R&gt;</ins> &amp;&amp;
+is_convertible_v&lt;U, <del>T</del><ins>R</ins>&gt;
+</tt> is <tt>true</tt>.
+<p/>
+-19- <i>Returns:</i>
+<tt>has_value() ? std::move(**this) : static_cast&lt;<del>T</del><ins>R</ins>&gt;(std::forward&lt;U&gt;(v))</tt>.
 </p>
 </blockquote>
 </blockquote>


### PR DESCRIPTION
Nobody need rush to merge this - it's not critical for the meeting this week. I just noticed this issue in passing, and realized it should be expanded to cover `expected` as well as `optional`.