### PR TITLE
Mark more issues as resolved by papers/issues

### DIFF
--- a/xml/issue3412.xml
+++ b/xml/issue3412.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3412" status="New">
+<issue num="3412" status="Resolved">
 <title>&sect;[format.string.std] references to "Unicode encoding" unclear</title>
 <section><sref ref="[format.string.std]"/></section>
 <submitter>Hubert Tong</submitter>
@@ -10,20 +10,22 @@
 
 <discussion>
 <p>
-In <sref ref="[format.string.std]"/>, the meaning of "Unicode encoding" in the text added by 
+In <sref ref="[format.string.std]"/>, the meaning of "Unicode encoding" in the text added by
 <a href="https://wg21.link/p1868r2">P1868R2</a> (the "Unicorn width" paper) is unclear.
 <p/>
-One interpretation of what is meant by "Unicode encoding" is "UCS encoding scheme" 
-(as defined by ISO/IEC 10646). Another interpretation is an encoding scheme capable of 
-encoding all UCS code points that have been assigned to characters. Yet another interpretation 
+One interpretation of what is meant by "Unicode encoding" is "UCS encoding scheme"
+(as defined by ISO/IEC 10646). Another interpretation is an encoding scheme capable of
+encoding all UCS code points that have been assigned to characters. Yet another interpretation
 is an encoding scheme capable of encoding all UCS scalar values.
 <p/>
-SG16 reflector discussion (with the LWG reflector on CC) indicates that the third option 
-above is the closest to the intent of the study group. The situation of the current wording, 
+SG16 reflector discussion (with the LWG reflector on CC) indicates that the third option
+above is the closest to the intent of the study group. The situation of the current wording,
 which readers can easily read as indicating the first option above, is undesirable.
 </p>
 
 <note>2020-07-17; Priority set to 3 in telecon</note>
+
+<note>2023-03-22 Resolved by the adoption of <paper num="P2736R2"/> in Issaquah. Status changed: New &rarr; Resolved.</note>
 </discussion>
 
 <resolution>

--- a/xml/issue3565.xml
+++ b/xml/issue3565.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3565" status="SG16">
+<issue num="3565" status="Resolved">
 <title>Handling of encodings in localized formatting of <tt>chrono</tt> types is underspecified</title>
 <section><sref ref="[time.format]"/></section>
 <submitter>Victor Zverovich</submitter>
@@ -19,7 +19,7 @@ auto s = std::format("&Dcy;&iecy;&ncy;&softcy; &ncy;&iecy;&dcy;&iecy;&lcy;&icy;:
 <p>
 (Note that "<tt>{}</tt>" should be replaced with "<tt>{:L}</tt>" if <paper num="P2372"/> is adopted but that's non-essential.)
 <p/>
-If the literal encoding is UTF-8 and the <tt>"Russian.1251"</tt> locale exists we have a mismatch between encodings. 
+If the literal encoding is UTF-8 and the <tt>"Russian.1251"</tt> locale exists we have a mismatch between encodings.
 As far as I can see the standard doesn't specify what happens in this case.
 <p/>
 One possible and undesirable result is
@@ -38,7 +38,7 @@ Another possible and desirable result is
 <p>
 where everything is in one encoding (UTF-8).
 <p/>
-This issue is not resolved by LWG <iref ref="3547"/> / <paper num="P2372"/> but the resolution proposed here is 
+This issue is not resolved by LWG <iref ref="3547"/> / <paper num="P2372"/> but the resolution proposed here is
 compatible with P2372 and can be rebased onto its wording if the paper is adopted.
 </p>
 
@@ -47,9 +47,7 @@ compatible with P2372 and can be rebased onto its wording if the paper is adopte
 Set priority to 2 after reflector poll. Send to SG16.
 </p>
 
-</discussion>
-
-<resolution>
+<superseded>
 <p>
 This wording is relative to <a href="https://wg21.link/n4885">N4885</a>.
 </p>
@@ -59,17 +57,23 @@ This wording is relative to <a href="https://wg21.link/n4885">N4885</a>.
 
 <blockquote>
 <p>
--2- Each conversion specifier <i>conversion-spec</i> is replaced by appropriate characters as described in Table 
-[tab:time.format.spec]; the formats specified in ISO 8601:2004 shall be used where so described. Some of the 
-conversion specifiers depend on the locale that is passed to the formatting function if the latter takes one, 
-or the global locale otherwise. <ins>If the string literal encoding is UTF-8 the replacement of a conversion 
-specifier that depends on the locale is transcoded to UTF-8 for narrow strings, otherwise the replacement is 
-taken as is.</ins> If the formatted object does not contain the information the conversion specifier refers to, 
+-2- Each conversion specifier <i>conversion-spec</i> is replaced by appropriate characters as described in Table
+[tab:time.format.spec]; the formats specified in ISO 8601:2004 shall be used where so described. Some of the
+conversion specifiers depend on the locale that is passed to the formatting function if the latter takes one,
+or the global locale otherwise. <ins>If the string literal encoding is UTF-8 the replacement of a conversion
+specifier that depends on the locale is transcoded to UTF-8 for narrow strings, otherwise the replacement is
+taken as is.</ins> If the formatted object does not contain the information the conversion specifier refers to,
 an exception of type <tt>format_error</tt> is thrown.
 </p>
 </blockquote>
 </li>
 
 </ol>
+</superseded>
+
+<note>2023-03-22 Resolved by the adoption of <paper num="P2419R2"/> in the July 2022 virtual plenary. Status changed: SG16 &rarr; Resolved.</note>
+</discussion>
+
+<resolution>
 </resolution>
 </issue>

--- a/xml/issue3576.xml
+++ b/xml/issue3576.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3576" status="SG16">
+<issue num="3576" status="Resolved">
 <title>Clarifying fill character in <tt>std::format</tt></title>
 <section><sref ref="[format.string.std]"/></section>
 <submitter>Mark de Wever</submitter>
@@ -10,56 +10,56 @@
 
 <discussion>
 <p>
-The paper <paper num="P1868"/> "width: clarifying units of width and precision in 
-<tt>std::format</tt>" added optional Unicode support to the <tt>format</tt> header.  
+The paper <paper num="P1868"/> "width: clarifying units of width and precision in
+<tt>std::format</tt>" added optional Unicode support to the <tt>format</tt> header.
 This paper didn't update the definition of the fill character, which is defined as
 </p>
 <blockquote><p>
 "The fill character can be any character other than <tt>{</tt> or <tt>}</tt>."
 </p></blockquote>
 <p>
-This wording means the fill is a character and not a Unicode grapheme cluster. Based 
-on the current wording the range of available fill characters depends on the 
-<tt>char_type</tt> of the format string. After P1868 the determination of the required 
-padding size is Unicode aware, but it's not possible to use a Unicode grapheme clusters 
-as padding. This looks odd from a user's perspective and already lead to implementation 
+This wording means the fill is a character and not a Unicode grapheme cluster. Based
+on the current wording the range of available fill characters depends on the
+<tt>char_type</tt> of the format string. After P1868 the determination of the required
+padding size is Unicode aware, but it's not possible to use a Unicode grapheme clusters
+as padding. This looks odd from a user's perspective and already lead to implementation
 divergence between libc++ and MSVC STL:
 </p>
 <ul>
 <li><p>The WIP libc++ implementation stores one <tt>char_type</tt>, strictly adhering
 to the wording of the Standard.</p></li>
-<li><p>MSVC STL stores one code point, regardless of the <tt>char_type</tt> used. This 
-is already better from a user's perspective; all 1 code point grapheme clusters are 
+<li><p>MSVC STL stores one code point, regardless of the <tt>char_type</tt> used. This
+is already better from a user's perspective; all 1 code point grapheme clusters are
 properly handled.</p></li>
 </ul>
 <p>
-For the width calculation the width of a Unicode grapheme cluster is estimated to be 1 or 2. 
-Since padding with a 2 column width can't properly pad an odd number of columns the grapheme 
+For the width calculation the width of a Unicode grapheme cluster is estimated to be 1 or 2.
+Since padding with a 2 column width can't properly pad an odd number of columns the grapheme
 cluster used should always have a column width of 1.
 <p/>
-The responsibility for precondition can be either be validated in the library or by the user. 
-It would be possible to do the validation compile time and make the code ill-formed when the 
+The responsibility for precondition can be either be validated in the library or by the user.
+It would be possible to do the validation compile time and make the code ill-formed when the
 precondition is violated. For the following reason I think it's better to not validate
 the width:
 </p>
 <ul>
 <li><p>P1868 14. Implementation</p>
 <blockquote><p>
-"More importantly, our approach permits refining the definition in the future if there is 
-interest in doing so. It will mostly require researching the status of Unicode support on 
+"More importantly, our approach permits refining the definition in the future if there is
+interest in doing so. It will mostly require researching the status of Unicode support on
 terminals and minimal or no changes to the implementation."
 </p></blockquote>
-<p>When an estimated width of 1 is required it means that improving the Standard may make 
+<p>When an estimated width of 1 is required it means that improving the Standard may make
 previously valid code ill-formed after the improvement.</p></li>
 <li><p>P1868 13. Examples</p>
-<p>The example of the family grapheme cluster is only rendered properly on the MacOS terminal. 
-So even when the library does a proper validation it's not certain the output will be 
+<p>The example of the family grapheme cluster is only rendered properly on the MacOS terminal.
+So even when the library does a proper validation it's not certain the output will be
 rendered properly.</p></li>
 </ul>
 <p>
 Changing the fill type changes the size of the <tt>std::formatter</tt> and thus will be an ABI break.
 <p/>
-The proposed resolution probably needs some additional changes since the Unicode and output 
+The proposed resolution probably needs some additional changes since the Unicode and output
 width are specified later in the standard, specifically <sref ref="[format.string.std]"/>/9 - 12.
 </p>
 
@@ -74,13 +74,13 @@ This wording is relative to <a href="https://wg21.link/n4892">N4892</a>.
 
 <blockquote>
 <p>
--2- [<i>Note 2</i>: <del>The <i>fill</i> character can be any character other than <tt>{</tt> or <tt>}</tt>.</del> 
-<ins>For a string in a Unicode encoding, the <i>fill</i> character can be any Unicode grapheme cluster 
-other than <tt>{</tt> or <tt>}</tt>. For a string in a non-Unicode encoding, the <i>fill</i> character 
-can be any character other than <tt>{</tt> or <tt>}</tt>. The output width of the fill character is 
-always assumed to be one column.</ins> The presence of a fill character is signaled by the character 
-following it, which must be one of the alignment options. If the second character of <i>std-format-spec</i> 
-is not a valid alignment option, then it is assumed that both the fill character and the alignment 
+-2- [<i>Note 2</i>: <del>The <i>fill</i> character can be any character other than <tt>{</tt> or <tt>}</tt>.</del>
+<ins>For a string in a Unicode encoding, the <i>fill</i> character can be any Unicode grapheme cluster
+other than <tt>{</tt> or <tt>}</tt>. For a string in a non-Unicode encoding, the <i>fill</i> character
+can be any character other than <tt>{</tt> or <tt>}</tt>. The output width of the fill character is
+always assumed to be one column.</ins> The presence of a fill character is signaled by the character
+following it, which must be one of the alignment options. If the second character of <i>std-format-spec</i>
+is not a valid alignment option, then it is assumed that both the fill character and the alignment
 option are absent. &mdash; <i>end note</i>]
 </p>
 </blockquote>
@@ -118,14 +118,14 @@ This wording is relative to <a href="https://wg21.link/n4892">N4892</a>.
 </pre>
 </blockquote>
 <p>
--2- <del>[<i>Note 2</i>: The <i>fill</i> character can be any character other than <tt>{</tt> or <tt>}</tt>.</del> 
-<ins>For a string in a Unicode encoding, the <i>fill</i> character can be any Unicode grapheme cluster 
-other than <tt>{</tt> or <tt>}</tt>. For a string in a non-Unicode encoding, the <i>fill</i> character 
-can be any character other than <tt>{</tt> or <tt>}</tt>. The output width of the fill character is 
-always assumed to be one column.</ins> 
+-2- <del>[<i>Note 2</i>: The <i>fill</i> character can be any character other than <tt>{</tt> or <tt>}</tt>.</del>
+<ins>For a string in a Unicode encoding, the <i>fill</i> character can be any Unicode grapheme cluster
+other than <tt>{</tt> or <tt>}</tt>. For a string in a non-Unicode encoding, the <i>fill</i> character
+can be any character other than <tt>{</tt> or <tt>}</tt>. The output width of the fill character is
+always assumed to be one column.</ins>
 <p/>
-<ins>[<i>Note 2</i>:</ins> The presence of a fill character is signaled by the character following it, which must be 
-one of the alignment options. If the second character of <i>std-format-spec</i> is not a valid alignment option, 
+<ins>[<i>Note 2</i>:</ins> The presence of a fill character is signaled by the character following it, which must be
+one of the alignment options. If the second character of <i>std-format-spec</i> is not a valid alignment option,
 then it is assumed that both the fill character and the alignment option are absent. &mdash; <i>end note</i>]
 </p>
 </blockquote>
@@ -136,15 +136,12 @@ then it is assumed that both the fill character and the alignment option are abs
 
 <note>2021-08-26; SG16 reviewed and provides alternative wording</note>
 
-<note>2023-01-11; LWG telecon
+<note>2023-01-11; LWG telecon</note>
 <p>
 <paper num="P2572"/> would resolve this issue and LWG <iref ref="3639"/>.
 </p>
-</note>
 
-</discussion>
-
-<resolution>
+<superseded>
 <p>
 This wording is relative to <a href="https://wg21.link/n4892">N4892</a>.
 </p>
@@ -160,20 +157,26 @@ This wording is relative to <a href="https://wg21.link/n4892">N4892</a>.
 <pre>
 [&hellip;]
 <i>fill</i>:
-             any <del>character</del><ins>codepoint of the literal encoding</ins> other than <tt>{</tt> or <tt>}</tt>
+                any <del>character</del><ins>codepoint of the literal encoding</ins> other than <tt>{</tt> or <tt>}</tt>
 [&hellip;]
 </pre>
 </blockquote>
 <p>
--2- [<i>Note 2</i>: The <i>fill</i> character can be any <del>character</del><ins>codepoint</ins> other than 
-<tt>{</tt> or <tt>}</tt>. The presence of a fill character is signaled by the character following it, which must be 
-one of the alignment options. If the second character of <i>std-format-spec</i> is not a valid alignment option, 
+-2- [<i>Note 2</i>: The <i>fill</i> character can be any <del>character</del><ins>codepoint</ins> other than
+<tt>{</tt> or <tt>}</tt>. The presence of a fill character is signaled by the character following it, which must be
+one of the alignment options. If the second character of <i>std-format-spec</i> is not a valid alignment option,
 then it is assumed that both the fill character and the alignment option are absent. &mdash; <i>end note</i>]
 </p>
 </blockquote>
 </li>
 
 </ol>
+</superseded>
+
+<note>2023-03-22 Resolved by the adoption of <paper num="P2572R1"/> in Issaquah. Status changed: SG16 &rarr; Resolved.</note>
+</discussion>
+
+<resolution>
 </resolution>
 
 </issue>

--- a/xml/issue3639.xml
+++ b/xml/issue3639.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3639" status="SG16">
+<issue num="3639" status="Resolved">
 <title>Handling of fill character width is underspecified in <tt>std::format</tt></title>
 <section><sref ref="[format.string.std]"/></section>
 <submitter>Victor Zverovich</submitter>
@@ -10,7 +10,7 @@
 
 <discussion>
 <p>
-<sref ref="[format.string.std]"/> doesn't specify if implementations should consider the estimated width 
+<sref ref="[format.string.std]"/> doesn't specify if implementations should consider the estimated width
 of the fill character when substituting it into the formatted results.
 <p/>
 For example:
@@ -24,9 +24,9 @@ auto s = std::format("{:&#x1F921;&gt;10}", 42);
 There are at least three possible resolutions:
 </p>
 <ol>
-<li><p><tt>s == "&#x1F921;&#x1F921;&#x1F921;&#x1F921;42"</tt>: use the estimated display width, 
+<li><p><tt>s == "&#x1F921;&#x1F921;&#x1F921;&#x1F921;42"</tt>: use the estimated display width,
 correctly displayed on compatible terminals.</p></li>
-<li><p><tt>s == "&#x1F921;&#x1F921;&#x1F921;&#x1F921;&#x1F921;&#x1F921;&#x1F921;&#x1F921;42"</tt>: 
+<li><p><tt>s == "&#x1F921;&#x1F921;&#x1F921;&#x1F921;&#x1F921;&#x1F921;&#x1F921;&#x1F921;42"</tt>:
 assume the display width of 1, incorrectly displayed.</p></li>
 <li><p>Require the fill character to have the estimated width of 1.</p></li>
 </ol>
@@ -46,6 +46,7 @@ Set priority to 3 after reflector poll. Sent to SG16.
 <paper num="P2572"/> would resolve this issue and LWG <iref ref="3576"/>.
 </p>
 
+<note>2023-03-22 Resolved by the adoption of <paper num="P2572R1"/> in Issaquah. Status changed: SG16 &rarr; Resolved.</note>
 </discussion>
 
 <resolution>

--- a/xml/issue3698.xml
+++ b/xml/issue3698.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3698" status="Open">
+<issue num="3698" status="Resolved">
 <title><tt>regex_iterator</tt> and <tt>join_view</tt> don't work together very well</title>
 <section><sref ref="[re.iter]"/><sref ref="[range.join]"/></section>
 <submitter>Barry Revzin</submitter>
@@ -39,35 +39,35 @@ int main() {
 }
 </pre></blockquote>
 <p>
-This example seems sound, having <tt>lower</tt> be a range of <tt>string_view</tt> that should refer 
-back into <tt>text</tt>, which is in scope for all this time. The <tt>std::regex</tt> object is also 
+This example seems sound, having <tt>lower</tt> be a range of <tt>string_view</tt> that should refer
+back into <tt>text</tt>, which is in scope for all this time. The <tt>std::regex</tt> object is also
 in scope for all this time.
 <p/>
-Yet, if run this through address sanitizer, this blows up in the first call to the dereference operator 
+Yet, if run this through address sanitizer, this blows up in the first call to the dereference operator
 of the underlying <tt>transform_view</tt>'s iterator with heap-use-after-free.
 <p/>
-The problem here is ultimately that <tt>regex_iterator</tt> is a stashing iterator (it has a member 
-<tt>match_results</tt>) yet advertises itself as a <tt>forward_iterator</tt> (despite violating 
+The problem here is ultimately that <tt>regex_iterator</tt> is a stashing iterator (it has a member
+<tt>match_results</tt>) yet advertises itself as a <tt>forward_iterator</tt> (despite violating
 <sref ref="[forward.iterators]"/> p6 and <sref ref="[iterator.concept.forward]"/> p3.
 <p/>
-Then, <tt>join_view</tt>'s iterator stores an outer iterator (the <tt>regex_iterator</tt>) and an 
-<tt>inner_iterator</tt> (an iterator into the container that the <tt>regex_iterator</tt> stashes). 
-Copying that iterator effectively invalidates it &mdash; since the new iterator's inner iterator will 
-refer to the old iterator's outer iterator's container. These aren't (and can't be) independent copies. 
-In this particular example, <tt>join_view</tt>'s <tt>begin</tt> iterator is copied into the 
-<tt>transform_view</tt>'s iterator, and then the original is destroyed (which owns the container that 
+Then, <tt>join_view</tt>'s iterator stores an outer iterator (the <tt>regex_iterator</tt>) and an
+<tt>inner_iterator</tt> (an iterator into the container that the <tt>regex_iterator</tt> stashes).
+Copying that iterator effectively invalidates it &mdash; since the new iterator's inner iterator will
+refer to the old iterator's outer iterator's container. These aren't (and can't be) independent copies.
+In this particular example, <tt>join_view</tt>'s <tt>begin</tt> iterator is copied into the
+<tt>transform_view</tt>'s iterator, and then the original is destroyed (which owns the container that
 the new inner iterator still points to), which causes us to have a dangling iterator.
 <p/>
-Note that the example is well-formed in libc++ because libc++ moves instead of copying an iterator, 
+Note that the example is well-formed in libc++ because libc++ moves instead of copying an iterator,
 which happens to work. But I can produce other non-transform-view related examples that fail.
 <p/>
 This is actually two different problems:
 </p>
 <ol>
-<li><p><tt>regex_iterator</tt> is really an input iterator, not a forward iterator. It does not meet either 
+<li><p><tt>regex_iterator</tt> is really an input iterator, not a forward iterator. It does not meet either
 the C++17 or the C++20 forward iterator requirements.</p></li>
-<li><p><tt>join_view</tt> can't handle stashing iterators, and would need to additionally store the outer 
-iterator in a non-propagating-cache for input ranges (similar to how it already potentially stores the 
+<li><p><tt>join_view</tt> can't handle stashing iterators, and would need to additionally store the outer
+iterator in a non-propagating-cache for input ranges (similar to how it already potentially stores the
 inner iterator in a non-propagating-cache).</p></li>
 </ol>
 <p>
@@ -84,9 +84,10 @@ Set priority to 2 after reflector poll.
 
 <note>2023-01-16; Tim comments</note>
 <p>
-The paper <paper num="D2770R0"/> is provided with proposed wording.
+The paper <paper num="P2770R0"/> is provided with proposed wording.
 </p>
 
+<note>2023-03-22 Resolved by the adoption of <paper num="P2770R0"/> in Issaquah. Status changed: Open &rarr; Resolved.</note>
 </discussion>
 
 <resolution>

--- a/xml/issue3700.xml
+++ b/xml/issue3700.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3700" status="New">
+<issue num="3700" status="Resolved">
 <title>The <tt>const begin</tt> of the <tt>join_view</tt> family does not require <tt><i>InnerRng</i></tt> to be a range</title>
 <section><sref ref="[range.join.view]"/><sref ref="[range.join.with.view]"/></section>
 <submitter>Hewill Kang</submitter>
@@ -24,7 +24,7 @@ constexpr auto begin() const
 </pre>
 </blockquote>
 <p>
-which only requires <tt><i>InnerRng</i></tt> to be a reference type, but in some cases, <tt><i>InnerRng</i></tt> 
+which only requires <tt><i>InnerRng</i></tt> to be a reference type, but in some cases, <tt><i>InnerRng</i></tt>
 may not be a <tt>range</tt>. <a href="https://godbolt.org/z/P8baTb5ee">Consider</a>
 </p>
 <blockquote>
@@ -41,8 +41,8 @@ int main() {
 </pre>
 </blockquote>
 <p>
-The reference type of <tt>single_view</tt> is <tt>const split_view&amp;</tt>, which only has the non-<tt>const</tt> 
-version of <tt>begin</tt>, which will cause <tt>view_interface</tt>'s <tt>const front</tt> to be incorrectly 
+The reference type of <tt>single_view</tt> is <tt>const split_view&amp;</tt>, which only has the non-<tt>const</tt>
+version of <tt>begin</tt>, which will cause <tt>view_interface</tt>'s <tt>const front</tt> to be incorrectly
 instantiated, making <tt>r.front()</tt> unnecessarily ill-formed.
 </p>
 <p>
@@ -55,9 +55,7 @@ We should add this check for <tt>join_view</tt>'s <tt>const begin</tt>, as well 
 Set priority to 3 after reflector poll.
 </p>
 
-</discussion>
-
-<resolution>
+<superseded>
 <p>
 This wording is relative to <paper num="N4910"/>.
 </p>
@@ -82,21 +80,21 @@ namespace std::ranges {
     constexpr auto begin() {
       [&hellip;]
     }
-    
-    constexpr auto begin() const 
+
+    constexpr auto begin() const
       requires input_range&lt;const V&gt; &amp;&amp;
-               <ins>input_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;</ins>
-               is_reference_v&lt;range_reference_t&lt;const V&gt;&gt;
+                <ins>input_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;</ins>
+                is_reference_v&lt;range_reference_t&lt;const V&gt;&gt;
     { return <i>iterator</i>&lt;true&gt;{*this, ranges::begin(<i>base_</i>)}; }
-    
+
     constexpr auto end() {
       [&hellip;]
     }
-    
+
     constexpr auto end() const
       requires input_range&lt;const V&gt; &amp;&amp;
-               <ins>input_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;</ins>
-               is_reference_v&lt;range_reference_t&lt;const V&gt;&gt; {
+                <ins>input_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;</ins>
+                is_reference_v&lt;range_reference_t&lt;const V&gt;&gt; {
       if constexpr (forward_range&lt;const V&gt; &amp;&amp;
                     forward_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;
                     common_range&lt;const V&gt; &amp;&amp;
@@ -106,9 +104,9 @@ namespace std::ranges {
         return <i>sentinel</i>&lt;true&gt;{*this};
     }
   };
-  
+
   [&hellip;]
-  
+
 }
 </pre>
 </blockquote>
@@ -135,21 +133,21 @@ namespace std::ranges {
     constexpr auto begin() {
       [&hellip;]
     }
-    constexpr auto begin() const 
+    constexpr auto begin() const
       requires input_range&lt;const V&gt; &amp;&amp;
-               forward_range&lt;const Pattern&gt; &amp;&amp;
-               <ins>input_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;</ins>
-               is_reference_v&lt;range_reference_t&lt;const V&gt;&gt; { 
-      return <i>iterator</i>&lt;true&gt;{*this, ranges::begin(<i>base_</i>)}; 
+                forward_range&lt;const Pattern&gt; &amp;&amp;
+                <ins>input_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;</ins>
+                is_reference_v&lt;range_reference_t&lt;const V&gt;&gt; {
+      return <i>iterator</i>&lt;true&gt;{*this, ranges::begin(<i>base_</i>)};
     }
-  
+
     constexpr auto end() {
       [&hellip;]
     }
     constexpr auto end() const
       requires input_range&lt;const V&gt; &amp;&amp; forward_range&lt;const Pattern&gt; &amp;&amp;
-               <ins>input_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;</ins>
-               is_reference_v&lt;range_reference_t&lt;const V&gt;&gt; {
+                <ins>input_range&lt;range_reference_t&lt;const V&gt;&gt; &amp;&amp;</ins>
+                is_reference_v&lt;range_reference_t&lt;const V&gt;&gt; {
       using InnerConstRng = range_reference_t&lt;const V&gt;;
       if constexpr (forward_range&lt;const V&gt; &amp;&amp; forward_range&lt;InnerConstRng&gt; &amp;&amp;
                     common_range&lt;const V&gt; &amp;&amp; common_range&lt;InnerConstRng&gt;)
@@ -158,14 +156,20 @@ namespace std::ranges {
         return <i>sentinel</i>&lt;true&gt;{*this};
     }
   };
-  
+
   [&hellip;]
-  
+
 }
 </pre>
 </blockquote>
 </li>
 </ol>
+</superseded>
+
+<note>2023-03-22 Resolved by the adoption of <paper num="P2770R0"/> in Issaquah. Status changed: New &rarr; Resolved.</note>
+</discussion>
+
+<resolution>
 </resolution>
 
 </issue>

--- a/xml/issue3718.xml
+++ b/xml/issue3718.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3718" status="New">
+<issue num="3718" status="Resolved">
 <title>P2418R2 broke the overload resolution for <tt>std::basic_format_arg</tt></title>
 <section><sref ref="[format.arg]"/></section>
 <submitter>Jiang An</submitter>
@@ -10,17 +10,17 @@
 
 <discussion>
 <p>
-While correcting some bugs in MSVC STL, 
-<a href="https://github.com/microsoft/STL/pull/2768#discussion_r892950656">it is found that</a> 
-<paper num="P2418R2"/> broke the overload resolution involving non-const lvalue: constructing 
-<tt>basic_format_arg</tt> from a non-<tt>const basic_string</tt> lvalue incorrectly selects the 
-<tt>T&amp;&amp;</tt> overload and uses <tt>handle</tt>, while the separated <tt>basic_string</tt> 
-overload should be selected (i.e. the old behavior before P2418R2 did the right thing). Currently 
-MSVC STL is using a workaround that treats <tt>basic_string</tt> to be as if passed by value 
+While correcting some bugs in MSVC STL,
+<a href="https://github.com/microsoft/STL/pull/2768#discussion_r892950656">it is found that</a>
+<paper num="P2418R2"/> broke the overload resolution involving non-const lvalue: constructing
+<tt>basic_format_arg</tt> from a non-<tt>const basic_string</tt> lvalue incorrectly selects the
+<tt>T&amp;&amp;</tt> overload and uses <tt>handle</tt>, while the separated <tt>basic_string</tt>
+overload should be selected (i.e. the old behavior before P2418R2 did the right thing). Currently
+MSVC STL is using a workaround that treats <tt>basic_string</tt> to be as if passed by value
 during overload resolution.
 <p/>
-I think the <tt>T&amp;&amp;</tt> overload should not interfere the old result of overload resolution, 
-which means that when a type is <tt>const</tt>-formattable, the newly added non-<tt>const</tt> 
+I think the <tt>T&amp;&amp;</tt> overload should not interfere the old result of overload resolution,
+which means that when a type is <tt>const</tt>-formattable, the newly added non-<tt>const</tt>
 mechanism shouldn't be considered.
 </p>
 
@@ -31,16 +31,14 @@ Set priority to 2 after reflector poll.
 
 <note>2022-10-19; Would be resolved by <iref ref="3631"/></note>
 
-</discussion>
-
-<resolution>
+<superseded>
 <p>
 This wording is relative to <paper num="N4910"/>.
 </p>
 
 <blockquote class="note">
 <p>
-[<i>Drafting note:</i> The below presented wording adds back the <tt>const T&amp;</tt> constructor and its specification 
+[<i>Drafting note:</i> The below presented wording adds back the <tt>const T&amp;</tt> constructor and its specification
 that were present before <paper num="P2418R2"/>. Furthermore it adds an additional constraint to the <tt>T&amp;&amp;</tt>
 constructor and simplifies the <i>Effects</i> of this constructors to the <tt>handle</tt> construction case.]
 </p>
@@ -57,7 +55,7 @@ namespace std {
   class basic_format_arg {
   public:
     class handle;
-    
+
   private:
     [&hellip;]
     template&lt;class T&gt; explicit basic_format_arg(T&amp;&amp; v) noexcept; <i>// exposition only</i>
@@ -79,8 +77,8 @@ template&lt;class T&gt; explicit basic_format_arg(T&amp;&amp; v) noexcept;
 typename Context::template formatter_type&lt;remove_cvref_t&lt;T&gt;&gt;
 </pre></blockquote>
 <p>
-meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent 
-to which an implementation determines that the specialization meets the <i>BasicFormatter</i> 
+meets the <i>BasicFormatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent
+to which an implementation determines that the specialization meets the <i>BasicFormatter</i>
 requirements is unspecified, except that as a minimum the expression
 </p>
 <blockquote><pre>
@@ -88,25 +86,25 @@ typename Context::template formatter_type&lt;remove_cvref_t&lt;T&gt;&gt;()
   .format(declval&lt;T&amp;&gt;(), declval&lt;Context&amp;&gt;())
 </pre></blockquote>
 <p>
-shall be well-formed when treated as an unevaluated operand (<sref ref="[expr.context]"/>)<ins>, and 
-if this overload were not declared, the overload resolution  would find no usable candidate or be 
-ambiguous. [<i>Note ?</i>: This overload has no effect if the overload resolution among other 
+shall be well-formed when treated as an unevaluated operand (<sref ref="[expr.context]"/>)<ins>, and
+if this overload were not declared, the overload resolution  would find no usable candidate or be
+ambiguous. [<i>Note ?</i>: This overload has no effect if the overload resolution among other
 overloads succeeds. &mdash; <i> end note</i>]</ins>.
 <p/>
 -5- <i>Effects</i>:
 </p>
 <ol style="list-style-type:none">
-<li><p><del>(5.1) &mdash; if <tt>T</tt> is <tt>bool</tt> or <tt>char_type</tt>, initializes <tt>value</tt> 
+<li><p><del>(5.1) &mdash; if <tt>T</tt> is <tt>bool</tt> or <tt>char_type</tt>, initializes <tt>value</tt>
 with <tt>v</tt>;</del></p></li>
-<li><p><del>(5.2) &mdash; otherwise, if <tt>T</tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>, 
+<li><p><del>(5.2) &mdash; otherwise, if <tt>T</tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;wchar_t&gt;(v)</tt>;</del></p></li>
-<li><p><del>(5.3) &mdash; otherwise, if <tt>T</tt> is a signed integer type (<sref ref="[basic.fundamental]"/>) 
+<li><p><del>(5.3) &mdash; otherwise, if <tt>T</tt> is a signed integer type (<sref ref="[basic.fundamental]"/>)
 and <tt>sizeof(T) &lt;= sizeof(int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;int&gt;(v)</tt>;</del></p></li>
-<li><p><del>(5.4) &mdash; otherwise, if <tt>T</tt> is an unsigned integer type and <tt>sizeof(T) &lt;= 
+<li><p><del>(5.4) &mdash; otherwise, if <tt>T</tt> is an unsigned integer type and <tt>sizeof(T) &lt;=
 sizeof(unsigned int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;unsigned int&gt;(v)</tt>;</del></p></li>
-<li><p><del>(5.5) &mdash; otherwise, if <tt>T</tt> is a signed integer type and <tt>sizeof(T) &lt;= 
+<li><p><del>(5.5) &mdash; otherwise, if <tt>T</tt> is a signed integer type and <tt>sizeof(T) &lt;=
 sizeof(long long int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;long long int&gt;(v)</tt>;</del></p></li>
-<li><p><del>(5.6) &mdash; otherwise, if <tt>T</tt> is an unsigned integer type and <tt>sizeof(T) &lt;= 
+<li><p><del>(5.6) &mdash; otherwise, if <tt>T</tt> is an unsigned integer type and <tt>sizeof(T) &lt;=
 sizeof(unsigned long long int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;unsigned long long int&gt;(v)</tt>;</del></p></li>
 <li><p><del>(5.7) &mdash; otherwise, i</del><ins>I</ins>nitializes <tt>value</tt> with <tt>handle(v)</tt>.</p></li>
 </ol>
@@ -122,8 +120,8 @@ sizeof(unsigned long long int)</tt>, initializes <tt>value</tt> with <tt>static_
 <ins>typename Context::template formatter_type&lt;T&gt;</ins>
 </pre></blockquote>
 <p>
-<ins>meets the <i>Formatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent 
-to which an implementation determines that the specialization meets the <i>Formatter</i> 
+<ins>meets the <i>Formatter</i> requirements (<sref ref="[formatter.requirements]"/>). The extent
+to which an implementation determines that the specialization meets the <i>Formatter</i>
 requirements is unspecified, except that as a minimum the expression</ins>
 </p>
 <blockquote><pre>
@@ -136,17 +134,17 @@ requirements is unspecified, except that as a minimum the expression</ins>
 <ins>-?- <i>Effects</i>:</ins>
 </p>
 <ol style="list-style-type:none">
-<li><p><ins>(?.1) &mdash; if <tt>T</tt> is <tt>bool</tt> or <tt>char_type</tt>, initializes <tt>value</tt> 
+<li><p><ins>(?.1) &mdash; if <tt>T</tt> is <tt>bool</tt> or <tt>char_type</tt>, initializes <tt>value</tt>
 with <tt>v</tt>;</ins></p></li>
-<li><p><ins>(?.2) &mdash; otherwise, if <tt>T</tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>, 
+<li><p><ins>(?.2) &mdash; otherwise, if <tt>T</tt> is <tt>char</tt> and <tt>char_type</tt> is <tt>wchar_t</tt>,
 initializes <tt>value</tt> with <tt>static_cast&lt;wchar_t&gt;(v)</tt>;</ins></p></li>
-<li><p><ins>(?.3) &mdash; otherwise, if <tt>T</tt> is a signed integer type (<sref ref="[basic.fundamental]"/>) 
+<li><p><ins>(?.3) &mdash; otherwise, if <tt>T</tt> is a signed integer type (<sref ref="[basic.fundamental]"/>)
 and <tt>sizeof(T) &lt;= sizeof(int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;int&gt;(v)</tt>;</ins></p></li>
-<li><p><ins>(?.4) &mdash; otherwise, if <tt>T</tt> is an unsigned integer type and <tt>sizeof(T) &lt;= 
+<li><p><ins>(?.4) &mdash; otherwise, if <tt>T</tt> is an unsigned integer type and <tt>sizeof(T) &lt;=
 sizeof(unsigned int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;unsigned int&gt;(v)</tt>;</ins></p></li>
-<li><p><ins>(?.5) &mdash; otherwise, if <tt>T</tt> is a signed integer type and <tt>sizeof(T) &lt;= 
+<li><p><ins>(?.5) &mdash; otherwise, if <tt>T</tt> is a signed integer type and <tt>sizeof(T) &lt;=
 sizeof(long long int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;long long int&gt;(v)</tt>;</ins></p></li>
-<li><p><ins>(?.6) &mdash; otherwise, if <tt>T</tt> is an unsigned integer type and <tt>sizeof(T) &lt;= 
+<li><p><ins>(?.6) &mdash; otherwise, if <tt>T</tt> is an unsigned integer type and <tt>sizeof(T) &lt;=
 sizeof(unsigned long long int)</tt>, initializes <tt>value</tt> with <tt>static_cast&lt;unsigned long long int&gt;(v)</tt>;</ins></p></li>
 <li><p><ins>(?.7) &mdash; otherwise, initializes <tt>value</tt> with <tt>handle(v)</tt>.</ins></p></li>
 </ol>
@@ -157,6 +155,12 @@ sizeof(unsigned long long int)</tt>, initializes <tt>value</tt> with <tt>static_
 </li>
 
 </ol>
+</superseded>
+
+<note>2023-03-22 Resolved by the adoption of <iref ref="3631"/> in Issaquah. Status changed: New &rarr; Resolved.</note>
+</discussion>
+
+<resolution>
 </resolution>
 
 </issue>

--- a/xml/issue3780.xml
+++ b/xml/issue3780.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3780" status="SG16">
+<issue num="3780" status="Resolved">
 <title><tt>format</tt>'s width estimation is too approximate and not forward compatible</title>
 <section><sref ref="[format.string.std]"/></section>
 <submitter>Corentin Jabot</submitter>
@@ -10,7 +10,7 @@
 
 <discussion>
 <p>
-For the purpose of width estimation, <tt>format</tt> considers ranges of codepoints initially 
+For the purpose of width estimation, <tt>format</tt> considers ranges of codepoints initially
 derived from an implementation of <tt>wcwidth</tt> with modifications (see <paper num="P1868R1"/>).
 <p/>
 This however present a number of challenges:
@@ -18,10 +18,10 @@ This however present a number of challenges:
 <blockquote>
 <ul>
 <li><p>From a reading of the spec, it is not clear how these ranges were selected.</p></li>
-<li><p>Poor forward compatibility with future Unicode versions. The list will become less and 
-less meaningful overtime or require active maintenance at each Unicode release (which 
+<li><p>Poor forward compatibility with future Unicode versions. The list will become less and
+less meaningful overtime or require active maintenance at each Unicode release (which
 we have not done for Unicode 14 already).</p></li>
-<li><p>Some of these codepoints are unassigned or otherwise reserved, which is another 
+<li><p>Some of these codepoints are unassigned or otherwise reserved, which is another
 forward compatibility concern.</p></li>
 </ul>
 </blockquote>
@@ -31,8 +31,8 @@ Instead, we propose to
 <blockquote>
 <ul>
 <li><p>Rely on <a href="https://www.unicode.org/reports/tr11/">UAX-11</a> for most of the codepoints)</p></li>
-<li><p>Grand-father specific and fully assigned, blocks of codepoints to support additional pictograms 
-per the original intent of the paper and existing practices. We add the name of these blocks 
+<li><p>Grand-father specific and fully assigned, blocks of codepoints to support additional pictograms
+per the original intent of the paper and existing practices. We add the name of these blocks
 in the wording for clarity.</p></li>
 </ul>
 </blockquote>
@@ -53,8 +53,8 @@ This change:
 <ul>
 <li><p>Considers 8477 extra codepoints as having a width 2 (as of Unicode 15) (mostly Tangut Ideographs)</p></li>
 <li><p>Change the width of 85 unassigned code points from 2 to 1</p></li>
-<li><p>Change the width of 8 codepoints (in the range <tt>U+3248 CIRCLED NUMBER TEN ON BLACK SQUARE</tt> 
-&hellip; <tt>U+324F CIRCLED NUMBER EIGHTY ON BLACK SQUARE</tt>) from 2 to 1, because it seems 
+<li><p>Change the width of 8 codepoints (in the range <tt>U+3248 CIRCLED NUMBER TEN ON BLACK SQUARE</tt>
+&hellip; <tt>U+324F CIRCLED NUMBER EIGHTY ON BLACK SQUARE</tt>) from 2 to 1, because it seems
 questionable to make an exception for those without input from Unicode</p></li>
 </ul>
 </blockquote>
@@ -166,9 +166,7 @@ For the following code points, the estimated width used to be 2, and is 1 after 
 Set priority to 3 after reflector poll. Send to SG16.
 </p>
 
-</discussion>
-
-<resolution>
+<superseded>
 <p>
 This wording is relative to <paper num="N4917"/>.
 </p>
@@ -198,7 +196,7 @@ of a string are defined by UAX #29. The estimated width of the following code po
 <li><p><del>(12.12) &mdash; U+1F900 &ndash; U+1F9FF</del></p></li>
 <li><p><del>(12.13) &mdash; U+20000 &ndash; U+2FFFD</del></p></li>
 <li><p><del>(12.14) &mdash; U+30000 &ndash; U+3FFFD</del></p></li>
-<li><p><ins>(?.1) &mdash; Any code point with the <tt>East_Asian_Width="W"</tt> or <tt>East_Asian_Width="F"</tt> 
+<li><p><ins>(?.1) &mdash; Any code point with the <tt>East_Asian_Width="W"</tt> or <tt>East_Asian_Width="F"</tt>
 Derived Extracted Property as described by UAX #44</ins></p></li>
 <li><p><ins>(?.2) &mdash; U+4DC0 &ndash; U+4DFF (Yijing Hexagram Symbols)</ins></p></li>
 <li><p><ins>(?.3) &mdash; U+1F300 &ndash; U+1F5FF (Miscellaneous Symbols and Pictographs)</ins></p></li>
@@ -211,6 +209,12 @@ The estimated width of other code points is 1.
 </li>
 
 </ol>
+</superseded>
+
+<note>2023-03-22 Resolved by the adoption of <paper num="P2675R1"/> in Issaquah. Status changed: SG16 &rarr; Resolved.</note>
+</discussion>
+
+<resolution>
 </resolution>
 
 </issue>

--- a/xml/issue3791.xml
+++ b/xml/issue3791.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3791" status="New">
+<issue num="3791" status="Resolved">
 <title><tt>join_view::<i>iterator</i>::operator--</tt> may be ill-formed</title>
 <section><sref ref="[range.join.iterator]"/></section>
 <submitter>Hewill Kang</submitter>
@@ -22,7 +22,7 @@ return *this;
 </pre></blockquote>
 <p>
 which uses <tt>ranges::end(*--<i>outer_</i>)</tt> to get the sentinel of the inner range.
-However, <tt>*--<i>outer_</i></tt> may return an rvalue reference to a non-borrowed range, 
+However, <tt>*--<i>outer_</i></tt> may return an rvalue reference to a non-borrowed range,
 in which case calling <tt>ranges::end</tt> will be ill-formed,
 <a href="https://godbolt.org/z/s4bxTWfqv">for example</a>:
 </p>
@@ -38,8 +38,8 @@ int main() {
 }
 </pre></blockquote>
 <p>
-The proposed resolution uses a temporary reference to bind <tt>*--<i>outer_</i></tt>, so that 
-<tt>ranges::end</tt> is always invoked on an lvalue range, which is consistent with the behavior of 
+The proposed resolution uses a temporary reference to bind <tt>*--<i>outer_</i></tt>, so that
+<tt>ranges::end</tt> is always invoked on an lvalue range, which is consistent with the behavior of
 <tt>join_with_view::<i>iterator</i>::operator--</tt>.
 </p>
 
@@ -52,9 +52,7 @@ Set priority to 3 after reflector poll.
 <code>auto as_lvalue = []&lt;class T&gt;(T&amp;&amp; x) -&gt; T&amp; { return (T&amp;)x; };</code>) and use it throughout."
 </p>
 
-</discussion>
-
-<resolution>
+<superseded>
 <p>
 This wording is relative to <paper num="N4917"/>.
 </p>
@@ -66,8 +64,8 @@ This wording is relative to <paper num="N4917"/>.
 <pre>
 constexpr <i>iterator</i>&amp; operator--()
   requires <i>ref-is-glvalue</i> &amp;&amp; bidirectional_range&lt;<i>Base</i>&gt; &amp;&amp;
-           bidirectional_range&lt;range_reference_t&lt;<i>Base</i>&gt;&gt; &amp;&amp;
-           common_range&lt;range_reference_t&lt;<i>Base</i>&gt;&gt;;
+            bidirectional_range&lt;range_reference_t&lt;<i>Base</i>&gt;&gt; &amp;&amp;
+            common_range&lt;range_reference_t&lt;<i>Base</i>&gt;&gt;;
 </pre>
 </blockquote>
 <p>
@@ -91,6 +89,13 @@ return *this;
 </pre></blockquote>
 </li>
 </ol>
+</superseded>
+
+<note>2023-03-22 Resolved by the adoption of <paper num="P2770R0"/> in Issaquah. Status changed: New &rarr; Resolved.</note>
+
+</discussion>
+
+<resolution>
 </resolution>
 
 </issue>

--- a/xml/issue3859.xml
+++ b/xml/issue3859.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="3859" status="New">
+<issue num="3859" status="Resolved">
 <title><tt>std::projected</tt> cannot handle proxy iterator</title>
 <section><sref ref="[projected]"/></section>
 <submitter>Hewill Kang</submitter>
@@ -10,7 +10,7 @@
 
 <discussion>
 <p>
-Currently, <tt>std::projected</tt> is heavily used in <tt>&lt;algorithm&gt;</tt> to transform the original iterator into 
+Currently, <tt>std::projected</tt> is heavily used in <tt>&lt;algorithm&gt;</tt> to transform the original iterator into
 a new readable type for concept checking, which has the following definition:
 </p>
 <blockquote><pre>
@@ -21,20 +21,20 @@ struct projected {
 };
 </pre></blockquote>
 <p>
-It provides the member type <tt>value_type</tt>, which is defined as the cvref-unqualified of a projection function 
-applied to the reference of the iterator, this seems reasonable since this is how iterators are usually defined for 
+It provides the member type <tt>value_type</tt>, which is defined as the cvref-unqualified of a projection function
+applied to the reference of the iterator, this seems reasonable since this is how iterators are usually defined for
 the value type.
 <p/>
-However, this does not apply to C++20 proxy iterators such as <tt>zip_view::<i>iterator</i></tt>, we cannot obtain 
+However, this does not apply to C++20 proxy iterators such as <tt>zip_view::<i>iterator</i></tt>, we cannot obtain
 the <tt>tuple</tt> of value by simply removing the <i>cvref</i>-qualifier of the <tt>tuple</tt> of reference.<br/>
-This incorrect definition allows us to unethically bypass the constraint checking of the constraint algorithm, 
+This incorrect definition allows us to unethically bypass the constraint checking of the constraint algorithm,
 <a href="https://godbolt.org/z/98h36M4d8">for example</a>:
 </p>
 <blockquote><pre>
 #include &lt;algorithm&gt;
 #include &lt;ranges&gt;
 #include &lt;vector&gt;
-  
+
 struct Cmp {
   bool operator()(std::tuple&lt;int&amp;&gt;, std::tuple&lt;int&amp;&gt;) const;
   bool operator()(auto, auto) const = delete;
@@ -46,9 +46,9 @@ int main() {
 }
 </pre></blockquote>
 <p>
-In the above example, the value type and reference of the original iterator <tt>I</tt> are <tt>tuple&lt;int&gt;</tt> 
-and <tt>tuple&lt;int&amp;&gt;</tt> respectively, however, the value type and reference of <tt>projected&lt;I, identity&gt;</tt> 
-will be <tt>tuple&lt;int&amp;&gt;</tt> and <tt>tuple&lt;int&amp;&gt;&amp;&amp;</tt>, which makes the constraint only 
+In the above example, the value type and reference of the original iterator <tt>I</tt> are <tt>tuple&lt;int&gt;</tt>
+and <tt>tuple&lt;int&amp;&gt;</tt> respectively, however, the value type and reference of <tt>projected&lt;I, identity&gt;</tt>
+will be <tt>tuple&lt;int&amp;&gt;</tt> and <tt>tuple&lt;int&amp;&gt;&amp;&amp;</tt>, which makes the constraint only
 require that the comparator can compare two <tt>tuple&lt;int&amp;&gt;</tt>s, resulting in a hard error in the implementation.
 </p>
 
@@ -57,17 +57,15 @@ require that the comparator can compare two <tt>tuple&lt;int&amp;&gt;</tt>s, res
 Set priority to 3 after reflector poll.
 </p>
 
-</discussion>
-
-<resolution>
+<superseded>
 <p>
 This wording is relative to <paper num="N4928"/>.
 </p>
 
 <blockquote class="note">
 <p>
-[<i>Drafting note:</i> The proposed resolution is to alias <tt>projected</tt> as <tt>I</tt> when the projection function 
-is exactly <tt>identity</tt>. This form of type aliasing has similarities to the proposed wording of 
+[<i>Drafting note:</i> The proposed resolution is to alias <tt>projected</tt> as <tt>I</tt> when the projection function
+is exactly <tt>identity</tt>. This form of type aliasing has similarities to the proposed wording of
 <paper num="P2538R1"/>, except for the nested <tt>struct type</tt>. &mdash; <i>end drafting note</i>]
 </p>
 </blockquote>
@@ -94,10 +92,10 @@ namespace std {
 <li><p>Modify <sref ref="[projected]"/> as indicated:</p>
 
 <blockquote>
-<p> 
--1- Class template <tt>projected</tt> is used to constrain algorithms that accept callable objects and projections 
-(<sref ref="[defns.projection]"/>). It combines a <tt>indirectly_readable</tt> type <tt>I</tt> and a callable object 
-type <tt>Proj</tt> into a new <tt>indirectly_readable</tt> type whose <tt>reference</tt> type is the result of applying 
+<p>
+-1- Class template <tt>projected</tt> is used to constrain algorithms that accept callable objects and projections
+(<sref ref="[defns.projection]"/>). It combines a <tt>indirectly_readable</tt> type <tt>I</tt> and a callable object
+type <tt>Proj</tt> into a new <tt>indirectly_readable</tt> type whose <tt>reference</tt> type is the result of applying
 <tt>Proj</tt> to the <tt>iter_reference_t</tt> of <tt>I</tt>.
 </p>
 <blockquote><pre>
@@ -122,6 +120,12 @@ namespace std {
 </li>
 
 </ol>
+</superseded>
+
+<note>2023-03-22 Resolved by the adoption of <paper num="P2609R3"/> in Issaquah. Status changed: New &rarr; Resolved.</note>
+</discussion>
+
+<resolution>
 </resolution>
 
 </issue>

--- a/xml/issue3884.xml
+++ b/xml/issue3884.xml
@@ -11,13 +11,13 @@
 
 <discussion>
 <p>
-This issue is part of the "<tt>flat_<i>foo</i></tt>" sequence, LWG <iref ref="3786"/>, <iref ref="3802"/>, 
-<iref ref="3803"/>, <iref ref="3804"/>. <tt>flat_set</tt>, <tt>flat_multiset</tt>, <tt>flat_map</tt>, and 
-<tt>flat_multimap</tt> all have implicitly defaulted copy and move constructors, but they lack 
+This issue is part of the "<tt>flat_<i>foo</i></tt>" sequence, LWG <iref ref="3786"/>, <iref ref="3802"/>,
+<iref ref="3803"/>, <iref ref="3804"/>. <tt>flat_set</tt>, <tt>flat_multiset</tt>, <tt>flat_map</tt>, and
+<tt>flat_multimap</tt> all have implicitly defaulted copy and move constructors, but they lack
 allocator-extended versions of those constructors. This means that the following code is broken:
 </p>
 <blockquote><pre>
-// <a href="https://godbolt.org/z/qezv5rTrW"/>https://godbolt.org/z/qezv5rTrW<a/>
+// <a href="https://godbolt.org/z/qezv5rTrW">https://godbolt.org/z/qezv5rTrW</a>
 #include &lt;cassert&gt;
 #include &lt;flat_set&gt;
 #include &lt;memory_resource&gt;
@@ -37,7 +37,7 @@ int main() {
 }
 </pre></blockquote>
 <p>
-<tt>pmr_flat_set&lt;int&gt;</tt> advertises that it "<tt>uses_allocator</tt>" <tt>std::pmr::polymorphic_allocator&lt;int&gt;</tt>, 
+<tt>pmr_flat_set&lt;int&gt;</tt> advertises that it "<tt>uses_allocator</tt>" <tt>std::pmr::polymorphic_allocator&lt;int&gt;</tt>,
 but in fact it lacks the allocator-extended constructor overload set necessary to interoperate with <tt>std::pmr::vector</tt>.
 </p>
 
@@ -107,10 +107,10 @@ template&lt;class InputIterator, class Allocator&gt;
 </pre>
 <blockquote>
 <p>
--11- <i>Constraints</i>: <tt>uses_allocator_v&lt;key_container_type, Allocator<ins>&gt;</ins></tt> is <tt>true</tt> and 
+-11- <i>Constraints</i>: <tt>uses_allocator_v&lt;key_container_type, Allocator<ins>&gt;</ins></tt> is <tt>true</tt> and
 <tt>uses_allocator_v&lt;mapped_container_type, Allocator&gt;</tt> is <tt>true</tt>.
 <p/>
--12- <i>Effects</i>: Equivalent to the corresponding non-allocator constructors except that <tt>c.keys</tt> and 
+-12- <i>Effects</i>: Equivalent to the corresponding non-allocator constructors except that <tt>c.keys</tt> and
 <tt>c.values</tt> are constructed with uses-allocator construction (<sref ref="[allocator.uses.construction]"/>).
 </p>
 </blockquote>
@@ -129,7 +129,7 @@ namespace std {
   public:
     [&hellip;]
     // <i><sref ref="[flat.multimap.cons]"/>, construct/copy/destroy</i>
-    flat_multimap() : flat_multimap(key_compare()) { }  
+    flat_multimap() : flat_multimap(key_compare()) { }
 
     <ins>template&lt;class Allocator&gt;
       flat_multimap(const flat_multimap&amp;, const Allocator&amp; a);
@@ -159,10 +159,10 @@ template&lt;class Allocator&gt;
 </pre>
 <blockquote>
 <p>
--11- <i>Constraints</i>: <tt>uses_allocator_v&lt;key_container_type, Allocator&gt;</tt> is <tt>true</tt> and 
+-11- <i>Constraints</i>: <tt>uses_allocator_v&lt;key_container_type, Allocator&gt;</tt> is <tt>true</tt> and
 <tt>uses_allocator_v&lt;mapped_container_type, Allocator&gt;</tt> is <tt>true</tt>.
 <p/>
--12- <i>Effects</i>: Equivalent to the corresponding non-allocator constructors except that <tt>c.keys</tt> and 
+-12- <i>Effects</i>: Equivalent to the corresponding non-allocator constructors except that <tt>c.keys</tt> and
 <tt>c.values</tt> are constructed with uses-allocator construction (<sref ref="[allocator.uses.construction]"/>).
 </p>
 </blockquote>
@@ -181,7 +181,7 @@ namespace std {
     [&hellip;]
     // <i><sref ref="[flat.set.cons]"/>, constructors</i>
     flat_set() : flat_set(key_compare()) { }
-    
+
     <ins>template&lt;class Allocator&gt;
       flat_set(const flat_set&amp;, const Allocator&amp; a);
     template&lt;class Allocator&gt;
@@ -212,7 +212,7 @@ template&lt;class Allocator&gt;
 <p>
 -9- <i>Constraints</i>: <tt>uses_allocator_v&lt;container_type, Allocator&gt;</tt> is <tt>true</tt>.
 <p/>
--10- <i>Effects</i>: Equivalent to the corresponding non-allocator constructors except that <tt><i>c</i></tt> is 
+-10- <i>Effects</i>: Equivalent to the corresponding non-allocator constructors except that <tt><i>c</i></tt> is
 constructed with uses-allocator construction (<sref ref="[allocator.uses.construction]"/>).
 </p>
 </blockquote>
@@ -231,7 +231,7 @@ namespace std {
     [&hellip;]
     // <i><sref ref="[flat.multiset.cons]"/>, constructors</i>
     flat_multiset() : flat_multiset(key_compare()) { }
-    
+
     <ins>template&lt;class Allocator&gt;
       flat_multiset(const flat_multiset&amp;, const Allocator&amp; a);
     template&lt;class Allocator&gt;
@@ -262,7 +262,7 @@ template&lt;class Allocator&gt;
 <p>
 -9- <i>Constraints</i>: <tt>uses_allocator_v&lt;container_type, Allocator&gt;</tt> is <tt>true</tt>.
 <p/>
--10- <i>Effects</i>: Equivalent to the corresponding non-allocator constructors except that <tt><i>c</i></tt> is 
+-10- <i>Effects</i>: Equivalent to the corresponding non-allocator constructors except that <tt><i>c</i></tt> is
 constructed with uses-allocator construction (<sref ref="[allocator.uses.construction]"/>).
 </p>
 </blockquote>


### PR DESCRIPTION
In most cases the resolving paper references the issue. Two exceptions:

- [3412](https://wg21.link/LWG3412) is resolved by [P2736R2](https://wg21.link/P2736R2), which removed the phrase "Unicode encoding" entirely from [format.string.std].
- [3859](https://wg21.link/LWG3859) is resolved by [P2609R3](https://wg21.link/P2609R3), which fixes `projected`'s interaction with the indirect callable concepts.

There's also a drive-by formatting fix for 3884.