### PR TITLE
Add title attributes to <iref> and <paper> links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ R*-mailing.zip
 /meta-data/annex-f
 /meta-data/networking-annex-f
 /meta-data/dates
+/meta-data/index.json

--- a/bin/make_paper_titles.py
+++ b/bin/make_paper_titles.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+
+import json
+import sys
+import re
+
+with open(sys.argv[1]) as f:
+    for num,data in json.load(f).items():
+        if re.match(r'^(P\d\d\d\dR\d+|N\d\d\d\d)$', num):
+            print("{} {}".format(num, data['title']))

--- a/how-to-docs.html
+++ b/how-to-docs.html
@@ -106,6 +106,10 @@ to tell the makefile where to find the LaTeX sources.
 </li>
 </ol>
 <p>If you are happy with the deltas of the <code>annex-f</code> files, commit them to Git.</p>
+<p>
+To update the list of paper titles, run <code> make new-papers </code>
+(this needs <code>curl</code> and <code>python</code> to be installed).
+</p>
 
 <h2>Generate Issues Lists for a Mailing</h2>
 <p>We no longer include lists of issues, accepted/resolved issues, and rejected/closed issues in each mailing.

--- a/meta-data/paper_titles.txt
+++ b/meta-data/paper_titles.txt
@@ -1,0 +1,8871 @@
+N1208 Core Language Issues List (Revision 9)
+N1212 J16 Record of Discussion
+N1213 WG21 Formal Minutes
+N1214 J16 Formal Minutes
+N1215 Exit Processing Order
+N1216 Allocating Zero Bytes or Objects
+N1217 Core WG Defect Resolutions
+N1218 Clarifying the Definition of Accessible Base Class (Rev. 3)
+N1219 Proposed Resolution to Library Issue 60
+N1220 Library Motion for Kona
+N1221 Minutes of US TAG Meeting
+N1222 C++ Standard Library Defect Report List (Revision 11)
+N1223 C++ Standard Library Closed Issues List (Revision 11)
+N1224 C++ Standard Library Active Issues List (Revision 11)
+N1225 Agenda, SC22/WG21, C++, Tokyo, Japan
+N1226 C++ Standard Library Active Issues List (Revision 12)
+N1227 C++ Standard Library Defect Report List (Revision 12)
+N1228 C++ Standard Library Closed Issues List (Revision 12)
+N1229 Friend Declaration Issues
+N1230 Agenda, J16 Meeting No. 30, WG21 Meeting No. 25
+N1231 Miscellaneous Template Issues for Tokyo Meeting
+N1232 The core language auto_ptr problem
+N1233 Technical Report on Basic I/O Hardware Addressing
+N1234 Proposed Resolution for Core Issue 73
+N1235 October 2000 Meeting of WG21/J16 Travel Information
+N1236 C++ Standard Core Language Active Issues, Revision 10
+N1237 C++ Standard Core Language Defect Reports, Revision 10
+N1238 C++ Standard Core Language Closed Issues, Revision 10
+N1239 C++ Standard Core Language Active Issues, Revision 12
+N1240 C++ Standard Core Language Defect Reports, Revision 12
+N1241 C++ Standard Core Language Closed Issues, Revision 12
+N1242 C++ Standard Library Active Issues List (Revision 14)
+N1243 C++ Standard Library Closed Issues List (Revision 14)
+N1244 C++ Standard Library Defect Report List (Revision 14)
+N1245 Binder Problem and Reference Proposal (Revised)
+N1246 Fixing valarray for Real-World Use
+N1247 Programmer-directed Optimizations
+N1248 Draft Technical Report on Performance Issues
+N1249 Drafting from Tokyo Meeting — Revision 2
+N1250 Library Motions for Tokyo
+N1251 Definition of Dependent Name
+N1252 Shades of Namespace std Functions
+N1253 Minutes, SC22/WG21, C++, Tokyo, Japan
+N1254 Member Access Control — Proposed Revisions
+N1255 Minutes, J16 + WG21 Meeting, Tokyo
+N1256 Agenda, SC22/WG21, C++, Toronto, Canada
+N1257 Business Plan and Convener's Report, ISO/IEC JTCI/SC22/WG21(C++)
+N1258 ROM-ability (Performance Group)
+N1259 C++ Standard Library Active Issues List (Revision 15)
+N1260 C++ Standard Library Closed Issues List (Revision 15)
+N1261 C++ Standard Library Defect Report List (Revision 15)
+N1262 Agenda, J16 Meeting No. 31, WG21 Meeting No. 26
+N1263 Default Arguments and Friend Declarations
+N1265 C++ Standard Core Language Active Issues, Revision 13
+N1266 C++ Standard Core Language Defect Reports, Revision 13
+N1267 C++ Standard Core Language Closed Issues, Revision 13
+N1268 Member Access Control and Nested Classes
+N1269 C++ Standard Library Active Issues List (Revision 16)
+N1270 C++ Standard Library Closed Issues List (Revision 16)
+N1271 C++ Standard Library Defect Report List (Revision 16)
+N1272 C++ Standard Core Language Active Issues, Revision 15
+N1273 C++ Standard Core Language Defect Reports, Revision 15
+N1274 C++ Standard Core Language Closed Issues, Revision 15
+N1275 Minutes of ISO WG21 Meeting, October 22, 2000
+N1276 Minutes of ANSI J16 and ISO WG21 Co-located Meeting, October 23-27, 2000
+N1278 October 2001 WG14/WG21 Meeting
+N1279 Definition of Dependent Name - Revision 2
+N1280 Formal Motions
+N1281 Performance TR - Working Paper
+N1282 Request for Library TR
+N1283 A New Work Item Proposal: Technical Report for Library Issues
+N1285 Minutes of U.S. TAG Meeting, October 27, 2000
+N1286 The point of destruction of a call argument temporary
+N1287 Agenda, SC22/WG21, C++, Copenhagen, Denmark
+N1288 Agenda, J16 Meeting No.32, WG21 Meeting No. 27, April 30-May 4, 2001
+N1289 Library issues 225 and 229
+N1290 Extensions for the programming language C to support embedded proces
+N1291 C++ Standard Library Active Issues List (Revision 17)
+N1292 C++ Standard Library Defect Report List (Revision 17)
+N1293 C++ Standard Library Closed Issues List (Revision 17)
+N1294 October 2001 WG14/WG21 Meeting
+N1295 Partial Specialization of Function Templates
+N1296 User-supplied Specializations of Standard Library Algorithms
+N1297 Improved Iterator Categories and Requirements
+N1298 C++ Core Language Active Issues, Revision 16
+N1299 C++ Core Language Defect Reports, Revision 16
+N1300 C++ Core Language Closed Issues, Revision 16
+N1301 DTR 14652: Specification Method for Cultural Conventions
+N1302 Core WG Defect Resolutions
+N1303 Minutes of ISO WG21 Meeting, April 29, 2001
+N1304 Minutes of ANSI J16 and ISO WG21 Co-located Meeting, April 30-May 4,
+N1305 Agenda, SC22/WG21, C++, Redmond, Washington, USA
+N1306 C++ Core Language Active Issues, Revision 18
+N1307 C++ Core Language Defect Reports, Revision 18
+N1308 C++ Core Language Closed Issues, Revision 18
+N1309 Technical Report on C++ Performance (DRAFT)
+N1310 C++ Standard Library Active Issues List (Revision 18)
+N1311 C++ Standard Library Defect Report List (Revision 18)
+N1312 C++ Standard Library Closed Issues List (Revision 18)
+N1313 Binary Search with Heterogeneous Comparison
+N1314 Notes on standard library extensions
+N1315 Business Plan and Convenor's Report
+N1316 Draft Expanded Technical Corrigendum
+N1317 C++ Standard Library Active Issues List (Revision 19)
+N1318 C++ Standard Library Defect Report List (Revision 19)
+N1319 C++ Standard Library Closed Issues List (Revision 19)
+N1320 Agenda, J16 Meeting No.33, WG21 Meeting No. 28, October 22-26, 2001
+N1321 C++ Core Language Active Issues, Revision 19
+N1322 C++ Core Language Defect Reports, Revision 19
+N1323 C++ Core Language Closed Issues, Revision 19
+N1324 Issue 273: POD classes and operator&
+N1325 Library Technical Report Proposals List Trial Balloon
+N1326 A Proposal to Add Hashtables to the Standard Library
+N1327 Minutes of ISO WG21 Meeting, October 21, 2001
+N1328 Minutes of ANSI J16 and ISO WG21 Co-located Meeting, 22-26 October 2001
+N1329 Minutes of J16 TAG Meeting, 26 October 2001
+N1330 Spring 2002 Meeting
+N1331 ISO WG21 Meeting, October 21, 2001 Record of Discussion
+N1332 ANSI J16 and ISO WG21 Co-located Meeting, 22-26 October 2001 Record of Discussion
+N1333 J16 TAG Meeting, 26 October 2001 Record of Discussion
+N1334 Draft Consolidated Technical Corrigendum
+N1335 Agenda, SC22/WG21, C++, Curacao
+N1336 Technical Report on C++ Performance (DRAFT)
+N1337 C++ Standard Library Active Issues List (Revision 20)
+N1338 C++ Standard Library Defect Report List (Revision 20)
+N1339 C++ Standard Library Closed Issues List (Revision 20)
+N1340 WG21 and J16 (C++) Joint Mailing and Meeting Information
+N1341 C++ Standard Core Language Active Issues, Revision 20
+N1342 C++ Standard Core Language Defect Reports, Revision 20
+N1343 C++ Standard Core Language Closed Issues, Revision 20
+N1344 Namespaces and Library Versioning
+N1345 Type Traits Proposal
+N1346 Agenda: J16 Meeting No. 34, WG21 Meeting No. 29, April 22-26, 2002
+N1347 C++ Standard Core Language Active Issues, Revision 21
+N1348 C++ Standard Core Language Defect Reports, Revision 21
+N1349 C++ Standard Core Language Closed Issues, Revision 21
+N1350 C++ Standard Library Active Issuess List (Revision 21)
+N1351 C++ Standard Library Defect Report List (Revision 21)
+N1352 C++ Standard Library Closed Issues List (Revision 21)
+N1353 Local Classes and Linkage
+N1354 Proposed C99 Library Additions to C++
+N1355 Technical Report on C++ Performance (DRAFT)
+N1356 Predictable data layout for certain non-POD types
+N1357 Minutes of ISO WG21 Meeting, April 21, 2002
+N1358 Minutes of ANSI J16 and ISO WG21 Co-located Meeting, 22-26 April 2002
+N1359 Technical Report on C++ Performance (DRAFT)
+N1360 const-correctness and other safety issues in clause 27: input/output library
+N1361 Library Technical Report Proposals and Issues List (Revision 3)
+N1362 Agenda for October 2002 Meeting of WG21
+N1363 C++ Support for Delegation
+N1364 Evolution WG Proposal Skeleton
+N1365 October 2002 meeting information in Santa Cruz CA
+N1366 C++ Standard Core Language Active Issues, Revision 22
+N1367 C++ Standard Core Language Defect Reports, Revision 22
+N1368 C++ Standard Core Language Closed Issues, Revision 22
+N1369 C++ Standard Library Active Issuess List (Revision 22)
+N1370 C++ Standard Library Defect Report List (Revision 22)
+N1371 C++ Standard Library Closed Issues List (Revision 22)
+N1372 Proposed C99 Library Additions to C++ (Revised)
+N1374 WG21 Business Plan and Convener's Report
+N1375 A Proposal to add a Polymorphic Function Object Wrapper to the Standard Library
+N1376 Consolidated edits for core issues 245, 254, et al.
+N1377 A Proposal to Add Move Semantics Support to the C++ Language
+N1378 C++ Standard Core Language Active Issues, Revision 23
+N1379 C++ Standard Core Language Defect Reports, Revision 23
+N1380 C++ Standard Core Language Closed Issues, Revision 23
+N1381 Proposal to Add Static Assertions to the Core Language
+N1382 Proposal for adding tuple type into the standard library
+N1383 Agenda: J16 Meeting No. 35, WG21 Meeting No. 30, October 21-25, 2002
+N1384 PME: Properties, methods and events
+N1385 The Forwarding Problem: Arguments
+N1386 A Proposal to add Regular Expressions to the Standard Library
+N1387 Proposed Resolution to LWG Issues 225, 226, 229
+N1388 Enhancing numerical support
+N1390 C++ Standard Library Active Issuess List (Revision 23)
+N1391 C++ Standard Library Defect Report List (Revision 23)
+N1392 C++ Standard Library Closed Issues List (Revision 23)
+N1393 Revisions to Partial Ordering Rules
+N1394 Some proposed extensions to C++ language
+N1395 Aspects of Forwarding (was C++ Support For Delegation)
+N1396 Technical Report on C++ Performance
+N1397 Library Technical Report Proposals and Issues List (Revision 4)
+N1398 A Proposal to Add an Extensible Random Number Facility to the Standard Library
+N1399 A proposal to add Hash Tables to the Standard Library (revision 2)
+N1400 Toward standardization of dynamic libraries
+N1401 Atomic operations with multi-threaded environments
+N1402 A Proposal to add a Polymorphic Function Object Wrapper to the Standard Library
+N1403 Proposal for adding tuple types into the standard library
+N1404 Evolution Working Group Record of Discussion
+N1405 Minutes of ANSI J16 and ISO WG21 Co-located Meeting, 21-25 October 2002
+N1406 Proposed Addition to C++: Typedef Templates
+N1408 Qualified Namespaces
+N1409 Minutes of ISO WG21 meeting, October 20, 2002
+N1411 C++ Standard Library Active Issuess List (Revision 24)
+N1412 C++ Standard Library Defect Report List (Revision 24)
+N1413 C++ Standard Library Closed Issues List (Revision 24)
+N1414 C++ Standard Core Language Active Issues, Revision 24
+N1415 C++ Standard Core Language Defect Reports, Revision 24
+N1416 C++ Standard Core Language Closed Issues, Revision 24
+N1417 Oxford meeting information
+N1418 Dynamic Libraries in C++
+N1419 WG21 Agenda
+N1420 Proposed Addition to C++: Class Namespaces
+N1421 Agenda: J16 Meeting No. 36, WG21 Meeting No. 31, April 7-11, 2003
+N1422 A Proposal to Add Mathematical Special Functions to the C++ Standard Library
+N1423 2003 Five-Year Maintenance Review
+N1424 A Proposal to add Type Traits to the Standard Library
+N1425 Proposal for Technical Report on C++ Standard Library Security
+N1426 Why We Can't Afford Export
+N1427 Making Local Templates more Useful
+N1428 Proposal for Dynamic Library Support in C++
+N1429 A Proposal to add Regular Expression to the Standard Library
+N1430 Technical Report on C++ Performance
+N1431 A Proposal to Add General Purpose Smart Pointers to the Library Technical Report
+N1432 A Proposal to Add an Enhanced Member Pointer Adaptor to the Library Technical Report
+N1433 C++ Standard Core Language Active Issues, Revision 25
+N1434 C++ Standard Core Language Defect Reports, Revision 25
+N1435 C++ Standard Core Language Closed Issues, Revision 25
+N1436 A proposal to add a reference wrapper to the standard library
+N1437 A uniform method for computing function object return types
+N1438 A Proposal to Add an Enhanced Binder to the Library Technical Report
+N1439 Proposed Resolution to LWG issues 225, 226, 229
+N1440 C++ Standard Library Active Issuess List (Revision 25)
+N1441 C++ Standard Library Defect Report List (Revision 25)
+N1442 C++ Standard Library Closed Issues List (Revision 25)
+N1443 A Proposal to Add Hash Tables to the Standard Library (revision 3)
+N1444 Library Technical Report Proposals and Issues List (Revision 5)
+N1445 Class defaults
+N1448 Controling Implicit Template Instantiation
+N1449 Proposal to add template aliases to C++
+N1450 A Proposal to Add General Purpose Smart Pointers to the Library Technical Report
+N1451 A Case for Template Aliasing
+N1452 A Proposal to Add an Extensible Random Number Facility to the Standard Library (Revision 2)
+N1453 A proposal to add a reference wrapper to the standard library (revision 1)
+N1454 A uniform method for computing function object return types (revision 1)
+N1455 A Proposal to Add an Enhanced Binder to the Library Technical Report (revision 1)
+N1456 A Proposal to Add Hash Tables to the Standard Library (revision 4)
+N1457 Technical Report on C++ Performance
+N1458 Minutes of ISO WG21 Meeting, April 6, 2003
+N1459 Minutes of J16 Meeting No. 36/WG21 Meeting No. 31, April 7-11, 2003
+N1460 WG21 agenda
+N1461 Security and Standard C Libraries
+N1462 Safe Exceptions and Compiler Security Checks
+N1463 Draft proposal for adding Multimethods to C++
+N1464 Anonymous array members
+N1465 Constant inheritance
+N1466 Expliciting default parameters
+N1467 Non default constructors for arrays
+N1468 Self methods
+N1469 Inline Constants
+N1470 Enum Type checking for SWITCH statements
+N1471 Reflective Metaprogramming in C++
+N1472 C++ Standard Core Language Active Issues, Revision 26
+N1473 C++ Standard Core Language Defect Reports, Revision 26
+N1474 C++ Standard Core Language Closed Issues, Revision 26
+N1475 Library Technical Report Proposals and Issues List (Revision 6)
+N1476 Iterator Facade and Adaptor
+N1477 New Iterator Concepts
+N1478 Decltype and auto
+N1479 A Proposal to Add a Fixed Size Array Wrapper to the Standard Library Technical Report
+N1480 C++ Standard Library Active Issues List (Revision 26)
+N1481 C++ Standard Library Defect Report List (Revision 26)
+N1482 C++ Standard Library Closed Issues List (Revision 26)
+N1483 Typesafe Variable-length Function and Template Argument Lists
+N1486 Business Plan and Convener's Report
+N1487 Technical Report on C++ Performance
+N1488 A name for the null pointer: nullptr
+N1489 Template aliases for C++
+N1490 Proposed resolution of core issue 301
+N1491 AGENDA, J16 Meeting No. 37, WG21 Meeting No. 32, October 27-31, 2003, Kona, Hawaii
+N1492 Exclusive Inheritance
+N1493 Braces Initialization Overloading
+N1494 Pure implementation method declaration
+N1496 Draft Proposal for Dynamic Libraries in C++ (Revision 1)
+N1499 Simplifying Interfaces in basic_regex
+N1500 Regular Expressions: Internationalization and Customization
+N1501 Information for March-April 2004 WG21/WG14 Meetings in Sydney, NSW Australia
+N1502 Proposed Signature Changes for Special Math Functions in TR-1
+N1503 Proposed Additions to TR-1 to Improve Compatibility with C99
+N1504 C++ Standard Core Language Active Issues, Revision 27
+N1505 C++ Standard Core Language Defect Reports, Revision 27
+N1506 C++ Standard Core Language Closed Issues, Revision 27
+N1507 Errata to the Regular Expression Proposal
+N1508 Proposal to add Deletion Traits to the Standard Library
+N1509 Generalized Initializer Lists
+N1510 Concept checking - A more abstract complement to type checking
+N1511 Literals for user-defined types
+N1512 Evolution WG issues list
+N1513 Improving Enumeration Types
+N1514 A Proposal to Add Mathematical Special Functions to the C++ Standard Library (version 2)
+N1515 C++ Standard Library Active Issuess List (Revision 27)
+N1516 C++ Standard Library Defect Report List (Revision 27)
+N1517 C++ Standard Library Closed Issues List (Revision 27)
+N1518 (Draft) Technical Report on Standard Library Extensions
+N1519 Type Traits Issue List
+N1520 Extended friend Declarations
+N1521 Generalized Constant Expressions
+N1522 Concepts - Design choices for template argument checking
+N1523 Proposed Resolution To LWG issues 225, 226, 229 (revision 1)
+N1524 Nested Namespace Definition Proposal
+N1526 Proposal to add namespace references to C++
+N1527 Mechanisms for querying types of expressions: decltype and auto revisited
+N1528 Syntactic Disambiguation Using the Template Keyword
+N1529 Draft proposal for adding Multimethods to C++
+N1530 Iterator Facade and Adaptor
+N1531 New Iterator Concepts
+N1532 WG20 liaison report
+N1534 Proposed addition of __func__ predefined identifier from C99
+N1535 Random Number Generators Issues List
+N1536 Concepts - syntax and composition
+N1537 C++ Standard Library Active Issues List (Revision 28)
+N1538 C++ Standard Library Defect Report List (Revision 28)
+N1539 C++ Standard Library Closed Issues List (Revision 28)
+N1540 (Draft) Technical Report on Standard Library Extensions
+N1541 Library Extension Technical Report - Issues List
+N1542 A Proposal to Add Mathematical Special Functions to the C++ Standard Library (version 3)
+N1543 Analysis and Proposed Resolution for Core Issue 39
+N1544 Comments about Issues with Random Number Generators
+N1545 Variadic Macros and Placemarkers
+N1546 Alignment Proposal
+N1547 Comments on the Initialization of Random Engines
+N1548 A Proposal to Add a Fixed Size Array Wrapper to the Standard Library Technical Report
+N1549 Const correctness in unordered associative containers
+N1550 New Iterator Concepts
+N1551 Changes to N1540 to Implement N1499 Parts 1 and 2
+N1552 Minutes of ISO WG21 Meeting, October 26, 2003
+N1553 Minutes of J16 Meeting No. 37/WG21 Meeting No. 32, October 27-31, 2003
+N1554 C++ Standard Core Language Active Issues, Revision 28
+N1555 C++ Standard Core Language Defect Reports, Revision 28
+N1556 C++ Standard Core Language Closed Issues, Revision 28
+N1557 C++/CLI Overview
+N1558 Library Technical Report Component Detection
+N1559 WG21 Agenda
+N1563 TG5 Liaison Report to WG21
+N1564 Core Issue 195 and "Conditionally-Supported Behavior"
+N1565 Adding the long long type to C++
+N1566 Synchronizing the C++ preprocessor with C99
+N1567 Critique of WG14/N1016 decimal floating-point arithmetic
+N1568 Proposed additions to TR-1 to improve compatibility with C99
+N1569 Proposed fixes to library inconsistencies
+N1570 Corrections to domain-error reporting for TR1 chapter on special math functions
+N1571 C++ Standard Core Language Active Issues, Revision 29
+N1572 C++ Standard Core Language Defect Reports, Revision 29
+N1573 C++ Standard Core Language Closed Issues, Revision 29
+N1575 Library Technical Report Component Detection (Revision 1)
+N1576 Filesystem library query
+N1577 Working Draft, Standard for Programming Language C++
+N1578 Editor's report
+N1579 Strongly Typed Enums
+N1580 AGENDA J16 Meeting No. 38 WG21 Meeting No. 33 March 22-26, 2004, Sydney Australia
+N1581 Delegating Constructors
+N1582 Compiler Generated Defaults
+N1583 Inheriting Constructors
+N1584 Regularizing Initialization Syntax
+N1585 Uniform Calling Syntax (Re-opening public interfaces)
+N1588 On Random-Number Distributions for C++0x
+N1589 complex and issue 387
+N1590 Smart Pointer Comparison Operators
+N1591 October 2004 Meeting Information
+N1592 Explicit Conversion Operators
+N1593 C++ Standard Library Active Issues List (Revision 29)
+N1594 C++ Standard Library Defect Report List (Revision 29)
+N1595 C++ Standard Library Closed Issues List (Revision 29)
+N1596 (Draft) Technical Report on Standard Library Extensions
+N1597 Library Extension Technical Report - Issues List
+N1598 Evolution WG issues list
+N1599 Issue 431: Swapping containers with unequal allocators
+N1600 C++/CLI Properties
+N1601 A name for the null pointer: nullptr (revision 2)
+N1602 Class Scope Using Declarations & private Members
+N1603 Variadic Templates
+N1604 Proposal to Add Static Assertions to the Core Language (Revision 1)
+N1605 Extending Template Type Parameters I: Namespace and scope
+N1607 Decltype and auto (revision 3)
+N1608 TG5 Liaison Report #2
+N1609 More on Issues with Random Number Generators in the Library TR Proposal
+N1610 Clarification of Initialization of Class Objects by rvalues
+N1611 Implicitly-Callable Functions in C++0x
+N1612 How we might remove the remaining shortcomings of std::complex<T>
+N1613 Proposal to add Design by Contract to C++
+N1614 #scope: A simple scoping mechanism for the C/C++ preprocessor
+N1615 C++ Properties — a Library Solution
+N1616 Extended friend Declarations (Rev. 1)
+N1617 Proposal to Add Static Assertions to the Core Language (Revision 2)
+N1618 Delegating Constructors (revision 1)
+N1619 Library Extension Technical Report — Issues List
+N1620 Dimension and Rank
+N1621 Resolution to TR issue 4.37
+N1622 Resolutions to unordered associative container issues
+N1623 Resolutions to regular expression issues
+N1624 Resolutions to fixed-size array issues
+N1625 #scope for C/C++
+N1626 Proposed Resolution for Core Issue 39 (Rev. 1)
+N1627 "Conditionally-Supported Behavior" (Rev. 1)
+N1628 Extensions for the Programming Language C++ to Support New Character Data Types
+N1629 Minutes of J16 Meeting No. 38/WG21 Meeting No. 33, March 22-26, 2004
+N1630 Minutes of ISO WG21 Meeting, March 21, 2004
+N1631 Electronic review process
+N1632 C++ Standard Core Language Active Issues, Revision 30
+N1633 C++ Standard Core Language Defect Reports, Revision 30
+N1634 C++ Standard Core Language Closed Issues, Revision 30
+N1635 C++ Standard Library Active Issues List (Revision 30)
+N1636 C++ Standard Library Defect Report List (Revision 30)
+N1637 C++ Standard Library Closed Issues List (Revision 30)
+N1638 Working Draft, Standard for Programming Language C++
+N1639 Editor's Report
+N1640 New Iterator Concepts
+N1641 Iterator Facade and Adaptor
+N1642 Adoption of C99's __func__ predefined identifier and improved default argument behavior
+N1647 (Draft) Technical Report on Standard Library Extensions
+N1648 Motivation, Objectives and Design Decisions
+N1649 Right Angle Brackets
+N1650 C++ Evolution Working Group — Active Proposals, Revision 1
+N1651 WG21 agenda
+N1652 WG21 Agenda
+N1653 Working draft changes for C99 preprocessor synchronization
+N1654 TG5 Liaison Report #3
+N1655 Unofficial Working Draft, Standard for Programming Language C++
+N1656 Editor's report
+N1657 C++ Standard Library Active Issues List (Revision 31)
+N1658 C++ Standard Library Defect Report List (Revision 31)
+N1659 C++ Standard Library Closed Issues List (Revision 31)
+N1660 (Draft) Technical Report on Standard Library Extensions
+N1661 Library Extension Technical Report - Issues List
+N1662 WG21 Business Plan and Convener's Report
+N1663 TG5 Liaison Report #4
+N1664 Toward Improved Optimization Opportunities in C++0x
+N1665 Guidelines for Domain Errors in Mathematical Special Functions
+N1666 Technical Report on C++ Performance
+N1667 Accessing the target of a tr1::function object
+N1668 A Proposal to add Mathematical Functions for Statistics to the C++ Standard Library
+N1669 Proposal to add Contract Programming to C++ (revision 1)
+N1671 Overloading Operator.() & Operator.*()
+N1672 Adapting N1640=04-0080 To C++0x
+N1673 Unifying TR1 Function Object Type Specifications
+N1674 A Proposal to Improve const_iterator Use from C++0X Containers
+N1675 TG5 Liaison Report #5
+N1676 Non-member overloaded copy assignment operator
+N1677 C++ Standard Core Language Active Issues, Revision 31
+N1678 C++ Standard Core Language Defect Reports, Revision 31
+N1679 C++ Standard Core Language Closed Issues, Revision 31
+N1680 Memory Model for multithreaded C++
+N1681 A Proposal to Add a Policy-Based Smart Pointer Framework to the Standard Library
+N1682 A Multi-threading Library for Standard C++
+N1683 Proposed Library Additions for Code Conversions
+N1684 C++ Standard Library Active Issues List (Revision 32)
+N1685 C++ Standard Library Defect Report List (Revision 32)
+N1686 C++ Standard Library Closed Issues List (Revision 32)
+N1687 (Draft) Technical Report on Standard Library Extensions
+N1688 Library Extension Technical Report - Issues List (Revision 5)
+N1689 C++0x Standard Library wishlist
+N1690 A Proposal to Add an Rvalue Reference to the C++ Language
+N1691 Explicit Namespaces
+N1692 A Proposal to add the Infinite Precision Integer to the C++ Standard Library
+N1693 Adding the long long type to C++ (Revision 1)
+N1694 A Proposal to Extend the Function Call Operator
+N1695 A Proposal to Make Pointers to Members Callable
+N1696 Language Support for Restricted Templates
+N1697 Restrictions on Order Parameters for Bessels and Other Function Families
+N1698 AGENDA J16 Meeting No. 39 WG21 Meeting No. 34 Oct 17-22, 2004, Redmond, Washington
+N1700 C++ Evolution Working Group — Active Proposals, Revision 1b
+N1701 Regularizing Initialization Syntax (revision 1)
+N1702 explicit class and default definitions
+N1703 Function Qualifiers
+N1704 Variadic Templates: Exploring the Design Space
+N1705 Decltype and Auto (revision 4)
+N1706 Toward Opaque typedefs in C++0X
+N1707 Invitation April 2005 meeting
+N1708 C++ Standard Library Active Issues List (Revision 33)
+N1709 C++ Standard Library Defect Report List (Revision 33)
+N1710 C++ Standard Library Closed Issues List (Revision 33)
+N1711 (Draft) Technical Report on Standard Library Extensions
+N1712 Library Extension Technical Report - Issues List
+N1713 Proposed Resolution to TR1 Issues 3.12, 3.14, and 3.15
+N1714 Minutes of ISO WG21 Meeting, October 17, 2004
+N1715 Minutes of J16 Meeting No. 39/WG21 Meeting No. 34, October 17-22, 2004
+N1717 Explicit class and default definitions
+N1718 A Proposal to add the Infinite Precision Integer and Rational to the C++ Standard Library
+N1719 Strongly Typed Enums (revision 1)
+N1720 Proposal to Add Static Assertions to the Core Language (Revision 3)
+N1721 Deducing the type of variable from its initializer expression
+N1722 Extended friend Declarations (Rev. 2)
+N1723 Proposed Resolutions to Library TR Issues
+N1724 A Library Approach to Initialization
+N1725 Copy Elision in Exception Handling
+N1726 Macro scopes
+N1727 Changing Undefined Behavior into Diagnosable Errors
+N1729 C++ Standard Core Language Active Issues, Revision 32
+N1730 C++ Standard Core Language Defect Reports, Revision 32
+N1731 C++ Standard Core Language Closed Issues, Revision 32
+N1732 C++0x Standard Library wishlist (revision 2)
+N1733 Working Draft, Standard for Programming Language C++
+N1734 Editor's report
+N1735 Adding the long long type to C++ (Revision 2)
+N1736 Modules in C++ (Revision 1)
+N1737 A Proposal to Restore Multi-declarator auto Declarations
+N1738 Memory Model for Multithreaded C++
+N1739 Adding a Policy-Based Smart Pointer Framework to the Standard Library
+N1740 The "scope" extension for the C/C++ preprocessor
+N1741 Proposal for Extending the switch statement
+N1742 Auxiliary class interfaces
+N1743 Agenda
+N1744 Big Integer Library Proposal for C++0x
+N1745 Proposed Draft Technical Report on C++ Library Extensions
+N1746 Adding extended integer types to C++
+N1747 C++ Standard Core Language Active Issues, Revision 33
+N1748 C++ Standard Core Language Defect Reports, Revision 33
+N1749 C++ Standard Core Language Closed Issues, Revision 33
+N1750 Critique of Code Conversion Proposal (N1683)
+N1751 Aspects of Reflection in C++
+N1752 C++0x Standard Library wishlist (revision 3)
+N1753 C++ Standard Library Active Issues List (Revision 34)
+N1754 C++ Standard Library Defect Report List (Revision 34)
+N1755 C++ Standard Library Closed Issues List (Revision 34)
+N1756 Library Extension Technical Report - Issues List
+N1757 Right Angle Brackets (Revision 1)
+N1758 Concepts for C++0x
+N1759 TG5 Liaison Report #6
+N1760 TG5 Liaison Report #7
+N1761 TG5 Liaison Report #8
+N1762 C++ Standard Library Active Issues List (Revision 35)
+N1763 C++ Standard Library Defect Report List (Revision 35)
+N1764 C++ Standard Library Closed Issues List (Revision 35)
+N1765 Library Extension Technical Report - Issues List
+N1766 C++0x Standard Library wishlist (revision 4)
+N1767 C++ Standard Core Language Active Issues, Revision 34
+N1768 C++ Standard Core Language Defect Reports, Revision 34
+N1769 C++ Standard Core Language Closed Issues, Revision 34
+N1770 A Proposal to Add an Rvalue Reference to the C++ Language: Proposed Wording
+N1771 Impact of the rvalue reference on the Standard Library
+N1772 Agenda
+N1773 Proposal to add Contract Programming to C++ (revision 2)
+N1774 On the Future Evolution of C++
+N1775 A Case for Reflection
+N1776 Decimal Types for C++
+N1777 Memory model for multithreaded C++: Issues
+N1778 Modules in C++ (Revision 1)
+N1780 Comments on LWG issue 233: Insertion hints in associative containers
+N1781 Rules of thumb for the design of C++0x
+N1782 A concept design (Rev. 1)
+N1783 TG5 Liaison Report #9
+N1784 A proposal to add l-value member function qualifier
+N1785 Toward a Proposal for Object Templates in C++0x
+N1786 C++ Standard Core Language Active Issues, Revision 35
+N1787 C++ Standard Core Language Defect Reports, Revision 35
+N1788 C++ Standard Core Language Closed Issues, Revision 35
+N1789 Minutes of J16 Meeting No. 40/WG21 Meeting No. 34, April 11-15, 2005
+N1790 Minutes of ISO WG21 Meeting, April 10, 2005
+N1791 Extended friend Declarations (Rev. 3)
+N1792 A Modest Proposal: Fixing ADL
+N1794 Deducing the type of variable from its initializer expression (revision 2)
+N1796 Proposal for new for-loop
+N1798 Explicit model definitions are necessary
+N1799 C++ Language Support for Generic Programming
+N1800 Contract Programming For C++0x
+N1801 Proposed resolution of core issue 301
+N1802 Uniform Use of std::string
+N1803 Simple Numeric Access
+N1804 Working Draft, Standard for Programming Language C++
+N1805 Editor's Report
+N1806 C++ Standard Library Active Issues List (Revision R36)
+N1807 C++ Standard Library Defect Report List (Revision R36)
+N1808 C++ Standard Library Closed Issues List (Revision R36)
+N1809 Library Extension Technical Report - Issues List
+N1810 Library Extension TR2 Call for Proposals
+N1811 Adding the long long type to C++ (Revision 3)
+N1814 October 2005 Meeting Information (Revision 1)
+N1815 ISO C++ Strategic Plan for Multithreading
+N1816 Business Plan and Convener's Report
+N1817 Agenda
+N1818 C++ Standard Core Language Active Issues, Revision 36
+N1819 C++ Standard Core Language Defect Reports, Revision 36
+N1820 C++ Standard Core Language Closed Issues, Revision 36
+N1821 Extending Move Semantics To *this (Revision 2)
+N1822 A Proposal to add a max significant decimal digits value to the C++ Standard Library Numeric limits
+N1823 New Character Types in C++
+N1824 Extending Aggregate Initialization
+N1825 Addressing Exception Specifications for Next Generation of C++
+N1827 An Explicit Override Syntax for C++
+N1830 C++ Standard Library Active Issues List (Revision R37)
+N1831 C++ Standard Library Defect Report List (Revision R37)
+N1832 C++ Standard Library Closed Issues List (Revision R37)
+N1833 Transparent Garbage Collection for C++
+N1834 A Pleading for Reasonable Parallel Processing Support in C++
+N1835 <stdint.h> for C++
+N1836 Draft Technical Report on C++ Library Extensions
+N1837 Library Extension Technical Report - Issues List
+N1838 A Proposal to Add Sockets to the Standard Library
+N1839 Decimal Types for C++: Second Draft
+N1840 C++0x Proposal: Function template std::minmax and / or algorithm std::minmax_element
+N1841 Filesystem Library Proposal
+N1842 A Proposal to add two iostream manipulators to the C++ Standard Library
+N1843 A Proposal to add Interval Arithmetic to the C++ Standard Library
+N1844 C++ Standard Core Language Active Issues, Revision 37
+N1845 C++ Standard Core Language Defect Reports, Revision 37
+N1846 C++ Standard Core Language Closed Issues, Revision 37
+N1847 vector<bool>: More Problems, Better Solutions
+N1848 Implementing Concepts
+N1849 Concepts for C++0x Revision 1
+N1850 Towards a Better Allocator Model
+N1851 Improving Usability and Performance of TR1 Smart Pointers
+N1852 C++ Standard Library Active Issues List (Revision R38)
+N1853 C++ Standard Library Defect Report List (Revision R38)
+N1854 C++ Standard Library Closed Issues List (Revision R38)
+N1855 A Proposal to Add an Rvalue Reference to the C++ Language: Proposed Wording
+N1856 Rvalue Reference Recommendations for Chapter 20
+N1857 Rvalue Reference Recommendations for Chapter 21
+N1858 Rvalue Reference Recommendations for Chapter 23
+N1859 Rvalue Reference Recommendations for Chapter 24
+N1860 Rvalue Reference Recommendations for Chapter 25
+N1861 Rvalue Reference Recommendations for Chapter 26
+N1862 Rvalue Reference Recommendations for Chapter 27
+N1864 TG4 liaison report
+N1865 A Proposal to Improve const_iterator Use (version 2)
+N1866 Proposal to add Contract Programming to C++ (revision 3)
+N1867 Synergies between Contract Programming, Concepts and Static Assertions
+N1868 Proposal for new for-loop (revision 1)
+N1869 Wording for imaginary numbers
+N1870 14 crazy ideas for the standard library in C++0x
+N1871 Range Library Proposal
+N1872 Proposal for new string algorithms in C++0x
+N1873 The Cursor/Property Map Abstraction
+N1874 Thread-Local Storage
+N1875 C++ Threads
+N1876 Memory model for multithreaded C++: August 2005 status update
+N1877 Adding Alignment Support to the C++ Programming Language
+N1878 A proposal to add an utility class to represent optional objects (Revision 1)
+N1879 A proposal to add a general purpose ranged-checked numeric_cast<> (Revision 1)
+N1880 A proposal to extend numeric_limits for consistent range query (Revision 1)
+N1882 AGENDA
+N1883 Preliminary Threading Library Proposal for TR2
+N1884 Further Restrictions on Special Math Functions
+N1885 A formalism for C++
+N1886 Specifying C++ concepts
+N1887 Meeting information for SC 22/WG 21 Meetings in Berlin
+N1888 Defining Members of Explicit Specializations
+N1889 Filesystem Library Proposal for TR2 (Revision 1)
+N1890 Initialization and initializers
+N1891 Progress toward Opaque Typedefs for C++0X
+N1892 Extensible Literals
+N1893 A Modest Proposal: Fixing ADL (revision 1)
+N1894 Deducing the type of variable from its initializer expression (revision 3)
+N1895 Delegating Constructors (revision 2)
+N1896 Proposed resolution of core issue 301 (revision 1)
+N1898 Forwarding and inherited constructors
+N1899 Concept proposal comparison
+N1900 Proposal to Add Date-Time to the C++ Standard Library
+N1901 C++0x Standard Library wishlist (revision 5)
+N1902 C++ Standard Core Language Active Issues, Revision 38
+N1903 C++ Standard Core Language Defect Reports, Revision 38
+N1904 C++ Standard Core Language Closed Issues, Revision 38
+N1905 Working Draft, Standard for Programming Language C++
+N1906 Editor's Report
+N1907 A Multi-threading Library for Standard C++, Revision 1
+N1908 C++ Standard Library Active Issues List (Revision R39)
+N1909 C++ Standard Library Defect Report List (Revision R39)
+N1910 C++ Standard Library Closed Issues List (Revision R39)
+N1911 Memory Model for C++: Status update
+N1912 A sketch for a namespace() operator
+N1913 A Proposal to Improve const_iterator Use (version 3)
+N1914 A Proposal to Add Random-Number Distributions to C++0x
+N1915 Minutes of J16 Meeting No. 41/WG21 Meeting No. 35, October 3-8, 2005
+N1916 Minutes of ISO WG21 Meeting, October 2, 2005
+N1917 Agenda
+N1919 Initializer lists
+N1924 TG5 Liaison Report #11
+N1925 Networking proposal for TR2 (rev. 1)
+N1926 C++ Standard Library Active Issues List (Revision R40)
+N1927 C++ Standard Library Defect Report List (Revision R40)
+N1928 C++ Standard Library Closed Issues List (Revision R40)
+N1929 C++ Standard Core Language Active Issues, Revision 39
+N1930 C++ Standard Core Language Defect Reports, Revision 39
+N1931 C++ Standard Core Language Closed Issues, Revision 39
+N1932 Random Number Generation in C++0X: A Comprehensive Proposal
+N1933 Improvements to TR1's Facility for Random Number Generation
+N1934 Filesystem Library Proposal for TR2 (Revision 2)
+N1935 C++ Standard Core Language Active Issues, Revision 40
+N1936 C++ Standard Core Language Defect Reports, Revision 40
+N1937 C++ Standard Core Language Closed Issues, Revision 40
+N1938 Lookup Issues in Destructor and Pseudo-Destructor References
+N1939 Any Library Proposal for TR2
+N1940 Why POSIX Threads Are Unsuitable for C++
+N1941 Agenda: J16 Meeting No. 42, WG21 Meeting No. 37
+N1942 A Memory Model for C++: Strawman Proposal
+N1943 Transparent Garbage Collection for C++
+N1944 A finer-grained alternative to sequence points
+N1945 Names, Linkage, and Templates
+N1946 Portland meeting information
+N1947 The Memory Model and the C++ Library, Non-Memory Actions etc.
+N1949 C++ Standard Library Active Issues List (Revision R41)
+N1950 C++ Standard Library Defect Report List (Revision R41)
+N1951 C++ Standard Library Closed Issues List (Revision R41)
+N1952 A Proposal to Add an Rvalue Reference to the C++ Language: Proposed Wording Revision 2
+N1953 Upgrading the Interface of Allocators using API Versioning
+N1954 LWG Paper Summary
+N1955 New Character Types in C++
+N1956 A Design Rationale for C++/CLI Version 1.1
+N1957 Proposed Library Additions for Code Conversion
+N1958 A proposal to add lambda functions to the C++ standard
+N1959 Class member initializers
+N1960 Adding "extern template"
+N1961 Wording for range-based for-loop
+N1962 Proposal to add Contract Programming to C++ (revision 4)
+N1963 Generic Support for Threading Models
+N1964 Modules in C++ (Revision 3)
+N1965 Decimal Types for C++: Draft 3
+N1966 Thread-Local Storage
+N1968 Lambda expressions and closures for C++
+N1969 State of C++ Evolution (before Berlin 2006 Meeting)
+N1970 C99 Compatibility : __func__ and predeclared identifiers
+N1971 Adding Alignment Support to the C++ Programming Language
+N1972 Generalized Constant Expressions — Revision 2
+N1973 Lexical Conversion Library Proposal for TR2
+N1974 Boost Network Library Query
+N1975 Filesystem Library Proposal for TR2 (Revision 3)
+N1976 Dynamic Shared Objects: Survey and Issues
+N1977 Decimal Types for C++: Draft 4
+N1978 Decltype (revision 5)
+N1980 Generalized Constant Expressions— Revision 3
+N1981 Uniform Use of std::string Revision 1
+N1982 Simple Numeric Access Revision 1
+N1983 long long, size t and compatibility
+N1984 Deducing the type of variable from its initializer expression (revision 4)
+N1985 Request the Standard Provide Explicit Specialization of char_traits For All Built-in Character Types
+N1986 Delegating Constructors (revision 3)
+N1987 Adding "extern template" (version 2)
+N1988 Adding extended integer types to C++ (Revision 1)
+N1990 Proposed Text for minmax (N1840)
+N1991 Proposed Text for defaultfloat (N1842)
+N1992 Minutes of ISO WG21 Meeting, April 2, 2006
+N1993 Minutes of J16 Meeting No. 42/WG21 Meeting No. 37, April 3-7, 2006
+N1997 C++ Standard Core Language Active Issues, Revision 41
+N1998 C++ Standard Core Language Defect Reports, Revision 41
+N1999 C++ Standard Core Language Closed Issues, Revision 41
+N2000 C++ Standard Library Active Issues List (Revision R42)
+N2001 C++ Standard Library Defect Report List (Revision R42)
+N2002 C++ Standard Library Closed Issues List (Revision R42)
+N2003 LWG Paper Summary
+N2004 Impact of Language Changes on LWG Schedule
+N2005 A maximum significant decimal digits value for the C++0x Standard Library Numeric limits
+N2006 Accessibility and Visibility in C++ Modules
+N2007 Proposed Library Additions for Code Conversion
+N2008 Editor's Report
+N2009 Working Draft, Standard for Programming Language C++
+N2010 Memory Model Overview
+N2011 State of C++ Evolution (after Berlin 2006 Meeting)
+N2012 Thread Subcommittee Minutes from Berlin
+N2013 Versioning with Namespaces
+N2014 C99 and POSIX(2001) Compatibility
+N2015 Plugins in C++
+N2016 Should volatile Acquire Atomicity and Thread Visibility Semantics?
+N2018 New Character Types in C++
+N2019 Agenda
+N2020 Proposal for an Infinite Precision Integer for Library Technical Report 2, Revision 1
+N2021 Business plan and convenor's report
+N2022 Input & Output of NaN and infinity for the C++ Standard Library
+N2023 erase(iterator) for unordered containers should not return an iterator
+N2024 C++ Standard Library Active Issues List (Revision R43)
+N2025 C++ Standard Library Defect Report List (Revision R43)
+N2026 C++ Standard Library Closed Issues List (Revision R43)
+N2027 A Brief Introduction to Rvalue References
+N2028 Minor Modifications to the type traits Wording
+N2029 C++ Standard Core Language Active Issues, Revision 42
+N2030 C++ Standard Core Language Defect Reports, Revision 42
+N2031 C++ Standard Core Language Closed Issues, Revision 42
+N2032 Random Number Generation in C++0X: A Comprehensive Proposal, version 2
+N2033 Proposal to Consolidate the Subtract-with-Carry Engines
+N2034 C++0x Standard Library wishlist (revision 6)
+N2035 Minimal Unicode support for the standard library
+N2036 Concepts for the C++0x Standard Library: Approach
+N2037 Concepts for the C++0x Standard Library: Introduction
+N2038 Concepts for the C++0x Standard Library: Utilities
+N2039 Concepts for the C++0x Standard Library: Iterators
+N2040 Concepts for the C++0x Standard Library: Algorithms
+N2041 Concepts for the C++0x Standard Library: Numerics
+N2042 Concepts
+N2043 Simplifying And Extending Mutex and Scoped Lock Types For C++ Multi-Threading Library
+N2044 Memory Mapped Files And Shared Memory For C++
+N2045 Improving STL Allocators
+N2046 Bool_set: multi-valued logic
+N2047 An Atomic Operations Library for C++
+N2049 Conceptualizing the Range-Based for Loop
+N2050 Proposal to Add a Dynamically Sizeable Bitset to the Standard Library Technical Report Revision 1
+N2051 Evolution of the C++ Standard Library
+N2052 Sequencing and the concurrency memory model
+N2053 Raw String Literals
+N2054 Networking Library Proposal for TR2
+N2055 C++ Standard Core Language Active Issues, Revision 43
+N2056 C++ Standard Core Language Defect Reports, Revision 43
+N2057 C++ Standard Core Language Closed Issues, Revision 43
+N2058 Proposed Text for Proposal to add Date-Time to the Standard Library 1.0
+N2059 Proposal for new string algorithms in TR2
+N2061 Library Exception Propagation Support
+N2062 POD's Revisited
+N2063 AGENDA: J16 Meeting No. 43, WG21 Meeting No. 38
+N2065 A proposal to add stream objects based on fixed memory buffers
+N2066 TR2 Diagnostics Enhancements
+N2067 A Proposal to add Interval Arithmetic to the C++ Standard Library
+N2068 Range Library Core
+N2069 Yet another type-trait: decay
+N2070 Enhancing the time_get facet for POSIX� compatibility
+N2071 Iostream manipulators for convenient extraction and insertion of struct tm objects
+N2072 Iostream manipulators for convenient extraction and insertion of monetary values
+N2073 Modules in C++ (Revision 4)
+N2074 Plugins in C++
+N2075 Prism: A Principle-Based Sequential Memory Model for Microsoft Native Code Platforms
+N2076 Oxford meeting invitation
+N2079 Random Number Generation in C++0X: A Comprehensive Proposal, version 3
+N2080 Variadic Templates (Revision 3)
+N2081 Concepts (Revision 1)
+N2082 Concepts for the C++0x Standard Library: Utilities (Revision 1)
+N2083 Concepts for the C++0x Standard Library: Iterators (Revision 1)
+N2084 Concepts for the C++0x Standard Library: Algorithms (Revision 1)
+N2085 Concepts for the C++0x Standard Library: Containers
+N2086 Signals and Slots for Library TR2
+N2087 A Brief Introduction to Variadic Templates
+N2088 IEEE 754R Support and Threading (and Decimal)
+N2089 Asynchronous Exceptions for Threads
+N2090 A Threading API for C++
+N2091 C++ Standard Library Active Issues List (Revision R44)
+N2092 C++ Standard Library Defect Report List (Revision R44)
+N2093 C++ Standard Library Closed Issues List (Revision R44)
+N2094 Multithreading API for C++0X - A Layered Approach
+N2095 long long Goes to the Library
+N2096 Transporting Values and Exceptions between Threads
+N2098 Scoped Concept Maps
+N2099 3 of the least crazy ideas for the standard library in C++0x
+N2100 Initializer lists
+N2101 Hierarchical Data Structures and Related Concepts for the C++ Standard Library
+N2102 POD's Revisited; Resolving Core Issue 568 (Revision 1)
+N2103 A Modest Proposal: Fixing ADL (revision 2)
+N2104 A Proposal to Add Parallel Iteration to the Standard Library
+N2105 Proposed C++0x Keywords Considered
+N2106 Cloning and Throwing Dynamically Typed Exceptions
+N2107 Exception Propagation across Threads
+N2108 Explicit Virtual Overides
+N2109 Minutes of ISO WG21 Meeting, October 15, 2006
+N2110 Minutes of J16 Meeting No. 43/WG21 Meeting No. 38, October 16-20, 2006
+N2111 Random Number Generation in C++0X: A Comprehensive Proposal, version 4
+N2112 Templates Aliases
+N2114 long long Goes to the Library, Revision 1
+N2115 Decltype (revision 6): proposed wording
+N2116 Generalized Constant Expressions— Revision 4
+N2117 Minimal Dynamic Library Support
+N2118 A Proposal to Add an Rvalue Reference to the C++ Language: Proposed Wording: Revision 3
+N2119 Inheriting Constructors
+N2120 April 2007 Meeting
+N2121 Proposed Improvements to the Presentation of Requirements for Functions
+N2122 State of C++ Evolution (after Portland 2006 Meeting)
+N2123 Adding the prohibited access specifier to C++09
+N2125 C++ Standard Core Language Active Issues, Revision 44
+N2126 C++ Standard Core Language Defect Reports, Revision 44
+N2127 C++ Standard Core Language Closed Issues, Revision 44
+N2128 Transparent Programmer-Directed Garbage Collection for C++
+N2129 Transparent Garbage Collection for C++ (Revised)
+N2130 C++ Standard Library Active Issues List (Revision R45)
+N2131 C++ Standard Library Defect Report List (Revision R45)
+N2132 C++ Standard Library Closed Issues List (Revision R45)
+N2133 Editor's Report
+N2134 Working Draft, Standard for Programming Language C++
+N2135 Programming Languages —C++
+N2136 Bool_set: multi-valued logic (revision 1)
+N2137 A Proposal to add Interval Arithmetic to the C++ Standard Library (revision 2)
+N2138 A Less Formal Explanation of the Proposed C++ Concurrency Memory Model
+N2139 Thoughts on a Thread Library for C++
+N2140 Adding Alignment Support to the C++ Programming Language / Consolidated
+N2141 Strong Typedefs in C++09(Revisited)
+N2142 State of C++ Evolution (between Portland and Oxford 2007 Meetings)
+N2143 Proposal for an Infinite Precision Integer for Library Technical Report 2, Revision 2
+N2144 Proposal for exact specification of is modulo
+N2145 C++ Atomic Types and Operations
+N2146 Raw String Literals (Revision 1)
+N2147 Thread-Local Storage
+N2148 Dynamic Initialization and Destruction with Concurrency
+N2149 New Character Types in C++
+N2150 Extending sizeof to apply to non-static data members without an object
+N2151 Variadic Templates for the C++0x Standard Library
+N2152 Proposed Wording for Variadic Templates
+N2153 A simple and efficient memory model for weakly-ordered architectures
+N2154 C++ Standard Library Active Issues List (Revision R46)
+N2155 C++ Standard Library Defect Report List (Revision R46)
+N2156 C++ Standard Library Closed Issues List (Revision R46)
+N2157 Minor Modifications to the type traits Wording Revision 1
+N2158 LWG Issue 206: Linking new/delete operators
+N2159 UTF-8 String Literals
+N2160 Library Issue 96: Fixing vector<bool>
+N2161 Considering Concept Constraint Combinators
+N2162 C++ Standard Core Language Active Issues, Revision 45
+N2163 C++ Standard Core Language Defect Reports, Revision 45
+N2164 C++ Standard Core Language Closed Issues, Revision 45
+N2165 Adding Alignment Support to the C++ Programming Language / Wording
+N2166 Agenda
+N2167 Overview of Linux-Kernel Reference Counting
+N2168 July 2007 Meeting of WG21/J16 Travel Information
+N2169 State of C++ Evolution (pre-Oxford 2007 Meeting)
+N2170 Universal Character Names in Literals
+N2171 Sequencing and the concurrency memory model (revised)
+N2172 POD's Revisited; Resolving Core Issue 568 (Revision 2)
+N2173 Core Extensions for Evolution
+N2174 Diagnostics Enhancements for C++0x
+N2175 Networking Library Proposal for TR2 (Revision 1)
+N2176 Memory Model Rationales
+N2177 Sequential Consistency for Atomics
+N2178 Proposed Text for Chapter 30, Thread Support Library [threads]
+N2179 Language Support for Transporting Exceptions between Threads
+N2180 C++ Standard Library Active Issues List (Revision R47)
+N2181 C++ Standard Library Defect Report List (Revision R47)
+N2182 C++ Standard Library Closed Issues List (Revision R47)
+N2183 Issues From Batavia
+N2184 Thread Launching for C++0X
+N2185 Proposed Text for Parallel Task Execution
+N2186 Some Small Additions to iostream
+N2187 Names, Linkage, and Templates (rev 1)
+N2188 C++ Standard Core Language Defect Reports, Revision 46
+N2189 C++ Standard Core Language Active Issues, Revision 46
+N2190 C++ Standard Core Language Closed Issues, Revision 46
+N2191 Proposed Wording for Variadic Templates (Revision 1)
+N2192 Variadic Templates for the C++0x Standard Library (Revision 1)
+N2193 Proposed Wording for Concepts
+N2194 decltype for the C++0x Standard Library
+N2195 Proposed Text for Chapter 29, Atomic Operations Library [atomics]
+N2196 Wording for range-based for-loop (revision 1)
+N2197 Prism: A Principle-Based Sequential Memory Model for Microsoft Native Code Platforms
+N2198 Extension for the programming language C++ to support decimal floating-point arithmetic
+N2199 Improved min/max
+N2200 Operator Overloading
+N2201 AGENDA J16 Meeting No. 44 WG21 Meeting No. 39 April 16-20, 2006, Oxford, UK
+N2202 C99 Compatibility : __func__ and predeclared identifiers
+N2203 Inheriting Constructors
+N2204 A Specification to deprecate vector<bool>
+N2206 Consistent Insertion into Standard Containers
+N2207 Minimal Unicode support for the standard library (revision 2)
+N2209 UTF-8 String Literals
+N2210 Defaulted and Deleted Functions
+N2211 Enhancing the time_get facet for POSIX� compatibility, Revision 1
+N2212 Support for sequence in-place construction
+N2213 Strongly Typed Enums (revision 2)
+N2214 A name for the null pointer: nullptr (revision 3)
+N2215 Initializer lists (Rev. 3)
+N2216 Report on language support for Multi-Methods and Open-Methods for C++
+N2217 Placement Insert for Containers
+N2219 Constant Expressions in the Standard Library
+N2220 Initializer Lists for Standard Containers
+N2221 An analysis of concept intersection
+N2222 Toronto Agenda
+N2223 Explicit Conversion Operator Draft Working Paper
+N2224 Seeking a Syntax for Attributes in C++09
+N2225 Improved integration with C arrays and strings
+N2228 State of C++ Evolution (pre-Oxford 2007 Meeting)
+N2229 Cloning and Throwing Dynamically Typed Exceptions (Rev 1)
+N2230 POD's Revisited; Resolving Core Issue 568 (Revision 3)
+N2231 STL singly linked lists
+N2232 Improving shared_ptr for C++0x
+N2233 basic_string operator <<
+N2234 French Panel (AFNOR) Position
+N2235 Generalized Constant Expressions—Revision 5
+N2236 Towards support for attributes in C++
+N2237 A simple and efficient memory model for weakly-ordered architectures
+N2238 Minimal Unicode support for the standard library (revision 3)
+N2239 A finer-grained alternative to sequence points (revised)
+N2240 Two missing traits: enable_if and conditional
+N2241 Diagnostics Enhancements for C++0x (Rev. 1)
+N2242 Proposed Wording for Variadic Templates (Revision 2)
+N2243 Wording for range-based for-loop (revision 2)
+N2244 Wording for decay, make_pair and make_tuple
+N2245 Range Utilities for C++0x
+N2246 2 of the least crazy ideas for the standard library in C++0x
+N2248 Toward a More Perfect Union
+N2249 New Character Types in C++
+N2251 C99 Compatibility : __func__ and predeclared identifiers (revision 1)
+N2252 Adding Alignment Support to the C++ Programming Language / Wording
+N2253 Extending sizeof to apply to non-static data members without an object (revision 1)
+N2254 Inheriting Constructors (revision 1)
+N2255 Minor Modifications to the type traits Wording Revision 2
+N2256 Container insert/erase and iterator constness
+N2257 Removing unused allocator functions
+N2258 Templates Aliases
+N2259 Specify header dependency for <iostream>
+N2260 C++ Data-Dependency Ordering
+N2261 Optimization-robust finalization
+N2262 Explicit Memory Fences
+N2263 C++ Standard Core Language Active Issues, Revision 47
+N2264 C++ Standard Core Language Defect Reports, Revision 47
+N2265 C++ Standard Core Language Closed Issues, Revision 47
+N2266 Minutes of J16 Meeting No. 44/WG21 Meeting No. 39, April 16-20, 2007
+N2267 Minutes of ISO WG21 Meeting, April 15, 2007
+N2268 Placement Insert for Containers (Revision 1)
+N2269 AGENDA July 16-20, 2007, Toronto, Ontario, Canada
+N2270 Incompatible changes in C++0x
+N2271 EASTL — Electronic Arts Standard Template Library
+N2272 Optional Sequential Consistency
+N2273 Non-Memory Actions (Core Aspects)
+N2274 Object Aliasing and Threads
+N2275 Non-Memory Actions (Library)
+N2276 Thread Pools and Futures
+N2277 C++ Standard Library Active Issues List (Revision R48)
+N2278 C++ Standard Library Defect Report List (Revision R48)
+N2279 C++ Standard Library Closed Issues List (Revision R48)
+N2280 Thread-Local Storage
+N2281 Digit Separators
+N2282 Extensible Literals (revision 2)
+N2283 Editor's report
+N2284 Working Draft, Standard for Programming Language C++
+N2285 A Multi-threading Library for Standard C++, Revision 2
+N2286 Programmer Directed GC for C++
+N2287 Transparent Programmer-Directed Garbage Collection for C++
+N2288 Constant Expressions in the Standard Library —Revision 1
+N2289 October 2007 Meeting
+N2290 Business plan and convenor's report
+N2291 State of C++ Evolution (Toronto 2007 Meeting)
+N2292 Standard Library Applications for Deleted Functions
+N2293 Standard Library Applications for Explicit Conversion Operators
+N2294 POD's Revisited; Resolving Core Issue 568 (Revision 4)
+N2295 Raw and Unicode String Literals; Unified Proposal
+N2296 Diagnostics Enhancements; Resolution of Small Issues
+N2297 Improving shared_ptr for C++0x, Revision 1
+N2298 Thread-Safety in the Standard Library
+N2299 Concatenating tuples
+N2300 Concurrency memory model (revised)
+N2301 Adding Alignment Support to the C++ Programming Language / Wording
+N2303 Revised system_error
+N2304 C++ Standard Core Language Active Issues, Revision 48
+N2305 C++ Standard Core Language Defect Reports, Revision 48
+N2306 C++ Standard Core Language Closed Issues, Revision 48
+N2307 Proposed Wording for Concepts (Revision 1)
+N2308 Adding allocator support to std::function for C++0x
+N2309 Error-handling and Exception-related library changes for C++0x
+N2310 Transparent Programmer-Directed Garbage Collection for C++
+N2311 2008 Fees for Participation on INCITS Technical Committees and Task Groups
+N2312 Namespace Regions
+N2314 Editor's report
+N2315 Working Draft, Standard for Programming Language C++
+N2316 Modules in C++ (Revision 5)
+N2317 C++ Standard Library Active Issues List (Revision R49)
+N2318 C++ Standard Library Defect Report List (Revision R49)
+N2319 C++ Standard Library Closed Issues List (Revision R49)
+N2320 Multi-threading Library for Standard C++
+N2321 Enhancing the time_get facet for POSIX� compatibility, Revision 2
+N2322 Concepts for the C++0x Standard Library: Utilities (Revision 2)
+N2323 Concepts for the C++0x Standard Library: Iterators (Revision 2)
+N2324 C++ Atomic Types and Operations
+N2325 Dynamic Initialization and Destruction with Concurrency
+N2326 Defaulted and Deleted Functions
+N2327 Inconsistencies in IOStreams Numeric Extraction
+N2328 Proposal for Date-Time Types in C++0x To Support Threading APIs
+N2329 Lambda expressions and closures for C++ (Revision 1)
+N2331 Namespace Association ("strong" using)
+N2332 Argument Deduction for Constructors
+N2333 Explicit Conversion Operator Draft Working Paper Revision 1
+N2334 Concurrency memory model (revised again)
+N2336 State of C++ Evolution (Toronto 2007 Meeting)
+N2337 The Syntax of auto Declarations
+N2338 Concurrency memory model compiler consequences
+N2339 Response to N2257=07-0117 "Removing unused allocator functions"
+N2340 C99 Compatibility : __func__ and predeclared identifiers (revision 2)
+N2341 Adding Alignment Support to the C++ Programming Language / Wording
+N2342 POD's Revisited; Resolving Core Issue 568 (Revision 5)
+N2343 Decltype (revision 7): proposed wording
+N2345 Placement Insert for Containers (Revision 2)
+N2346 Defaulted and Deleted Functions
+N2347 Strongly Typed Enums (revision 3)
+N2348 Wording for std::numeric_limits<T>::lowest()
+N2349 Constant Expressions in the Standard Library —Revision 2
+N2350 Container insert/erase and iterator constness (Revision 1)
+N2351 Improving shared_ptr for C++0x, Revision 2
+N2353 A Specification for vector<bool>
+N2354 Class member initializers
+N2355 Minutes of J16 Meeting No. 45/WG21 Meeting No. 40, July 16-20, 2007
+N2356 Minutes of ISO WG21 Meeting, July 15, 2007
+N2359 C++ Data-Dependency Ordering: Atomics
+N2360 C++ Data-Dependency Ordering: Memory Model
+N2361 C++ Data-Dependency Ordering: Function Annotation
+N2362 Converting Memory Fences to N2324 Form
+N2363 C++ Library Working Group Status Report (post-Toronto 2007 Meeting)
+N2364 Development of C++ Standard C++ Library Technical Report no. 1
+N2365 Explicit Virtual Overides
+N2366 C++ Standard Core Language Active Issues, Revision 49
+N2367 C++ Standard Core Language Defect Reports, Revision 49
+N2368 C++ Standard Core Language Closed Issues, Revision 49
+N2369 Working Draft, Standard for Programming Language C++
+N2370 Editor’s Report
+N2371 C++ Standard Library Active Issues List (Revision R50)
+N2372 C++ Standard Library Defect Report List (Revision R50)
+N2373 C++ Standard Library Closed Issues List (Revision R50)
+N2374 WG21 agenda
+N2375 AGENDA J16 Meeting No. 46 WG21 Meeting No. 41 October 1-6, 2007, Kona, Hawaii
+N2376 Inheriting Constructors (revision 2)
+N2377 Extending move semantics to *this (revised wording)
+N2378 User-defined Literals (aka. Extensible Literals (revision 3))
+N2379 Towards support for attributes in C++ (Revision 2)
+N2380 Explicit Conversion Operator Draft Working Paper (revision 2)
+N2381 C++ Atomic Types and Operations
+N2382 Dynamic Initialization and Destruction with Concurrency
+N2383 Abandoning a Process
+N2384 Raw and Unicode String Literals; Unified Proposal (Rev. 1)
+N2385 Initializer lists WP wording
+N2386 Namespace Regions
+N2387 Omnibus Allocator Fix-up Proposals
+N2388 Pointer Arithmetic for shared_ptr
+N2389 State of C++ Evolution (pre-Kona 2007 Meeting)
+N2390 C++ Library Working Group Status Report (pre-Kona 2007 Meeting)
+N2391 Recommendations for Resolving Issues re [rand]
+N2392 A Memory Model for C++: Sequential Consistency for Race-Free Programs
+N2393 C++ Atomic Types and Operations
+N2394 Wording for range-based for-loop (revision 3)
+N2395 C++ Standard Core Language Active Issues, Revision 50
+N2396 C++ Standard Core Language Defect Reports, Revision 50
+N2397 C++ Standard Core Language Closed Issues, Revision 50
+N2398 Proposed Wording for Concepts (Revision 2)
+N2399 A Tour of the Concepts Wording
+N2400 February 2008 Meeting
+N2401 Code Conversion Facets for the Standard C++ Library
+N2402 Names, Linkage, and Templates (rev 2)
+N2403 C++ Standard Library Active Issues List (Revision R51)
+N2404 C++ Standard Library Defect Report List (Revision R51)
+N2405 C++ Standard Library Closed Issues List (Revision R51)
+N2406 Mutex, Lock, Condition Variable Rationale
+N2407 C++ Dynamic Library Support
+N2408 Simple Numeric Access Revision 2
+N2409 Proposed Resolutions for the Outstanding Issues in Chapter 28: Regular expressions library
+N2410 Thread-Safety in the Standard Library (Rev 1)
+N2411 Proposal for Date-Time Types in C++0x To Support Threading APIs v2
+N2412 Unrestricted Unions
+N2413 Lambda Expressions and Closures: Wording for Monomorphic Lambdas
+N2414 Proposed Wording for Scoped Concept Maps
+N2415 Diagnostics Issues (Rev. 1)
+N2416 Agenda
+N2417 C++0x Timing Options for Kona Discussion
+N2418 Towards support for attributes in C++ (Revision 3)
+N2420 POSIX/C++ Liaison Report
+N2421 Proposed Wording for Concepts (Revision 3)
+N2422 Diagnostics Issues (Rev. 2)
+N2423 Recommendations for Resolving Issues re [rand], Version 2
+N2424 Recommendations for Resolving the 2007-09-21 Issues re [rand]
+N2425 DRAFT C++ Dynamic Library Support
+N2426 Class member initializers
+N2427 C++ Atomic Types and Operations
+N2429 Concurrency memory model (final revision)
+N2430 Unrestricted Unions (Revision 1)
+N2431 A name for the null pointer: nullptr (revision 4)
+N2432 State of C++ Evolution (post-Kona 2007 Meeting)
+N2433 C++ Library Working Group Status Report (post-Kona 2007 Meeting)
+N2434 Standard Library Applications for Explicit Conversion Operators
+N2435 Explicit bool for Smart Pointers
+N2436 Small Allocator Fix-ups
+N2437 Explicit Conversion Operator Draft Working Paper (revision 3)
+N2438 Inheriting Constructors (revision 3)
+N2439 Extending move semantics to *this (revised wording)
+N2440 Abandoning a Process
+N2442 Raw and Unicode String Literals; Unified Proposal (Rev. 2)
+N2444 Dynamic Initialization and Destruction with Concurrency
+N2445 New Function Declarator Syntax Wording
+N2446 The Scoped Allocator Model
+N2447 Multi-threading Library for Standard C++
+N2448 STL singly linked lists (revision 2)
+N2449 C++ Standard Core Language Active Issues, Revision 51
+N2450 C++ Standard Core Language Defect Reports, Revision 51
+N2451 C++ Standard Core Language Closed Issues, Revision 51
+N2452 Minutes of WG21 Meeting No. 41, October 1-6, 2007
+N2453 Minutes of J16 Meeting No. 46, October 1-6, 2007
+N2454 Minutes of ISO WG21 Meeting, October 1, 2007
+N2455 Thread Cancellation
+N2456 C++ Standard Library Active Issues List (Revision R52)
+N2457 C++ Standard Library Defect Report List (Revision R52)
+N2458 C++ Standard Library Closed Issues List (Revision R52)
+N2459 Allow atomics use in signal handlers
+N2461 Working Draft, Standard for Programming Language C++
+N2462 Editor’s Report
+N2464 Agenda
+N2465 Winter 2008 Meeting (Version 2)
+N2466 WG 14: Towards Attributes for C
+N2472 June 2008 Meeting
+N2473 C++ Standard Core Language Active Issues, Revision 52
+N2474 C++ Standard Core Language Defect Reports, Revision 52
+N2475 C++ Standard Core Language Closed Issues, Revision 52
+N2476 AGENDA J16 Meeting No. 47 February 25 - Mar 1, 2008, Bellevue, WA
+N2477 Uniform initialization design choices
+N2478 A Proposal to Add typedef default_random_engine to C++0X
+N2479 Normative Language to Describe Value Copy Semantics
+N2480 A Less Formal Explanation of the Proposed C++ Concurrency Memory Model
+N2481 Minimal Support for Garbage Collection and Reachability-Based Leak Detection
+N2482 C++ Standard Library Active Issues List (Revision R53)
+N2483 C++ Standard Library Defect Report List (Revision R53)
+N2484 C++ Standard Library Closed Issues List (Revision R53)
+N2485 A variadic std::min(T, ...) for the C++ Standard Library
+N2486 Alternative Allocators and Standard Containers
+N2487 Lambda Expressions and Closures: Wording for Monomorphic Lambdas (Revision 2)
+N2488 Extending Variadic Template Template Parameters
+N2492 C++ Data-Dependency Ordering: Atomics and Memory Model
+N2493 C++ Data-Dependency Ordering: Function Annotation
+N2494 C++ Standard Library Active Issues List (Revision R54)
+N2495 C++ Standard Library Defect Report List (Revision R54)
+N2496 C++ Standard Library Closed Issues List (Revision R54)
+N2497 Multi-threading Library for Standard C++ (Revision 1)
+N2498 Custom Time Duration Support
+N2499 Forward declaration of enumerations
+N2500 Iterator Concepts for the C++0x Standard Library
+N2501 Proposed Wording for Concepts (Revision 4)
+N2502 Core Concepts for the C++0x Standard Library
+N2503 Indicating iostream failures with system_error
+N2504 C++ Standard Core Language Active Issues, Revision 53
+N2505 C++ Standard Core Language Defect Reports, Revision 53
+N2506 C++ Standard Core Language Closed Issues, Revision 53
+N2507 State of C++ Evolution (Pre-Bellevue 2008 Mailing)
+N2508 C++ Library Working Group Status Report (Belleuve 2008 Mailing)
+N2509 Nesting Exceptions
+N2510 BSI Position on Lambda Functions
+N2511 Named Lambdas and Local Functions
+N2512 Inheriting Constructors (revision 4)
+N2513 Dynamic Initialization and Destruction with Concurrency
+N2514 Implicit Conversion Operators for Atomics
+N2516 Threads API Review Committee Report
+N2517 June 2008 Meeting
+N2518 Compiler Support for type_traits
+N2519 Library thread-safety from a user's point of view, with wording
+N2520 Proposed Wording for Concepts (Changes from Revision 3 to Revision 4)
+N2521 Working Draft, Standard for Programming Language C++
+N2522 Editor’s Report
+N2523 The Scoped Allocator Model (Rev 1)
+N2524 Conservative Swap and Move with Stateful Allocators
+N2525 Allocator-specific Swap and Move Behavior
+N2526 Why duration Should Be a Type in C++0X
+N2527 Minimal Support for Garbage Collection and Reachability-Based Leak Detection (revised)
+N2528 Timed_mutex in C++0x
+N2529 Lambda Expressions and Closures: Wording for Monomorphic Lambdas (Revision 3)
+N2530 Making It Easier to Use std::type_info as an Index in an Associative Container
+N2531 Initializer lists WP wording
+N2532 Uniform initialization design choices (Revision 2)
+N2533 Tuples and Pairs
+N2534 Concurrency Modifications to Basic String
+N2535 Namespace Association ("inline namespace")
+N2536 POSIX Liaison Report
+N2537 Fall 2008 meeting
+N2538 Removal of System error support
+N2539 A New Interface for C++ std::duration Type
+N2540 Inheriting Constructors (revision 5)
+N2541 New Function Declarator Syntax Wording
+N2542 Reserved namespaces for POSIX
+N2543 STL singly linked lists (revision 3)
+N2544 Unrestricted Unions (Revision 2)
+N2545 Thread-Local Storage
+N2546 Removal of auto as a storage-class specifier
+N2547 Allow atomics use in signal handlers
+N2549 Excision of Clause 31
+N2550 Lambda Expressions and Closures: Wording for Monomorphic Lambdas (Revision 4)
+N2551 A variadic std::min(T, ...) for the C++ Standard Library (Revision 2)
+N2552 Using ytime for Times in the Thread Support Library
+N2553 Towards support for attributes in C++ (Revision 4)
+N2554 The Scoped Allocator Model (Rev 2)
+N2555 Extending Variadic Template Template Parameters (Revision 1)
+N2556 C++ Data-Dependency Ordering: Atomics and Memory Model
+N2559 Nesting Exception Objects (Revision 1)
+N2561 An Asynchronous Future Value
+N2562 C++ Standard Core Language Active Issues, Revision 54
+N2563 C++ Standard Core Language Defect Reports, Revision 54
+N2564 C++ Standard Core Language Closed Issues, Revision 54
+N2565 State of C++ Evolution (Post-Bellevue 2008 Mailing)
+N2566 C++ Library Working Group Status Report (Post-Bellevue 2008 Mailing)
+N2568 Forward declaration of enumerations (rev. 1)
+N2569 More STL algorithms
+N2570 Iterator Concepts for the C++0x Standard Library (Revision 1)
+N2572 Core Concepts for the C++0x Standard Library (Revision 1)
+N2573 Concepts for the C++0x Standard Library: Algorithms (Revision 2)
+N2574 Concepts for the C++0x Standard Library: Numerics (Revision 1)
+N2575 Initializer Lists — Alternative Mechanism and Rationale
+N2576 Type-Soundness and Optimization in the Concepts Proposal
+N2577 C++ Standard Library Active Issues List (Revision R55)
+N2578 C++ Standard Library Defect Report List (Revision R55)
+N2579 C++ Standard Library Closed Issues List (Revision R55)
+N2580 Some More Small Additions to iostream
+N2581 Named Requirements for C++0X Concepts
+N2582 Unified Function Syntax
+N2583 Default Move Functions
+N2584 Default Swap Functions
+N2585 Minimal Support for Garbage Collection and Reachability-Based Leak Detection
+N2586 Minimal Support for Garbage Collection and Reachability-Based Leak Detection (revised)
+N2587 Minimal Garbage Collection Status API
+N2588 Working Draft, Standard for Programming Language C++
+N2589 Editor’s Report
+N2590 Simplifying swap overloads
+N2591 Refactoring numeric_limits
+N2592 Minutes of J16 Meeting No. 47, February 25-March 1, 2008
+N2593 Minutes of ISO WG21 Meeting, February 23, 2008
+N2595 WG21 Agenda
+N2596 Unofficial Record of Discussion: J16 Meeting No. 47, February 25-March 1, 2008
+N2597 State of C++ Evolution (Pre-Antipolis 2008 Mailing)
+N2598 C++ Library Working Group Status Report (Pre-Antipolis 2008 Mailing)
+N2600 noncopyable utility class
+N2601 Sexagesimal Numbers in C++
+N2602 BSI Requirements for a system-time library in C++0x
+N2604 Thoughts on Implementing errno as a Macro
+N2605 Changing some "undefined behavior" into "ill-formed"
+N2606 Working Draft, Standard for Programming Language C++
+N2607 Editor's Report
+N2608 C++ Standard Core Language Active Issues, Revision 55
+N2609 C++ Standard Core Language Defect Reports, Revision 55
+N2610 C++ Standard Core Language Closed Issues, Revision 55
+N2611 AGENDA J16 Meeting No. 48 June 9-14, 2008, Sophia Antipolis, France
+N2612 C++ Standard Library Active Issues List (Revision R56)
+N2613 C++ Standard Library Defect Report List (Revision R56)
+N2614 C++ Standard Library Closed Issues List (Revision R56)
+N2615 A Foundation to Sleep On
+N2617 Proposed Wording for Concepts (Revision 5)
+N2618 Concepts for the C++0x Standard Library: Chapter 17 -Introduction (Revision 1)
+N2619 CONCEPTS FOR CLAUSE 18
+N2620 Concepts for the C++0x Standard Library: Diagnostics library
+N2621 Core Concepts for the C++0x Standard Library (Revision 2)
+N2622 Concepts for the C++0x Standard Library: Utilities (Revision 3)
+N2623 Concepts for the C++0x Standard Library: Containers (Revision 1)
+N2624 Iterator Concepts for the C++0x Standard Library (Revision 2)
+N2625 Concepts for the C++0x Standard Library: Algorithms (Revision 2)
+N2626 Concepts for the C++0x Standard Library: Numerics (Revision 2)
+N2627 An Asynchronous Future Value (revised)
+N2628 Non-static data member initializers
+N2629 Detailed Reporting for Input/Output Library Errors
+N2631 Resolving the difference between C and C++ with regards to object representation of integers
+N2632 Shared_ptr atomic access
+N2633 Improved support for bidirectional fences
+N2634 Solving the SFINAE problem for expressions
+N2635 Local and Unnamed Types as Template Arguments
+N2636 Error Handling Specification for Chapter 30 (Threads)
+N2637 Revisiting std::shared_ptr comparison
+N2638 Improving the wording of std::shared_ptr
+N2639 Algorithms for permutations and combinations, with and without repetitions
+N2640 Initializer Lists — Alternative Mechanism and Rationale (v. 2)
+N2641 Allocator Concepts
+N2642 Proposed Wording for Placement Insert
+N2643 C++ Data-Dependency Ordering: Function Annotation
+N2644 Agenda
+N2645 Fundamental Mathematical Concepts for the STL in C++0x
+N2646 Concept Implication and Requirement Propagation
+N2647 Concurrency Modifications to Basic String
+N2648 C++ Dynamic Arrays
+N2649 Proposed Resolution for Valarray Constructors
+N2650 Toward a More Complete Taxonomy of Algebraic Properties for Numeric Libraries in TR2
+N2651 Constness of Lambda Functions
+N2652 State of C++ Evolution (Post-Antipolis 2008 Mailing)
+N2653 C++ Library Working Group Status Report (Post-Antipolis 2008 Mailing)
+N2654 Allocator Concepts (revision 1)
+N2655 Detailed Reporting for Input/Output Library Errors (Revision 1)
+N2656 Core issue 654 wording
+N2657 Local and Unnamed Types as Template Arguments
+N2658 Constness of Lambda Functions (Revision 1)
+N2659 Thread-Local Storage
+N2660 Dynamic Initialization and Destruction with Concurrency
+N2661 A Foundation to Sleep On
+N2664 C++ Data-Dependency Ordering: Atomics and Memory Model
+N2666 More STL algorithms (revision 2)
+N2667 Reserved namespaces for POSIX
+N2668 Concurrency Modifications to Basic String
+N2669 Thread-Safety in the Standard Library (Rev 2)
+N2670 Minimal Support for Garbage Collection and Reachability-Based Leak Detection (revised)
+N2671 An Asynchronous Future Value: Proposed Wording
+N2672 Initializer List proposed wording
+N2673 Non-static data member initializers with draft of initializer list wording
+N2674 Shared_ptr atomic access, revision 1
+N2675 noncopyable utility class (revision 1)
+N2676 Proposed Wording for Concepts (Revision 6)
+N2677 Foundational Concepts for the C++0x Standard Library (Revision 3)
+N2678 Error Handling Specification for Chapter 30 (Threads)
+N2679 Initializer Lists for Standard Containers (Revision 1)
+N2680 Proposed Wording for Placement Insert (Revision 1)
+N2681 Minutes of PL22.16 Meeting No. 48, June 8-15, 2008
+N2682 Minutes of ISO WG21 Meeting, June 8, 2008
+N2683 issue 454: problems and solutions
+N2684 C++ Standard Library Active Issues List (Revision R57)
+N2685 C++ Standard Library Defect Report List (Revision R57)
+N2686 C++ Standard Library Closed Issues List (Revision R57)
+N2687 Forward declaration of enumerations (rev. 2)
+N2688 C++ Standard Core Language Active Issues, Revision 56
+N2689 C++ Standard Core Language Defect Reports, Revision 56
+N2690 C++ Standard Core Language Closed Issues, Revision 56
+N2691 Working Draft, Standard for Programming Language C++
+N2692 Editor's Report
+N2693 Requirements on programs and backwards compatibility
+N2694 Concepts for the C++0x Standard Library: Containers (Revision 2)
+N2695 Iterator Concepts for the C++0x Standard Library (Revision 3)
+N2696 Concepts for the C++0x Standard Library: Algorithms (Revision 3)
+N2697 Minutes of WG21 Meeting, June 8-15, 2008
+N2698 Additional type traits: has_trivial_destructor_after_move and has_trivial_reallocation
+N2699 C++ Standard Core Language Active Issues, Revision 57
+N2700 C++ Standard Core Language Defect Reports, Revision 57
+N2701 C++ Standard Core Language Closed Issues, Revision 57
+N2702 C++ Standard Library Active Issues List (Revision R58)
+N2703 C++ Standard Library Defect Report List (Revision R58)
+N2704 C++ Standard Library Closed Issues List (Revision R58)
+N2705 State of C++ Evolution (Mid-term 2008 Mailing)
+N2706 C++ Library Working Group Status Report (Mid-term 2008 Mailing)
+N2707 Expedited core issues handling
+N2708 Business Plan and Convener's Report
+N2709 Packaging Tasks for Asynchronous Execution
+N2710 Proposed Wording for Concepts (Revision 7)
+N2711 WG21 July 2009 Meeting
+N2712 Non-static data member initializers
+N2713 Allow auto for non-static data members
+N2714 C++ Standard Core Language Active Issues, Revision 58
+N2715 C++ Standard Core Language Defect Reports, Revision 58
+N2716 C++ Standard Core Language Closed Issues, Revision 58
+N2717 Extensions to the C++ Library to Support Mathematical Special Functions
+N2718 Additional type traits: has_trivial_destructor_after_move and has_trivial_reallocation (rev1)
+N2719 Initializer lists and move semantics
+N2720 AGENDA PL22.16 Meeting No. 49 September 15-20, 2008, San Francisco, California
+N2722 Variadic functions: Variadic templates or initializer lists?
+N2723 Working Draft, Standard for Programming Language C++
+N2724 Editor's Report
+N2727 C++ Standard Library Active Issues List (Revision R59)
+N2728 C++ Standard Library Defect Report List (Revision R59)
+N2729 C++ Standard Library Closed Issues List (Revision R59)
+N2730 Expedited core issues handling (revision 1)
+N2731 Proposed Text for Bidirectional Fences
+N2732 Extension for the programming language C++ to support decimal floating-point arithmetic
+N2733 Appendix C: ISO C++ 2003 Compatibility
+N2734 Concepts for the C++0x Standard Library: Iterators (Revision 3)
+N2735 Concepts for the C++0x Standard Library: Utilities (Revision 4)
+N2736 Concepts for the C++0x Standard Library: Numerics (Revision 3)
+N2737 Foundational Concepts for the C++0x Standard Library (Revision 4)
+N2738 Concepts for the C++0x Standard Library: Containers (Revision 3)
+N2739 Iterator Concepts for the C++0x Standard Library (Revision 4)
+N2740 Concepts for the C++0x Standard Library: Algorithms (Revision 4)
+N2741 Proposed Wording for Concepts (Revision 8)
+N2742 Simplifying unique copy
+N2743 Unifying Operator and Function-Object Variants of Standard Library Algorithms
+N2744 Comments on Asynchronous Future Value Proposal
+N2745 Example POWER Implementation for C/C++ Memory Model
+N2746 Rationale for the C++ working paper definition of "memory location"
+N2747 Ambiguity and Insecurity with User-Defined Literals
+N2748 Strong Compare and Exchange
+N2749 Not so Trivial Issues with Trivial
+N2750 User-defined Literals (aka. Extensible Literals (revision 4))
+N2751 Towards support for attributes in C++ (Revision 5)
+N2752 Proposed Text for Bidirectional Fences
+N2753 March 2009 meeting information
+N2754 Additional concepts: TriviallyDestructibleAfterMove and TriviallyReallocatable
+N2755 Concepts for the C++0x Standard Library: Chapter 17 -Introduction (Revision 2)
+N2756 Non-static data member initializers
+N2757 Expedited core issues handling (revision 2)
+N2758 Iterator Concepts for the C++0x Standard Library (Revision 5)
+N2759 Concepts for the C++0x Standard Library: Algorithms (Revision 5)
+N2760 Input/Output Library Thread Safety
+N2761 Towards support for attributes in C++ (Revision 6)
+N2762 Not so Trivial Issues with Trivial
+N2763 Unified Function Syntax
+N2764 Forward declaration of enumerations (rev. 3)
+N2765 User-defined Literals (aka. Extensible Literals (revision 5))
+N2768 Allocator Concepts, part 1 (revision 2)
+N2769 Detailed Reporting for Input/Output Library Errors (Revision 2)
+N2770 Concepts for the C++0x Standard Library: Utilities (Revision 5)
+N2771 LWG Issues
+N2772 Variadic functions: Variadic templates or initializer lists? — Revision 1
+N2773 Proposed Wording for Concepts (Revision 9)
+N2774 Foundational Concepts for the C++0x Standard Library (Revision 5)
+N2775 Small library thread-safety revisions
+N2776 Concepts for the C++0x Standard Library: Containers (Revision 4)
+N2777 Concepts for the C++0x Standard Library: Iterators (Revision 4)
+N2778 Wording for range-based for-loop (revision 4)
+N2779 Concepts for Clause 18: Part 2
+N2780 Named Requirements for C++0X Concepts, version 2
+N2781 Concepts for Random Number Generation in C++0X
+N2782 C++ Data-Dependency Ordering: Function Annotation
+N2783 Collected Issues with Atomics
+N2784 Minutes of WG21 Meeting, September 15-20, 2008
+N2785 Minutes of PL22.16 Meeting, September 15-20, 2008
+N2786 Simplifying unique copy (Revision 1)
+N2791 C++ Standard Core Language Active Issues, Revision 59
+N2792 C++ Standard Core Language Defect Reports, Revision 59
+N2793 C++ Standard Core Language Closed Issues, Revision 59
+N2794 C++ Standard Library Active Issues List (Revision R60)
+N2795 C++ Standard Library Defect Report List (Revision R60)
+N2796 C++ Standard Library Closed Issues List (Revision R60)
+N2797 AGENDA PL22.16 Meeting No. 50 WG21 Meeting No. 45 March 1-6, 2009, Summit, NJ
+N2798 Working Draft, Standard for Programming Language C++
+N2799 Editor's Report
+N2800 Programming Languages — C++
+N2801 Initializer lists and move semantics
+N2802 A plea to reconsider detach-on-destruction for thread objects
+N2803 C++ Standard Core Language Active Issues, Revision 60
+N2804 C++ Standard Core Language Defect Reports, Revision 60
+N2805 C++ Standard Core Language Closed Issues, Revision 60
+N2806 C++ Standard Library Active Issues List (Revision R61)
+N2807 C++ Standard Library Defect Report List (Revision R61)
+N2808 C++ Standard Library Closed Issues List (Revision R61)
+N2809 Library Support for hybrid error handling
+N2810 Defects and Proposed Resolutions for Allocator Concepts
+N2811 Directed Rounding Arithmetic Operations
+N2812 A Safety Problem with RValue References (and what to do about it)
+N2813 Issue Resolutions for Concept-enabled Random Number Generation in C++0X
+N2814 Fixing freestanding
+N2815 Improving the standard library's exception specifications
+N2816 C++ Standard Core Language Active Issues, Revision 61
+N2817 C++ Standard Core Language Defect Reports, Revision 61
+N2818 C++ Standard Core Language Closed Issues, Revision 61
+N2819 Ref-qualifiers for assignment operators of the Standard Library
+N2820 Adding heterogeneous comparison lookup to associative containers
+N2821 C++ Standard Library Active Issues List (Revision R62)
+N2822 C++ Standard Library Defect Report List (Revision R62)
+N2823 C++ Standard Library Closed Issues List (Revision R62)
+N2824 AGENDA, PL22.16 Meeting No. 51, WG21 Meeting No. 46, July 13-18, 2009, Frankfurt, Germany
+N2825 Unified Function Syntax
+N2826 Issues with Constexpr
+N2827 Thread Unsafe Standard Functions
+N2828 Library Support for Hybrid Error Handling (Rev 1)
+N2829 Defects and Proposed Resolutions for Allocator Concepts (Rev 1)
+N2830 Problems with reference_closure
+N2831 Fixing a Safety Problem with Rvalue References: Proposed Wording
+N2832 Concepts and Ref-qualifiers
+N2834 Several Proposals to Simplify pair
+N2835 forward
+N2836 Wording Tweaks for Concept-enabled Random Number Generation in C++0X
+N2837 C++0X, CD 1, National Body Comments
+N2838 Library Support for Hybrid Error Handling (Rev 2)
+N2839 Response to "Problems with reference_closure"
+N2840 Defects and Proposed Resolutions for Allocator Concepts (Rev 2)
+N2841 Consolidated Quasi-Editorial Changes for National Body Comments Concerning the Core Language
+N2842 Another numeric facet
+N2843 Pack Expansion and Attributes
+N2844 Fixing a Safety Problem with Rvalue References: Proposed Wording (Revision 1)
+N2845 Remove std::reference_closure
+N2847 Minutes of PL22.16 Meeting, March 2, 2009
+N2848 Minutes of WG21 Meeting, March 2, 2009
+N2849 Extension for the programming language C++ to support decimal floating-point arithmetic
+N2850 Extensions to the C++ Library to Support Mathematical Special Functions
+N2851 Changes to the Decimal TR since the PDTR Ballot
+N2852 Explicit Virtual Overrides
+N2853 Constraining unique_ptr
+N2855 Rvalue References and Exception Safety
+N2857 Working Draft, Standard for Programming Language C++
+N2858 Editor's Report
+N2859 New wording for C++0x Lambdas
+N2860 C++ Standard Core Language Active Issues, Revision 62
+N2861 C++ Standard Core Language Defect Reports, Revision 62
+N2862 C++ Standard Core Language Closed Issues, Revision 62
+N2863 C++ CD1 Comment Status
+N2864 Thread Unsafe Standard Functions
+N2866 C++ Standard Library Active Issues List (Revision R63)
+N2867 C++ Standard Library Defect Report List (Revision R63)
+N2868 C++ Standard Library Closed Issues List (Revision R63)
+N2869 State of C++ Evolution (Post San Francisco 2008)
+N2870 C++ Library Working Group Status Report (Post San Francisco 2008)
+N2871 Summary of C++0x Standard : CD 1
+N2872 Ensuring Certain C++0x Features "just work"
+N2873 C++ Standard Library Active Issues List (Revision R64)
+N2874 C++ Standard Library Defect Report List (Revision R64)
+N2875 C++ Standard Library Closed Issues List (Revision R64)
+N2876 Directed Rounding Arithmetic Operations (Revision 1)
+N2877 C++ Standard Core Language Active Issues, Revision 64
+N2878 C++ Standard Core Language Defect Reports, Revision 64
+N2879 C++ Standard Core Language Closed Issues, Revision 64
+N2880 C++ object lifetime interactions with the threads API
+N2881 Base Class Aliases for The-C++-After-0x
+N2882 Adding heterogeneous comparison lookup to associative containers for TR2 (Rev 1)
+N2883 Report of the 2009-05.htm">2009-05.htm">2009-05.htm">2009-05 Batavia Meeting
+N2884 C++0x Stream Positioning
+N2886 Fixing freestanding: iteration 2
+N2887 Axioms: Semantics Aspects of C++ Concepts
+N2888 Moving Futures - Proposed Wording for UK comments 335, 336, 337 and 338
+N2889 An Asynchronous Call for C++
+N2890 Unified Function Syntax
+N2891 AGENDA, PL22.16 Meeting No. 52, WG21 Meeting No. 47, October 19-24, 2009, Santa Cruz, California
+N2892 Some Concerns About Axioms
+N2893 The long pole gets longer
+N2894 C++ Standard Library Active Issues List (Revision R65)
+N2895 C++ Standard Library Defect Report List (Revision R65)
+N2896 C++ Standard Library Closed Issues List (Revision R65)
+N2898 C++ CD1 Comment Status
+N2899 Directed Rounding Arithmetic Operations (Revision 2)
+N2900 Ensuring Certain C++0x Features "just work" - Revision 1
+N2901 A simple async()
+N2902 Business Plan and Convener's Report
+N2903 New wording for C++0x Lambdas
+N2904 Defining default copy and move
+N2905 Aggregation headers
+N2906 Simplifying the use of concepts
+N2907 Managing the lifetime of thread_local variables with contexts
+N2908 Several Proposals to Simplify pair (Rev 1)
+N2909 Specifying the complexity of size()
+N2910 Comment on Proposed Trigraph Deprecation
+N2911 Minimizing Dependencies within Generic Classes for Faster and Smaller Programs
+N2913 SCARY Iterator Assignment and Initialization
+N2914 Working Draft, Standard for Programming Language C++
+N2915 Editor's Report
+N2916 Intentional Concept Mapping
+N2917 N2880 Distilled, and a New Issue With Function Statics
+N2918 Exported Concept Maps
+N2919 Concept mapping unconstrained templates
+N2920 Minutes of WG21 Meeting, July 13, 2009
+N2921 Minutes of PL22.16 Meeting, July 13, 2009
+N2923 Specifying the complexity of size()(Revision 1)
+N2924 Implicitly-Deleted Special Member Functions
+N2925 More Collected Issues with Atomics
+N2926 C++0x Stream Positioning - Revision 1
+N2927 New wording for C++0x Lambdas (rev. 2)
+N2928 Explicit Virtual Overrides
+N2929 LWG Papers to Re-Merge into C++0x After Removing Concepts
+N2930 Range-Based For Loop Wording (Without Concepts)
+N2931 Unified Function Syntax
+N2932 Fixing freestanding: iteration 2.2
+N2933 Pack Expansion and Attributes
+N2935 Fall 2009 WG21 Meeting Information
+N2936 C++ Standard Core Language Active Issues, Revision 65
+N2937 C++ Standard Core Language Defect Reports, Revision 65
+N2938 C++ Standard Core Language Closed Issues, Revision 65
+N2939 C++ CD1 Comment Status, Rev. 2
+N2940 C++ Standard Library Active Issues List (Revision R66)
+N2941 C++ Standard Library Defect Report List (Revision R66)
+N2942 C++ Standard Library Closed Issues List (Revision R66)
+N2943 Allocators without Concepts (preview)
+N2944 Equality Comparison for Unordered Containers
+N2945 Proposal to Simplify pair (rev 2)
+N2946 Allocators post Removal of C++ Concepts
+N2947 Additional Type Traits for C++0x
+N2948 C++ Standard Library Active Issues List (Revision R67)
+N2949 C++ Standard Library Defect Report List (Revision R67)
+N2950 C++ Standard Library Closed Issues List (Revision R67)
+N2951 forward
+N2952 Accessing current exception during unwinding
+N2953 Defining Move Special Member Functions
+N2954 Unified Function Syntax
+N2955 Comments on the C++ Memory Model Following a Partial Formalization Attempt
+N2956 Spring 2010 JTC1/SC22/WG21 C++ Standards Committee Meeting
+N2957 Reaching Scope of Lambda Expressions
+N2958 Moving Swap Forward
+N2959 Managing the lifetime of thread_local variables with contexts (Revision 1)
+N2960 Working Draft, Standard for Programming Language C++
+N2961 Editor's Report
+N2962 C++ Standard Core Language Active Issues, Revision 66
+N2963 C++ Standard Core Language Defect Reports, Revision 66
+N2964 C++ Standard Core Language Closed Issues, Revision 66
+N2965 Type traits and base classes
+N2967 Issues on Futures
+N2969 Background for issue 887: Clocks and Condition Variables
+N2970 A simple async() (revision 1)
+N2971 Core issue 743: decltype(...) name qualifiers
+N2972 Core issue 814: Attribute [[nothrow]]
+N2973 An Asynchronous Call for C++
+N2974 An Analysis of Async and Futures
+N2975 Collected Issues for Tuples
+N2976 constexpr in the library: take 2
+N2977 Pairs do not make good ranges
+N2978 Core issue 789: Replacing Trigraphs
+N2979 Moving Swap Forward (revision 1)
+N2980 SCARY Iterator Assignment and Initialization Revision 1
+N2981 Proposal to Simplify pair (rev 3)
+N2982 Allocators post Removal of C++ Concepts (Rev 1)
+N2983 Allowing Move Constructors to Throw
+N2984 Additional Type Traits for C++0x (Revision 1)
+N2985 C and C++ Thread Compatibility
+N2986 Equality Comparison for Unordered Containers
+N2987 Defining Move Special Member Functions
+N2988 LWG Issue 897 and other small changes to forward_list
+N2989 Unified Function Syntax
+N2990 Core issue 789: Fixing Raw Strings wrt. Trigraphs
+N2991 Core issue 743: decltype(...) name qualifiers
+N2992 More Collected Issues with Atomics
+N2993 Expanding the meaning of variable
+N2994 constexpr in the library: take 2
+N2995 Pairs do not make good ranges
+N2996 A Simple Asynchronous Call
+N2997 Issues on Futures (Rev. 1)
+N2998 Reaching Scope of Lambda Expressions
+N2999 Background for issue 887: Clocks and Condition Variables (Rev. 1)
+N3000 Working Draft, Standard for Programming Language C++
+N3001 Editor's Report
+N3002 Gaussian Integers in the Standard Library
+N3003 Minutes of WG21 Meeting, October 19, 2009
+N3004 Minutes of PL22.16 Meeting, October 19, 2009
+N3006 C++ Standard Core Language Active Issues, Revision 67
+N3007 C++ Standard Core Language Defect Reports, Revision 67
+N3008 C++ Standard Core Language Closed Issues, Revision 67
+N3009 C++ CD1 Comment Status, Rev. 3
+N3010 Rvalue References as "Funny" Lvalues
+N3011 C++ Standard Library Active Issues List (Revision R68)
+N3012 C++ Standard Library Defect Report List (Revision R68)
+N3013 C++ Standard Library Closed Issues List (Revision R68)
+N3014 AGENDA, PL22.16 Meeting No. 53, WG21 Meeting No. 48, March 8-13, 2010, Pittsburgh, PA
+N3015 Fall 2010 WG21 Meeting Information
+N3016 SUMMER 2010 JTC1/SC22/WG21 C++ STANDARDS COMMITTEE MEETING
+N3017 Agenda and Meeting Notice for WG21 Telecon Meeting, 2010-06-18
+N3018 C++ Standard Library Active Issues List (Revision R69)
+N3019 C++ Standard Library Defect Report List (Revision R69)
+N3020 C++ Standard Library Closed Issues List (Revision R69)
+N3021 Harmonizing Effects and Returns Elements in Clause 21
+N3023 Defaulting non-public special member functions on first declaration
+N3024 Proposal to Simplify pair (rev 4)
+N3025 Specifying Pointer-Like Requirements
+N3026 C++ Standard Core Language Active Issues, Revision 68
+N3027 C++ Standard Core Language Defect Reports, Revision 68
+N3028 C++ Standard Core Language Closed Issues, Revision 68
+N3029 C++ CD1 Comment Status, Rev. 4
+N3030 Rvalue References as "Funny" Lvalues
+N3031 Core issues 743 and 950: Additional decltype(...) uses
+N3032 Core issue 374: Explicit specialization outside a template's parent
+N3033 Core issue 951: Various Attribute Issues
+N3034 Core issue 968: Disambiguating [[
+N3035 Working Draft, Standard for Programming Language C++
+N3036 Editor's Report
+N3037 Conceptless Random Number Generation in C++0X
+N3038 Managing the lifetime of thread_local variables with contexts (Revision 2)
+N3039 Constexpr functions with const reference parameters (a summary)
+N3040 Various threads issues in the library (LWG 1151)
+N3041 Futures and Async Cleanup
+N3042 Renaming launch::any and what asyncs really might be
+N3043 Converting Lambdas to Function Pointers
+N3044 Defining Move Special Member Functions
+N3045 Updates to C++ Memory Model Based on Formalization
+N3046 Iterators in C++0x
+N3047 Fixing is_constructible and is_explicitly_convertible
+N3048 Defining Swappable Requirements
+N3049 Core issues 743 and 950: Additional decltype(...) uses (revision 1)
+N3050 Allowing Move Constructors to Throw (Rev. 1)
+N3051 Deprecating Exception Specifications
+N3052 Converting Lambdas to Function Pointers
+N3053 Defining Move Special Member Functions
+N3054 C++ Standard Library Active Issues List (Revision D70)
+N3055 A Taxonomy of Expression Value Categories
+N3056 Conceptless Random Number Generation in C++0X, version 2
+N3057 Explicit Initializers for Atomics
+N3058 Futures and Async Cleanup (Rev.)
+N3059 Proposal to Simplify pair (rev 5.2)
+N3060 Extensions to the C++ Library to Support Mathematical Special Functions
+N3061 Record of Response
+N3062 Core issue 789: Fixing Raw Strings wrt. Trigraphs (revision 1)
+N3063 Core issue 968: Disambiguating [[ (revision 1)
+N3064 Core issue 374: Explicit specialization outside a template's parent (revision 1)
+N3065 Removing Export
+N3066 Iterators in C++0x
+N3067 Core issue 951: Various Attribute Issues (revision 1)
+N3068 Equality Comparison for Unordered Containers (Rev 2)
+N3069 Various threads issues in the library (LWG 1151)
+N3070 Handling Detached Threads and thread_local Variables
+N3071 Renaming launch::any and what asyncs really might be (Rev.)
+N3072 Harmonizing Effects and Returns Elements in Clause 21
+N3073 Specifying Pointer-Like Requirements (Revision 1)
+N3074 Updates to C++ Memory Model Based on Formalization
+N3075 C++0X, CD 14882, National Body Comments and Responses
+N3076 SUMMER 2010 JTC1/SC22/WG21 C++ STANDARDS COMMITTEE MEETING (REVISION 1.1)
+N3077 Alternative approach to Raw String issues
+N3078 Constexpr functions with reference parameters
+N3079 Redrafting: issues 667, 861, 990, 818
+N3080 Minutes of PL22.16 Meeting, March 08, 2010
+N3081 Minutes of WG21 Meeting, March 08, 2010
+N3082 C++0x Meeting Schedule
+N3083 C++ Standard Core Language Active Issues, Revision 69
+N3084 C++ Standard Core Language Defect Reports, Revision 69
+N3085 C++ Standard Core Language Closed Issues, Revision 69
+N3086 C++ CD1 Comment Status Rev. 7
+N3087 C++ Standard Library Active Issues List (Revision R70)
+N3088 C++ Standard Library Defect Report List (Revision R70)
+N3089 C++ Standard Library Closed Issues List (Revision R70)
+N3090 Working Draft, Standard for Programming Language C++
+N3091 Editor's Report
+N3092 Programming Languages - C++
+N3093 C and C++ Alignment Compatibility
+N3094 Minutes of PL22.16 Meeting, March 08, 2010 (Revision 2 )
+N3095 Minutes of WG21 Meeting, March 08, 2010 (Revision 2)
+N3096 AGENDA, PL22.16 Meeting No. 54, WG21 Meeting No. 49, August 2-7, 2010, Rapperswil, Switzerland
+N3097 Minutes, WG21 Teleconference 2010-06-18
+N3101 Spring 2011 JTC1/SC22/WG21 C++ Standards Committee Meeting
+N3102 ISO/IEC FCD 14882, C++0X, National Body Comments
+N3103 Security impact of noexcept
+N3104 Agenda and Meeting Notice for Upcoming WG21 Telecon Meetings
+N3105 Business Plan and Convener's Report, ISO/IEC JTC1/SC22/WG21 (C++)
+N3106 Proposed Resolution for US 122: Revision of N2772 and Issue 915 to adopt it into the Standard
+N3108 Proposed Resolution for US 114: Small-string optimization not possible with current swap() specification
+N3109 US 108
+N3110 Problems with bitmask types in the library
+N3111 C++ Standard Core Language Active Issues, Revision 70
+N3112 Proposed Resolution for CH 15: Double check copy and move semantics of classes due to new rules for default move constructors and assignment operators
+N3113 Async Launch Policies (CH 36)
+N3114 throw() becomes noexcept
+N3115 C++ Standard Core Language Active Issues, Revision 72
+N3116 C++ Standard Core Language Defect Reports, Revision 72
+N3117 C++ Standard Core Language Closed Issues, Revision 72
+N3118 C++ FCD Comment Status
+N3119 Minutes of WG21 Meeting, August 2, 2010
+N3120 Minutes of PL22.16 Meeting, August 2, 2010
+N3121 Minutes, WG21 Teleconference 2010-07-23
+N3122 Observers for the three handler functions
+N3123 Bringing result_of near to INVOKE
+N3124 C and C++ Alignment Compatibility
+N3125 Omnibus Memory Model and Atomics Paper
+N3126 Working Draft, Standard for Programming Language C++
+N3127 Editor's Report
+N3128 C++ Timeout Specification
+N3129 Managing C++ Associated Asynchronous State
+N3130 Lockable requirements for C++0x
+N3131 Compile-time rational arithmetic and overflow
+N3132 Mathematizing C++ Concurrency: The Post-Rapperswil Model
+N3133 C++ Standard Library Active Issues List (Revision R71)
+N3134 C++ Standard Library Defect Report List (Revision R71)
+N3135 C++ Standard Library Closed Issues List (Revision R71)
+N3136 Coherence Requirements Detailed
+N3137 C and C++ Liaison: Compatibility for Atomics
+N3138 AGENDA: PL22.16 Meeting No. 55, WG21 Meeting No. 50, Novermber 8-13, 2010, Batavia, IL
+N3139 An Incomplete Language Feature
+N3140 Cleanup of pair and tuple
+N3141 ISO/IEC FCD 14882, C++0X, National Body Comments
+N3142 Adjustments to constructor and assignment traits
+N3143 Proposed wording for US 90
+N3144 Wording for US 84
+N3145 Deprecating unary_function and binary_function
+N3146 Recommendations for extended identifier characters for C and C++
+N3148 throw() becomes noexcept (Version 2)
+N3149 From Throws: Nothing to noexcept
+N3150 Removing non-empty dynamic exception specifications from the library
+N3151 Keywords for override control
+N3152 Progress guarantees for C++0x (US 3 and US 186)
+N3153 Implicit Move Must Go
+N3154 US 19: Ambiguous use of "use"
+N3155 More on noexcept for the language support library
+N3156 More on noexcept for the diagnostics library
+N3157 More on noexcept for the General Utilities Library
+N3158 Missing preconditions for default-constructed match_result objects
+N3159 C++ Standard Core Language Active Issues, Revision 73
+N3160 C++ Standard Core Language Defect Reports, Revision 73
+N3161 C++ Standard Core Language Closed Issues, Revision 73
+N3162 C++ FCD Comment Status, Rev. 1
+N3163 Override Control Using Contextual Keywords
+N3164 Adjusting C++ Atomics for C Compatibility
+N3165 Allocator Requirements: Alternatives to US88
+N3166 Destructors default to noexcept
+N3167 Delete operators default to noexcept
+N3168 Problems with Iostreams Member Functions (Amended from US 137)
+N3169 A Few Small Library Issues
+N3170 Clarifying C++ Futures
+N3171 Proposed resolution for US104: Allocator-aware regular expressions
+N3172 Allocators for stringstream (US140)
+N3173 Terminology for constructing container elements (US115)
+N3174 To move or not to move
+N3175 C++ Standard Library Active Issues List (Revision R72)
+N3176 C++ Standard Library Defect Report List (Revision R72)
+N3177 C++ Standard Library Closed Issues List (Revision R72)
+N3178 emplace Broken for Associative Containers
+N3179 Move and swap for I/O streams (US138)
+N3180 More on noexcept for the Strings Library
+N3181 C++ Standard Library Active Issues List (Revision R73)
+N3182 C++ Standard Library Defect Report List (Revision R73)
+N3183 C++ Standard Library Closed Issues List (Revision R73)
+N3186 Appendix C: ISO C++ 2003 Compatibility, Revision 1
+N3187 More on noexcept for the Containers Library
+N3188 Revision to N3113: Async Launch Policies (CH 36)
+N3189 Observers for the three handler functions
+N3190 C and C++ Alignment Compatibility
+N3191 C++ Timeout Specification
+N3192 Managing C++ Associated Asynchronous State
+N3193 Adjusting C++ Atomics for C Compatibility
+N3194 Clarifying C++ Futures
+N3195 From Throws: Nothing to noexcept (version 2)
+N3196 Omnibus Memory Model and Atomics Paper
+N3197 Lockable requirements for C++0x
+N3198 Deprecating unary_function and binary_function (Revision 1)
+N3199 More on noexcept for the General Utilities Library (version 2)
+N3201 Moving right along
+N3202 To which extent can noexcept be deduced?
+N3203 Tightening the conditions for generating implicit moves
+N3204 Deducing "noexcept" for destructors
+N3205 Delete operators default to noexcept
+N3206 Override control: Eliminating Attributes
+N3207 noexcept(auto)
+N3208 Library Working group Issues resolved in Batavia
+N3209 Progress guarantees for C++0x (US 3 and US 186)(revised)
+N3210 New wording for arithmetic on ratios
+N3211 Minutes, WG21 Teleconference 2010-10-29
+N3212 Minutes of WG21 Meeting, November 8, 2010
+N3213 Minutes of PL22.16 Meeting, November 8, 2010
+N3214 US 19: Ambiguous use of "use" (version 2)
+N3215 Fixing LWG 1322, Explicit CopyConstructible requirements are insufficient
+N3216 Removing Implicit Move Constructors and Move Assignment Operators
+N3217 Wording for brace-initializers as default arguments
+N3218 Core Issue 1125: Unclear definition of "potential constant expression" (DE 8, GB 26)
+N3220 AGENDA, PL22.16 Meeting No. 56, WG21 Meeting No. 51, March 21-26, 2011, Madrid, Spain
+N3221 C++ Standard Core Language Active Issues, Revision 74
+N3222 C++ Standard Core Language Defect Reports, Revision 74
+N3223 C++ Standard Core Language Closed Issues, Revision 74
+N3224 C++ FCD Comment Status, Rev. 4
+N3225 Working Draft, Standard for Programming Language C++
+N3226 Editor's Report
+N3227 Please reconsider noexcept
+N3228 Constexpr Library Additions: complex
+N3229 Constexpr Library Additions: chrono
+N3230 Constexpr Library Additions: future
+N3231 Constexpr Library Additions: support/utilities
+N3232 Spring 2011 JTC1/SC22/WG21 C++ Standards Committee Meeting
+N3233 US22/DE9 Revisited: Decltype and Call Expressions
+N3234 Remove explicit from class-head
+N3235 Generalized pointer casts
+N3236 C++ Standard Core Language Active Issues, Revision 75
+N3237 C++ Standard Core Language Defect Reports, Revision 75
+N3238 C++ Standard Core Language Closed Issues, Revision 75
+N3239 Filesystem Library Update for TR2 (Preliminary)
+N3240 Agenda and Meeting Notice for Upcoming WG21 Telecon Meetings
+N3241 CH-18 and US-85: Clarifying the state of moved-from objects
+N3242 Working Draft, Standard for Programming Language C++
+N3243 Editor's Report
+N3244 WG21 C++ Standards Committee Meeting Summer 2011
+N3245 C++ Standard Library Active Issues List (Revision R74)
+N3246 C++ Standard Library Defect Report List (Revision R74)
+N3247 C++ Standard Library Closed Issues List (Revision R74)
+N3248 noexcept Prevents Library Validation
+N3249 C++ FCD Comment Status Rev. 5
+N3250 US-18: Removing User-Defined Literals
+N3251 noexcept for the Atomics Library
+N3252 A review of noexcept in the threads library
+N3253 A Proposal to Tweak Certain C++ Contextual Conversions
+N3254 Proposed resolution for US104: Allocator-aware regular expressions (rev 2)
+N3255 C++ Decay Copy
+N3256 C++ Freestanding and Conditionally Supported
+N3257 Range-based for statements and ADL
+N3258 US-65: Removing Inheriting Constructors
+N3259 Core Issue 355: Global-scope :: in elaborated-type-specifier
+N3260 Consolidated corrections for a cluster of constexpr concerns
+N3261 Agenda and Meeting Notice for Upcoming WG21 Telecon Meetings
+N3262 Additional Core Language Issue Resolutions for Madrid
+N3263 More on noexcept for the Containers Library (revision)
+N3264 CH-18 and US-85: Clarifying the state of moved-from objects (Revision 1)
+N3265 AGENDA, PL22.16 Meeting No. 57, WG21 Meeting No. 52, August 15-19, 2011, Bloomington, IN
+N3266 Revision 2 of: Proposed Resolution for CH 15: Double check copy and move semantics of classes due to new rules for default move constructors and assignment operators
+N3267 A review of noexcept in the threads library (revised)
+N3268 static_assert and list-initialization in constexpr functions
+N3269 shared_future(future<R>&& rhs) should be allowed to throw
+N3270 Variadic Templates: Wording for Core Issues 778, 1182, and 1183
+N3271 Wording for Range-Based For Loop (Option #5)
+N3272 Follow-up on override control
+N3273 Minutes, WG21 Teleconference 2011-03-04
+N3274 Minutes of WG21 Meeting, March 21, 2011
+N3275 Minutes of PL22.16 Meeting, March 21, 2011
+N3276 US22/DE9 Revisited: Decltype and Call Expressions
+N3277 Core issues 1194/1195/1199: References and constexpr
+N3278 Recent Concurrency Issue Resolutions
+N3279 Conservative use of noexcept in the Library
+N3280 C++ Freestanding and Conditionally Supported
+N3281 692. Partial ordering of variadic class template partial specializations
+N3282 Resolution for core issues 1207 and 1017
+N3283 Dependent Bases and the Current Instantiation: Wording for Core Issue 1043
+N3284 C++ Standard Library Active Issues List (Madrid Resolutions)
+N3285 C++ Standard Library Active Issues List (Revision R75)
+N3286 C++ Standard Library Closed Issues List (Revision R75)
+N3287 C++ Standard Library Closed Issues List (Revision R75)
+N3288 Appendix C: ISO C++ 2003 Compatibility, Revision 7
+N3289 ISO/IEC FCD 14882, C++0X Responses to National Body Comments
+N3290 Programming Languages — C++
+N3291 Working Draft, Standard for Programming Language C++
+N3292 Editor's report
+N3293 C++ Standard Core Language Active Issues, Revision 76
+N3294 C++ Standard Core Language Defect Reports, Revision 76
+N3295 C++ Standard Core Language Closed Issues, Revision 76
+N3296 C++ FCD Comment Status Rev. 6
+N3297 ISO/IEC FCD 14882, C++0X, Responses to National Body Comments, Rev. 1
+N3298 Convener's report
+N3299 February 2012 Meeting
+N3300 Minutes, WG21 Teleconference 2011-08-05
+N3301 Defect Report: Terminology for Container Element Requirements
+N3302 Constexpr Library Additions: complex, v2
+N3303 Constexpr Library Additions: chrono, v2
+N3304 Constexpr Library Additions: containers
+N3305 Constexpr Library Additions: utilities, v2
+N3306 A Proposal to Tweak Certain C++ Contextual Conversions, v2
+N3307 Issues Found Implementing C++0x
+N3308 constexpr consternation
+N3309 C++ Standard Core Language Active Issues, Revision 77
+N3310 C++ Standard Core Language Defect Reports, Revision 77
+N3311 C++ Standard Core Language Closed Issues, Revision 77
+N3312 C++ Standard Library Active Issues List (Revision R76)
+N3313 C++ Standard Library Defect Report List (Revision R76)
+N3314 C++ Standard Library Closed Issues List (Revision R76)
+N3315 Minutes, PL22.16 Meeting No. 57, WG21 Meeting No. 52, 15-19 August 2011 Bloomington, Indiana, USA
+N3316 Minutes, PL22.16 Meeting No. 57, WG21 Meeting No. 52, 15-19 August 2011 Bloomington, Indiana, USA
+N3317 AGENDA, PL22.16 Meeting No. 58, WG21 Meeting No. 53, February 6-10, 2012, Kona Hawaii
+N3318 C++ Standard Library Active Issues List (Revision R77)
+N3319 C++ Standard Library Defect Report List (Revision R77)
+N3320 C++ Standard Library Closed Issues List (Revision R77)
+N3321 Agenda and Meeting Notice for Upcoming WG21 Telecon Meetings
+N3322 A Preliminary Proposal for a Static if
+N3323 A Proposal to Tweak Certain C++ Contextual Conversions, v3
+N3324 Terminology: "indirection" versus "dereference"
+N3325 HTML for C++ Standards Documents
+N3326 Sequential access to data members and base sub-objects
+N3327 A Standard Programmatic Interface for Asynchronous Operations
+N3328 Resumable Functions
+N3329 Proposal: static if declaration
+N3330 C++ Standard Core Language Active Issues, Revision 78
+N3331 C++ Standard Core Language Defect Reports, Revision 78
+N3332 C++ Standard Core Language Closed Issues, Revision 78
+N3333 Hashing User-Defined Types in C++1y
+N3334 Proposing array_ref<T> and string_ref
+N3335 Filesystem Library for C++11/TR2 (Revision 1)
+N3336 Adapting Standard Library Strings and I/O to a Unicode World
+N3337 Working Draft, Standard for Programming Language C++
+N3338 Editor's Report
+N3339 A Preliminary Proposal for a Deep-Copying Smart Pointer
+N3340 Rich Pointers
+N3341 Transactional Language Constructs for C++
+N3342 Digit Separators coming back
+N3343 Portland meeting information
+N3344 Toward a Standard C++ 'Date' Class
+N3345 C++ Language Constructs for Parallel Programming
+N3346 Defect Report: Terminology for Container Element Requirements - Rev 1
+N3347 Modules in C++ (Revision 6)
+N3348 Scoping of operator new
+N3349 Ease of using namespaces
+N3350 A minimal std::range<Iter>
+N3351 A Concept Design for the STL
+N3352 C++ Binary Fixed-Point Arithmetic
+N3353 C++ Concurrent Queues
+N3354 C++ Stream Mutexes
+N3355 C++ Distributed Counters
+N3356 C++ Mutable Threads
+N3357 C++ Standard Library Active Issues List (Revision R78)
+N3358 C++ Standard Library Defect Report List (Revision R78)
+N3359 C++ Standard Library Closed Issues List (Revision R78)
+N3360 Networking Library Status Report
+N3361 C++ Language Constructs for Parallel Programming
+N3362 Terminology: "indirection" versus "dereference" (revision 2)
+N3363 A Rational Number Library for C++
+N3365 Filesystem Library Proposal (Revision 2)
+N3366 Runtime-sized arrays with automatic storage duration
+N3367 C++ Standard Core Language Active Issues, Revision 79
+N3368 C++ Standard Core Language Defect Reports, Revision 79
+N3369 C++ Standard Core Language Closed Issues, Revision 79
+N3370 Call for Library Proposals
+N3371 Status List for Library Proposals
+N3373 AGENDA, PL22.16 Meeting No. 59, WG21 Meeting No. 54, October 15-19, 2012 - Portland, Oregon
+N3374 SG4: Networking
+N3375 Proposal for Unbounded-Precision Integer Types
+N3376 Working Draft, Standard for Programming Language C++
+N3377 C++ Editor's Report, February 2012
+N3378 A preliminary proposal for work executors
+N3379 Minutes, WG21 Teleconference 2012-01-27
+N3380 Minutes, WG21 Meeting No. 53, 6-10 February 2012 Kona, Hawaii, USA
+N3381 Minutes, PL22.16 Meeting No. 58, 6-10 February 2012 Kona, Hawaii, USA
+N3382 C++ Standard Core Language Active Issues, Revision 80
+N3383 C++ Standard Core Language Defect Reports, Revision 80
+N3384 C++ Standard Core Language Closed Issues, Revision 80
+N3386 Return type deduction for normal functions
+N3387 Overload resolution tiebreakers for integer types
+N3388 Using Asio with C++11
+N3389 Urdl: a simple library for accessing web content
+N3390 Any Library Proposal (Revision 1)
+N3391 ISO C++ SG1 Meeting Minutes for May 2012
+N3392 Minutes, WG21/SG4 Meeting 8 May 2012 Redmond, Washington, USA
+N3393 Business Plan and Convener's Report
+N3394 [[deprecated]] attribute
+N3395 C++ Stream Mutexes
+N3396 Dynamic memory allocation for over-aligned data
+N3397 Spring 2013 JTC1/SC22/WG21 C++ Standards Committee Meeting
+N3398 String Interoperation Library
+N3399 Filesystem Library Proposal (Revision 3)
+N3400 A proposal for eliminating the underscore madness that library writers have to suffer
+N3401 Generating move operations (elaborating on Core 1402)
+N3402 User-defined Literals for Standard Library Types
+N3403 Use Cases for Compile-Time Reflection
+N3404 Tuple Tidbits
+N3405 Template Tidbits
+N3406 A proposal to add a utility class to represent optional objects (Revision 2)
+N3407 Proposal to Add Decimal Floating Point Support to C++
+N3408 Parallelizing The Standard Algorithms Library
+N3409 Strict Fork-Join Parallelism
+N3410 Rich Pointers with Dynamic and Static Introspection
+N3411 Additional Searching Algorithms
+N3412 Runtime-sized arrays with automatic storage duration (revision 2)
+N3413 Allowing arbitrary literal types for non-type template parameters
+N3414 A Rational Number Library for C++
+N3415 A Database Access Library
+N3416 Packaging Parameter Packs
+N3417 Proposal for Unbounded-Precision Integer Types
+N3418 Proposal for Generic (Polymorphic) Lambda Expressions
+N3419 Vector loops and Parallel Loops
+N3420 A URI Library for C++
+N3421 Making Operator Functors greater<>
+N3422 SG5: Software Transactional Memory (TM) Status Report
+N3423 SG5: Software Transactional Memory (TM) Meeting Minutes
+N3424 Lambda Correctness and Usability Issues
+N3425 Concurrent Unordered Associative Containers for C++
+N3426 Experience with Pre-Parsed Headers
+N3427 Shared locking in C++
+N3428 A Standard Programmatic Interface for Asynchronous Operations
+N3429 A C++ Library Solution To Parallelism
+N3430 Proposing std::split()
+N3431 Quoted Strings Library Proposal
+N3432 C++ Sized Deallocation
+N3433 Clarifying Memory Allocation
+N3434 C++ Concurrent Queues
+N3435 Standardized feature-test macros
+N3436 std::result_of and SFINAE
+N3437 Type Name Strings For C++
+N3438 C++ Standard Library Active Issues List (Revision R79)
+N3439 C++ Standard Library Defect Report List (Revision R79)
+N3440 C++ Standard Library Closed Issues List (Revision R79)
+N3441 Call Stack Utilities and std::exception Extension Proposal
+N3442 string_ref: a non-owning reference to a string
+N3443 Priority Queue Changes and Additions
+N3444 Relaxing syntactic constraints on constexpr function definitions
+N3445 Pass by Const Reference or Value
+N3446 C++ Mapreduce
+N3448 Painless Digit Separation
+N3449 Open and Efficient Type Switch for C++
+N3450 Iterator-Related Improvements to Containers
+N3451 async and ~future
+N3453 Minutes, WG21 Teleconference 2012-10-5
+N3454 Minutes, WG21 Meeting No. 54, 15-19 October 2012 Portland, Oregon, USA
+N3455 Minutes, PL22.16 Meeting No. 59, 15-19 October 2012 Portland, Oregon, USA
+N3456 Range arguments for container constructors and methods, with wording
+N3457 Algorithm std::iota and its modifications.
+N3458 Simple Database Integration in C++11
+N3459 Comparison of Two Database Access Methodologies
+N3462 std::result_of and SFINAE
+N3463 Portable Program Source Files
+N3465 Adding heterogeneous comparison lookup to associative containers for TR2 (Rev 2)
+N3466 More Perfect Forwarding
+N3467 Runtime-sized arrays with automatic storage duration (revision 3)
+N3468 User-defined Literals for Standard Library Types (version 2)
+N3469 Constexpr Library Additions: chrono, v3
+N3470 Constexpr Library Additions: containers, v2
+N3471 Constexpr Library Additions: utilities, v3
+N3472 Binary Literals in the C++ Core Language
+N3473 C++ Standard Library Active Issues List (Revision R80)
+N3474 C++ Standard Library Defect Report List (Revision R80)
+N3475 C++ Standard Library Closed Issues List (Revision R80)
+N3477 C++ Internet Protocol Classes
+N3478 Core Issue 1512: Pointer comparison vs qualification conversions
+N3479 Priority Queue, Queue and Stack: Changes and Additions
+N3480 C++ Standard Core Language Active Issues, Revision 81
+N3481 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 81
+N3482 C++ Standard Core Language Closed Issues, Revision 81
+N3484 A URI Library for C++
+N3485 Working Draft, Standard for Programming Language C++
+N3486 C++ Editor's Report, October 2012
+N3487 TLS and Parallelism
+N3488 Evolution Working Group paper status
+N3489 A Rational Number Library for C++
+N3490 ADL Control for C++
+N3491 Minutes: SG4 Networking, October 2012
+N3492 Use Cases for Compile-Time Reflection (Rev. 2)
+N3493 Compile-time integer sequences
+N3494 A proposal to add special mathematical functions according to the ISO/IEC 80000-2:2009 standard
+N3495 inplace realloc
+N3496 AGENDA, PL22.16 Meeting No. 60, WG21 Meeting No. 55, April 15-20, 2013 — Bristol, UK
+N3497 Runtime-sized arrays with automatic storage duration (revision 4)
+N3498 Core Issue 1512: Pointer comparison vs qualification conversions (revision 2)
+N3499 Digit Separators
+N3500 New assert variants
+N3501 C++ Standard Core Language Active Issues, Revision 82
+N3502 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 82
+N3503 C++ Standard Core Language Closed Issues, Revision 82
+N3505 Filesystem Library Proposal (Revision 4)
+N3506 A printf-like Interface for the Streams Library
+N3507 A URI Library for C++
+N3508 Any Library Proposal (Revision 2)
+N3509 Operator Bool for Ranges
+N3510 std::split(): An algorithm for splitting strings
+N3511 exchange() utility function
+N3512 string_ref: a non-owning reference to a string, revision 2
+N3513 Range arguments for container constructors and methods, wording revision 2
+N3514 A Proposal for the World's Dumbest Smart Pointer
+N3515 Toward Opaque Typedefs for C++1Y
+N3516 C++ Standard Library Active Issues List (Revision R81)
+N3517 C++ Standard Library Defect Report List (Revision R81)
+N3518 C++ Standard Library Closed Issues List (Revision R81)
+N3519 Feb 5, 2013 SG1 Teleconference Announcement and Agenda
+N3520 Critical sections in vector loops
+N3521 convert() utility function
+N3522 C++ Standard Library Active Issues List (Revision R82)
+N3523 C++ Standard Library Defect Report List (Revision R82)
+N3524 C++ Standard Library Closed Issues List (Revision R82)
+N3525 Polymorphic Allocators
+N3526 Uniform initialization for arrays and class aggregate types
+N3527 A proposal to add a utility class to represent optional objects (Revision 2)
+N3528 Minutes of Feb 5 2013 SG1 Phone Call
+N3529 SG5: Transactional Memory (TM) Meeting Minutes 2012/10/30-2013/02/04
+N3530 Leveraging OpenMP infrastructure for language level parallelisation
+N3531 User-defined Literals for Standard Library Types (version 3)
+N3532 C++ Dynamic Arrays
+N3533 C++ Concurrent Queues
+N3534 C++ Pipelines
+N3535 C++ Stream Mutexes
+N3536 C++ Sized Deallocation
+N3537 Clarifying Memory Allocation
+N3538 Pass by Const Reference or Value
+N3539 C++ Standard Core Language Active Issues, Revision 83
+N3540 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 83
+N3541 C++ Standard Core Language Closed Issues, Revision 83
+N3542 Proposal for Unbounded-Precision Integer Types
+N3543 Priority Queue, Queue and Stack: Changes and Additions
+N3544 SG5: Transactional Memory (TM) Meeting Minutes 2013/02/25-2013/03/04
+N3545 An Incremental Improvement to integral_constant
+N3546 TransformationTraits Redux
+N3547 Three <random>-related Proposals
+N3548 Conditionally-supported Special Math Functions for C++14
+N3549 s/bound/extent/
+N3550 Proposed C++14 Value Classification
+N3551 Random Number Generation in C++11
+N3552 Introducing Object Aliases
+N3553 Proposing a C++1Y Swap Operator
+N3554 A Parallel Algorithms Library
+N3556 Thread-Local Storage in X-Parallel Computations
+N3557 Considering a Fork-Join Parallelism Library
+N3558 A Standardized Representation of Asynchronous Operations
+N3559 Proposal for Generic (Polymorphic) Lambda Expressions
+N3560 Proposal for Assorted Extensions to Lambda Expressions
+N3561 Semantics of Vector Loops
+N3562 Executors and schedulers, revision 1
+N3563 C++ Mapreduce
+N3564 Resumable Functions
+N3565 IP Address Design Constraints
+N3566 Evolution Open Issues
+N3567 Evolution Closed Issues
+N3568 Shared locking in C++
+N3569 SPRING 2014 JTC1/SC22/WG21 C++ STANDARDS COMMITTEE MEETING: Preliminary Information
+N3570 Quoted Strings Library Proposal (Revision 1)
+N3571 A Proposal to add Single Instruction Multiple Data Computation to the Standard Library
+N3572 Unicode Support in the Standard Library
+N3573 Heterogenous extensions to unordered containers
+N3574 Binding stateful functions as function pointers
+N3575 Additional Standard allocation schemes
+N3576 SG8 Concepts Teleconference Minutes - 2013-03-12
+N3577 Fall 2013 JTC1/SC22/WG21 C++ Standards Committee Meeting
+N3578 Proposing the Rule of Five
+N3579 A type trait for signatures
+N3580 Concepts Lite: Constraining Templates with Predicates
+N3581 Delimited iterators
+N3582 Return type deduction for normal functions
+N3583 Exploring constexpr at Runtime
+N3584 Wording for Accessing Tuple Fields by Type
+N3585 Iterator-Related Improvements to Containers (Revision 2)
+N3586 Splicing Maps and Sets
+N3587 For Loop Exit Strategies
+N3588 make_unique
+N3589 Summary of Progress Since Portland towards Transactional Language Constructs for C++
+N3591 Summary of Discussions on Explicit Cancellation in Transactional Language Constructs for C++
+N3592 Alternative cancellation and data escape mechanisms for transactions
+N3593 std::split(): An algorithm for splitting strings
+N3594 std::join(): An algorithm for joining a range of elements
+N3595 Simplifying Argument-Dependent Lookup Rules
+N3596 Code Reuse in Class Template Specialization
+N3597 Relaxing constraints on constexpr functions
+N3598 constexpr member functions and implicit const
+N3599 Literal operator templates for strings
+N3600 C++ Latches and Barriers
+N3601 Implicit template parameters
+N3602 Template parameter deduction for constructors
+N3603 A Three-Class IP Address Proposal
+N3604 Centralized Defensive-Programming Support for Narrow Contracts
+N3605 Member initializers and aggregates
+N3606 Extending std::search to use Additional Searching Algorithms
+N3607 Making non-modifying sequence operations more robust
+N3608 exchange() utility function, revision 2
+N3609 string_view: a non-owning reference to a string, revision 3
+N3610 Generic lambda-capture initializers, supporting capture-by-move
+N3611 A Rational Number Library for C++
+N3612 Desiderata of a C++11 Database Interface
+N3613 "Static If" Considered
+N3614 unwinding_exception
+N3615 Constexpr Variable Templates
+N3617 Lifting overload sets into function objects
+N3618 What can signal handlers do? (CWG 1441)
+N3619 A proposal to add swappability traits to the standard library
+N3620 Network byte order conversion
+N3621 Minutes, WG21 Teleconference 2013-03-29
+N3622 Minutes: WG21 Meeting No. 55, 15-20 April 2013 - Bristol, UK
+N3623 Minutes: PL22.16 Meeting No. 60, 15-20 April 2013 - Bristol, UK
+N3624 Core Issue 1512: Pointer comparison vs qualification conversions (revision 3)
+N3625 A URI Library for C++
+N3626 Floating-Point Typedefs Having Specified Widths
+N3627 Relaxed switch statement
+N3628 C and C++ Compatibility
+N3629 Simplifying C++0x Concepts
+N3630 async, ~future, and ~thread (Revision 1)
+N3631 C11: The New C Standard
+N3632 Additional std::async Launch Policies
+N3633 What can signal handlers do? (CWG 1441)
+N3634 Improvements to std::future<T> and Related APIs
+N3635 Towards restrict-like semantics for C++
+N3636 ~thread should join
+N3637 async and ~future (Revision 3)
+N3638 Return type deduction for normal functions
+N3639 Runtime-sized arrays with automatic storage duration (revision 5)
+N3640 Extending shared_ptr to Support Arrays
+N3641 Extending make_shared to Support Arrays
+N3642 User-defined Literals for Standard Library Types (part 1 - version 4)
+N3643 Range Adaptor for Selecting from Pair or Tuple
+N3644 Null Forward Iterators
+N3645 Splicing Maps and Sets (Revision 1)
+N3646 Network byte order conversion
+N3647 Minutes: PL22.16 Meeting No. 59, 15-19 October 2012 Portland, Oregon, USA
+N3648 Wording Changes for Generalized Lambda-capture
+N3649 Generic (Polymorphic) Lambda Expressions (Revision 3)
+N3650 Resumable Functions
+N3651 Variable Templates (Revision 1)
+N3652 Relaxing constraints on constexpr functions / constexpr member functions and implicit const
+N3653 Member initializers and aggregates
+N3654 Quoted Strings Library Proposal (Revision 2)
+N3655 TransformationTraits Redux, v2
+N3656 make_unique (Revision 1)
+N3657 Adding heterogeneous comparison lookup to associative containers (rev 4)
+N3658 Compile-time integer sequences
+N3659 Shared locking in C++
+N3660 User-defined Literals for std::complex, part 2 of UDL for Standard Library Types (version 4)
+N3661 Digit Separators
+N3662 C++ Dynamic Arrays
+N3663 C++ Sized Deallocation
+N3664 Clarifying Memory Allocation
+N3665 Uninterleaved String Output Streaming
+N3666 C++ Latches and Barriers
+N3667 Drafting for Core 1402
+N3668 exchange() utility function, revision 3
+N3669 Fixing constexpr member functions without const
+N3670 Wording for Addressing Tuples by Type: Revision 2
+N3671 Making non-modifying sequence operations more robust: Revision 2
+N3672 A proposal to add a utility class to represent optional objects (Revision 4)
+N3673 C++ Library Working Group Ready Issues Bristol 2013
+N3674 C++ Standard Core Language Active Issues, Revision 84
+N3675 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 84
+N3676 C++ Standard Core Language Closed Issues, Revision 84
+N3677 A Proposal to Add additional RAII Wrappers to the Standard Library
+N3678 C++ Stream Guards
+N3679 Async() future destructors must wait
+N3680 Improving pair and tuple
+N3681 Auto and braced-init lists
+N3682 C++ Standard Evolution Active Issues List (Revision R02)
+N3683 C++ Standard Evolution Completed Issues List (Revision R02)
+N3684 C++ Standard Evolution Closed Issues List (Revision R02)
+N3685 string_view: a non-owning reference to a string, revision 4
+N3686 Traversable arguments for container constructors and methods, wording revision 3
+N3687 C++ Standard Library Active Issues List (Revision R83)
+N3688 C++ Standard Library Defect Report List (Revision R83)
+N3689 C++ Standard Library Closed Issues List (Revision R83)
+N3690 Programming Languages - C++
+N3691 Working Draft, Standard for Programming Language C++
+N3692 C++ Editor's Report, October 2012
+N3693 Working Draft, Technical Specification — File System
+N3694 Feature-testing recommendations for C++
+N3695 SG5: Transactional Memory (TM) Meeting Minutes 2013/03/11-2013/06/10
+N3696 Proposal to extend atomic with priority update functions
+N3697 Business Plan and Convener's Report
+N3698 July 25-26 Santa Clara SG1 Meeting Announcement and Agenda
+N3699 A proposal to add a generalized callable negator
+N3700 Hierarchical Data Structures and Related Concepts for the C++ Standard Library
+N3701 Concepts Lite
+N3702 Introducing an optional parameter for mem_fn, which allows to bind an object to its member function
+N3703 Extending std::search to use Additional Searching Algorithms (Version 3)
+N3704 AGENDA, PL22.16 Meeting No. 61, WG21 Meeting No. 56, September 23-28, 2013 - Chicago, IL, USA
+N3705 Agenda and Meeting Notice for WG21 Telecon Meeting
+N3706 C++ Distributed Counters
+N3707 2014-02 Meeting Invitation and Information
+N3708 A proposal to add coroutines to the C++ standard library
+N3709 Minutes for July 2013 Santa Clara SG1 Meeting
+N3710 Specifying the absence of "out of thin air" results (LWG2265)
+N3711 Task Groups As a Lower Level C++ Library Solution To Fork-Join Parallelism
+N3712 Policy-Based Design for Safe Destruction in Concurrent Containers
+N3713 C++ Standard Core Language Active Issues, Revision 85
+N3714 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 85
+N3715 C++ Standard Core Language Closed Issues, Revision 85
+N3716 A printf-like Interface for the Streams Library
+N3717 SG5: Transactional Memory (TM) Meeting Minutes 2013/06/24-2013/08/26
+N3718 Transactional Memory Support for C++
+N3719 Extend INVOKE to support types convertible to target class
+N3720 Working Draft Technical Specification - URI
+N3721 Improvements to std::future<T> and Related APIs
+N3722 Resumable Functions
+N3723 Extend operator-> to support rvalues
+N3724 A Parallel Algorithms Library
+N3725 Original Draft Specification of Transactional Language Constructs for C++ Version 1.1 (February 3, 2012)
+N3726 Polymorphic Memory Resources
+N3727 A proposal to add invoke function template
+N3728 Packaging Parameter Packs (Rev. 2)
+N3729 Invocation type traits
+N3730 Specializations and namespaces
+N3731 Executors and schedulers, revision 2
+N3732 Value-Oriented Concurrent Unordered Containers
+N3733 ISO/IEC CD 14882, C++ 2014, National Body Comments
+N3734 Vector Programming: A proposal for WG21
+N3735 On the difference between parallel loops and vector loops
+N3736 C++ Standard Evolution Active Issues List (Revision R03)
+N3737 C++ Standard Evolution Completed Issues List (Revision R03)
+N3738 C++ Standard Evolution Closed Issues List (Revision R03)
+N3739 Improving pair and tuple, revision 1
+N3740 A Proposal for the World's Dumbest Smart Pointer, v2
+N3741 Toward Opaque Typedefs for C++1Y, v2
+N3742 Three <random>-related Proposals, v2
+N3743 Conditionally-supported Special Math Functions for C++14, v2
+N3744 Proposing [[pure]]
+N3745 Feature-testing recommendations for C++
+N3746 Proposing a C++1Y Swap Operator, v2
+N3747 A Universal Model for Asynchronous Operations
+N3748 Implicit Evaluation of "auto" Variables and Arguments
+N3749 Constexpr Library Additions: functional
+N3750 C++ Ostream Buffers
+N3751 Object Lifetime, Low-level Programming, and memcpy
+N3752 Index Based Ranges
+N3753 Centralized Defensive-Programming Support for Narrow Contracts (Revision 1)
+N3754 C++ Standard Library Active Issues List (Revision R84)
+N3755 C++ Standard Library Defect Report List (Revision R84)
+N3756 C++ Standard Library Closed Issues List (Revision R84)
+N3757 Support for user-defined exception information and diagnostic information in std::exception
+N3758 Standard exception information types for std::exception
+N3759 SIMD Vector Types
+N3760 [[deprecated]] attribute
+N3761 Proposing type_at<>
+N3762 string_view: a non-owning reference to a string, revision 5
+N3763 Traversable arguments for container constructors and methods, wording revision 4
+N3764 Ruminations on relational operators
+N3765 On Optional
+N3766 The identity type transformation
+N3767 Teleconference Minutes (September 2013)
+N3768 Minutes (September 2013)
+N3769 Minutes: PL22.16 Meeting No. 61, 2013-09 Chicago Minutes
+N3770 C++ CD Comment Status, Rev. 1
+N3771 Canadian C++14 Comments
+N3772 Changing the type of address-of-member expression
+N3773 async and ~future (Revision 4)
+N3774 C++ Needs Language Support For Vectorization
+N3775 Deprecating rand() and Friends
+N3776 Wording for ~future
+N3777 Wording for deprecating async
+N3778 C++ Sized Deallocation
+N3779 User-defined Literals for std::complex
+N3780 Why Deprecating async() is the Worst of all Options
+N3781 Single-Quotation-Mark as a Digit Separator
+N3782 Index Based Ranges (Rev. 1)
+N3783 Network Byte Order Conversion
+N3784 Improvements to std::future<T> and Related APIs
+N3785 Executors and schedulers, revision 3
+N3786 Prohibiting "out of thin air" results in C++14
+N3787 What can signal handlers do? (CWG 1441)
+N3788 Immediate issues
+N3789 Constexpr Library Additions: functional
+N3790 Working Draft, Technical Specification — File System
+N3791 Lightweight Drawing Library - Objectives, Requirements, Strategies
+N3792 Working Draft Technical Specification - URI
+N3793 A proposal to add a utility class to represent optional objects (Revision 5)
+N3794 Proposal to Add Multi-Dimensional Support to std::array
+N3795 A more common version of algorithm std::partition_copy
+N3796 std::rand replacement
+N3797 Working Draft, Standard for Programming Language C++
+N3798 C++ Editor's Report, October 2013
+N3799 AGENDA: PL22.16 Meeting No. 62, WG21 Meeting No. 57, February 10-15, 2014 - Issaquah, WA, USA
+N3800 A proposal to add a generalized callable negator (Revision 1)
+N3801 Removing Undefined Behavior from the Preprocessor
+N3802 apply() call a function with arguments from a tuple
+N3803 Programming Languages — C++ Standard Library — File System Technical Specification
+N3804 Any Library Proposal (Revision 3)
+N3805 SPRING 2014 JTC1/SC22/WG21 C++ STANDARDS COMMITTEE MEETING: Preliminary Information
+N3806 C++ Standard Core Language Active Issues, Revision 86
+N3807 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 86
+N3808 C++ Standard Core Language Closed Issues, Revision 86
+N3810 Alternatives for Array Extensions
+N3811 C++ Standard Evolution Active Issues List (Revision R04)
+N3812 C++ Standard Evolution Completed Issues List (Revision R04)
+N3813 C++ Standard Evolution Closed Issues List (Revision R04)
+N3814 Call for Compile-Time Reflection Proposals
+N3815 Enumerator List Property Queries
+N3816 Polymorphic Memory Resources - r1
+N3817 C++ Latches and Barriers
+N3818 Centralized Defensive-Programming Support for Narrow Contracts (Revision 2)
+N3819 Concepts Lite Specification
+N3820 Working Draft, Technical Specification — Array Extensions
+N3821 C++ Standard Library Active Issues List (Revision R85)
+N3822 C++ Standard Library Defect Report List (Revision R85)
+N3823 C++ Standard Library Closed Issues List (Revision R85)
+N3824 make_array
+N3825 SG13 Graphics Discussion
+N3826 Agenda and Meeting Notice for WG21 Telecon Meeting
+N3827 Working Draft Technical Specification - URI
+N3828 FALL 2014 JTC1/SC22/WG21 C++ Standards Committee Meeting
+N3829 apply() call a function with arguments from a tuple (V2)
+N3830 Scoped Resource - Generic RAII Wrapper for the Standard Library
+N3831 Language Extensions for Vector level parallelism
+N3832 Task Region
+N3833 C++ Standard Core Language Active Issues, Revision 87
+N3834 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 87
+N3835 C++ Standard Core Language Closed Issues, Revision 87
+N3836 C++ Standard Evolution Active Issues List (Revision R05)
+N3837 C++ Standard Evolution Completed Issues List (Revision R05)
+N3838 C++ Standard Evolution Closed Issues List (Revision R05)
+N3839 Proposing the Rule of Five, v2
+N3840 A Proposal for the World's Dumbest Smart Pointer, v3
+N3841 Discouraging rand() in C++14
+N3842 A sample Proposal
+N3843 A SFINAE-Friendly std::common_type
+N3844 A SFINAE-Friendly std::iterator_traits
+N3845 Greatest Common Divisor and Least Common Multiple
+N3846 Extending static_assert
+N3847 Random Number Generation is Not Simple!
+N3848 Working Draft, Technical Specification on C++ Extensions for Library Fundamentals
+N3849 string_view: a non-owning reference to a string, revision 6
+N3850 Working Draft, Technical Specification for C++ Extensions for Parallelism
+N3851 Multidimensional bounds, index and array_view
+N3852 C++ CD Status, Rev. 1
+N3853 Range-Based For-Loops: The Next Generation
+N3854 Variable Templates For Type Traits
+N3856 Unforgetting standard functions min/max as constexpr
+N3857 Improvements to std::future<T> and Related APIs
+N3858 Resumable Functions
+N3859 Transactional Memory Support for C++
+N3861 Transactional Memory (TM) Meeting Minutes 2013/09/09-2014/01/20
+N3862 Towards a Transaction-safe C++ Standard Library: std::list
+N3863 Private Extension Methods
+N3864 A constexpr bitwise operations library for C++
+N3865 More Improvements to std::future<T>
+N3866 Invocation type traits (Rev. 2)
+N3867 Specializations and namespaces (Rev. 2)
+N3869 Extending shared_ptr to Support Arrays, Revision 1
+N3870 Extending make_shared to Support Arrays, Revision 1
+N3871 Proposal to Add Decimal Floating Point Support to C++ (revision 2)
+N3872 A Primer on Scheduling Fork-Join Parallelism with Work Stealing
+N3873 Improved insertion interface for unique-key maps
+N3874 Light-Weight Execution Agents
+N3875 Run-time bound array data members
+N3876 Convenience Functions to Combine Hash Values
+N3877 Centralized Defensive-Programming Support for Narrow Contracts (Revision 3)
+N3878 Extensions to the Concept Introduction Syntax in Concepts Lite
+N3879 Explicit Flow Control: break label, goto case and explicit switch
+N3880 Improving the Verification of C++ Programs
+N3881 Fixing the specification of universal-character-names
+N3882 An update to the preprocessor specification
+N3883 Code checkers & generators
+N3884 Contiguous Iterators: A Refinement of Random Access Iterators
+N3886 A Proposal to add a Database Access Layer to the Standard Library
+N3887 Consistent Metafunction Aliases
+N3888 A Proposal to Add 2D Graphics Rendering and Display to C++
+N3889 Concepts Lite Specification
+N3890 Container<Incomplete Type>
+N3891 A proposal to rename shared_mutex to shared_timed_mutex
+N3892 C++ Ostream Buffers
+N3893 C++ Standard Library Active Issues List (Revision R86)
+N3894 C++ Standard Library Defect Report List (Revision R86)
+N3895 C++ Standard Library Closed Issues List (Revision R86)
+N3896 LIBRARY FOUNDATIONS FOR ASYNCHRONOUS OPERATIONS
+N3897 Auto-type members
+N3898 HASHING AND FINGERPRINTING
+N3899 Nested Allocation
+N3900 WG21 2014-01-31 Telecon Minutes
+N3901 Minutes (February 2014) WG21 Meeting No. 57
+N3902 Minutes (February 2014) PL22.16 Meeting No. 62
+N3903 C++ CD Comment Status Rev. 6
+N3905 Extending std::search to use Additional Searching Algorithms (Version 4)
+N3906 ISO/IEC PDTS 18822, File System, National Body Comments
+N3908 Working Draft, Information technology – Programming languages, their environments and system software interfaces – C++ Extensions for Library Fundamentals
+N3909 A SFINAE-Friendly std::iterator_traits, v2
+N3910 What can signal handlers do? (CWG 1441)
+N3911 TransformationTrait Alias void_t
+N3912 Auto and braced-init-lists, continued
+N3913 Greatest Common Divisor and Least Common Multiple, v2
+N3914 Additional Core Language Issue Resolutions for Issaquah
+N3915 apply() call a function with arguments from a tuple (V3)
+N3916 Polymorphic Memory Resources - r2
+N3918 Core Issue 1299: Temporary objects vs temporary expressions
+N3919 Transactional Memory Support for C++
+N3920 Extending shared_ptr to Support Arrays, Revision 2
+N3921 string_view: a non-owning reference to a string, revision 7
+N3922 New Rules for auto deduction from braced-init-list
+N3923 A SFINAE-Friendly std::iterator_traits, v3
+N3924 Discouraging rand() in C++14, v2
+N3925 A sample Proposal, v4
+N3926 LWG Issue 2168 is NAD
+N3927 Definition of Lock-Free
+N3928 Extending static_assert, v2
+N3929 Concepts Lite Specification
+N3930 Immediate Issues
+N3931 Immediate Issues
+N3932 Variable Templates For Type Traits (Revision 1)
+N3936 Working Draft, Standard for Programming Language C++
+N3937 Programming Languages — C++
+N3938 Editor's Report
+N3939 Extending make_shared to Support Arrays, Revision 2
+N3940 Working Draft, Technical Specification – File System
+N3941 Filesystem Study Group (SG3) Active Issues List (Revision R0)
+N3942 Filesystem Study Group (SG3) Closed Issues List (Revision R0)
+N3943 Filesystem Study Group (SG3) Defect Report List (Revision R0)
+N3944 C++ Standard Library Active Issues List (Revision R87)
+N3945 C++ Standard Library Defect Report List (Revision R87)
+N3946 C++ Standard Library Closed Issues List (Revision R87)
+N3947 URI - Proposed Wording (Revision 4)
+N3948 Feature-testing for C++ Technical Specifications
+N3949 Scoped Resource - Generic RAII Wrapper for the Standard Library
+N3950 Defaulted comparison operators
+N3951 C++ type reflection via variadic template expansion
+N3952 C++ Standard Core Language Active Issues, Revision 88
+N3953 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 88
+N3954 C++ Standard Core Language Closed Issues, Revision 88
+N3955 Group Member Specifiers
+N3956 ISO/IEC CD 14882, C++ 2014 Responses to National Body Comments
+N3957 C++ Standard Evolution Active Issues List (Revision R06)
+N3958 C++ Standard Evolution Completed Issues List (Revision R06)
+N3959 C++ Standard Evolution Closed Issues List (Revision R06)
+N3960 Working Draft, Technical Specification for C++ Extensions for Parallelism
+N3961 A proposal to add shared_mutex (untimed)
+N3962 File System TS Editor's Report, February 2014 - Post-Issaquah
+N3963 Centralized Defensive-Programming Support for Narrow Contracts (Revision 4)
+N3964 Library Foundations for Asynchronous Operations, Revision 1
+N3965 Proposal for Unbounded-Precision Integer Types
+N3966 Fixes for optional objects
+N3967 C++ Standard Library Active Issues List (Revision R88)
+N3968 C++ Standard Library Defect Report List (Revision R88)
+N3969 C++ Standard Library Closed Issues List (Revision R88)
+N3970 Working Draft, Technical Specification for C++ Extensions for Concurrency
+N3971 Concurrency TS Editor's Report, May 2014
+N3972 Source-Code Information Capture
+N3973 A Proposal to Add a Logical Const Wrapper to the Standard Library Technical Report
+N3974 Polymorphic Deleter for Unique Pointers
+N3975 URI - Proposed Wording (Revision 5)
+N3976 Multidimensional bounds, index and array_view, revision 2
+N3977 Resumable Functions
+N3978 C++ Ostream Buffers
+N3979 AGENDA, PL22.16 Meeting No. 63, WG21 Meeting No. 58, June 16-21, 2014 — Rapperswil, Switzerland
+N3980 Types don't know #
+N3981 Removing trigraphs??!
+N3982 Rvalue reference overloads for optional
+N3983 Hashing tuple-like types
+N3984 Adding attribute reflection to C++.
+N3985 A proposal to add coroutines to the C++ standard library (Revision 1)
+N3986 Adding Standard support to avoid padding within structures
+N3987 Yet another set of C++ type traits.
+N3988 Towards restrict-like aliasing semantics for C++
+N3989 Working Draft, Technical Specification for C++ Extensions for Parallelism
+N3990 Adding Standard Circular Shift operators for computer integers
+N3991 Task Region R2
+N3992 Agenda and Meeting Notice for WG21 Telecon Meeting
+N3993 On Parallel Invocations of Functions in Parallelism TS
+N3994 Range-Based For-Loops: The Next Generation (Revision 1)
+N3995 A proposal to add shared_mutex (untimed) (Revision 2)
+N3996 Static reflection
+N3997 Centralized Defensive-Programming Support for Narrow Contracts (Revision 5)
+N3998 C++ Latches and Barriers
+N3999 Standard Wording for Transactional Memory Support for C++
+N4000 Towards a Transaction-safe C++ Standard Library: std::list
+N4001 SG5: Transactional Memory (TM) Meeting Minutes 2014/02/03-2014/05/19
+N4002 Cleaning-up noexcept in the Library
+N4003 File System TS Active Issues List (Revision R1)
+N4004 File System TS Closed Issues List (Revision R1)
+N4005 File System TS Defect Report List (Revision R1)
+N4006 An improved emplace() for unique-key maps
+N4007 Delimited iterators (Rev. 2)
+N4008 SIMD polymorphism
+N4009 Uniform Container Erasure
+N4010 C++ Standard Evolution Active Issues List (Revision R07)
+N4011 C++ Standard Evolution Completed Issues List (Revision R07)
+N4012 C++ Standard Evolution Closed Issues List (Revision R07)
+N4013 Atomic operations on non-atomic data
+N4014 Uniform Copy Initialization
+N4015 A proposal to add a utility class to represent expected monad
+N4016 Light-Weight Execution Agents Revision 2
+N4017 Non-member size() and more
+N4018 C++ Standard Core Language Active Issues, Revision 89
+N4019 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 89
+N4020 C++ Standard Core Language Closed Issues, Revision 89
+N4021 A Proposal to Add 2D Graphics Rendering and Display to C++
+N4022 A proposal to add a generalized callable negator (Revision 2)
+N4023 Working Draft, C++ Extensions for Library Fundamentals
+N4024 Distinguishing coroutines and fibers
+N4025 Exploring classes of runtime size
+N4026 Nested namespace definition
+N4027 Type Member Property Queries (rev 2)
+N4028 Defining a Portable C++ ABI
+N4029 Let return Be Direct and explicit
+N4030 Feature-testing recommendations for C++
+N4031 make_array, revision 1
+N4032 Comments on continuations and executors
+N4033 synchronized_value<T> for associating a mutex with a value
+N4034 Destructive Move
+N4035 Implicit Evaluation of "auto" Variables and Arguments
+N4036 Towards Implementation and Use of memory_order_consume
+N4037 Non-Transactional Implementation of Atomic Tree Move
+N4038 Proposal for Unbounded-Precision Integer Types
+N4039 Default executor
+N4040 Working Draft, C++ Extensions for Concepts
+N4041 Concerns with changing existing types in Technical Specifications
+N4042 Safe conversions in unique_ptr<T[]>
+N4043 Dynarray Allocation Context
+N4044 A Three-Class IP Address Proposal, Revision 1
+N4045 Library Foundations for Asynchronous Operations, Revision 2
+N4046 Executors and Asynchronous Operations
+N4047 A Module System for C++
+N4048 More Improvements to std::future<T> - Revision 1
+N4049 0-overhead-principle violations in exception handling
+N4050 Dynarray Semi-Editorial Issues
+N4051 Allow typename in a template template parameter
+N4052 WG21 2014-06-06 Telecon Minutes
+N4053 WG21 2014-06 Rapperswil Minutes
+N4054 PL22.16 2014-06 Rapperswil Minutes
+N4055 Ruminations on (node-based) containers and noexcept
+N4056 Minimal incomplete type support for standard containers
+N4057 A Proposal to Add a Const-Propagating Wrapper to the Standard Library
+N4058 Atomic Smart Pointers
+N4059 Spring 2015 C++ Standards Committee Meeting
+N4060 Changes to vector_execution_policy
+N4061 Greatest Common Divisor and Least Common Multiple, v3
+N4063 On Parallel Invocations of Functions in Parallelism TS
+N4064 Improving pair and tuple, revision 2
+N4065 make_array, revision 2
+N4066 Delimited iterators (Rev. 3)
+N4067 Experimental std::function etc.
+N4068 Toward More Expressive Iterator Tags
+N4069 C++ Ostream Buffers
+N4070 Improving the specification of the vector execution policy in Parallelism TS
+N4071 Working Draft, Technical Specification for C++ Extensions for Parallelism
+N4072 Fixed Size Parameter Packs
+N4073 A Proposal to Add 2D Graphics Rendering and Display to C++
+N4074 Let return {expr} Be Explicit, Revision 2
+N4075 Centralized Defensive-Programming Support for Narrow Contracts (Revision 5)
+N4076 A proposal to add a generalized callable negator (Revision 2)
+N4077 Experimental shared_ptr for Library Fundamentals TS
+N4078 Fixes for optional objects
+N4079 C++ Standard Library Issues Resolved Directly In Rapperswil, 2014
+N4080 File System TS Immediate Issues for Rapperswil
+N4081 Working Draft, C++ Extensions for Library Fundamentals
+N4082 Programming Languages — C++ Extensions for Library Fundamentals
+N4083 Editor's Report for Version 1 of the Library Fundamentals TS
+N4084 Working Draft, C++ Extensions for Library Fundamentals, Version 2
+N4085 Editor's Report for Version 2 of the Library Fundamentals TS
+N4086 Removing trigraphs??!
+N4087 Multidimensional bounds, index and array_view, revision 3
+N4088 Task Region R3
+N4089 Safe conversions in unique_ptr<T[]>, revision 2
+N4090 The Maladies of All Member Templates: An Incomplete Biography of Specialization (DR727 + DR1755)
+N4091 C++ Standard Core Language Active Issues, Revision 90
+N4092 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 90
+N4093 C++ Standard Core Language Closed Issues, Revision 90
+N4094 Response To: Let return {expr} Be Explicit
+N4095 File System TS Active Issues List (Revision R2)
+N4096 File System TS Closed Issues List (Revision R2)
+N4097 File System TS Defect Report List (Revision R2)
+N4098 File System TS Editor's Report, Post-Rapperswil
+N4099 Working Draft, Technical Specification — File System
+N4100 Programming Languages — C++ — File System Technical Specification
+N4101 C++ Standard Evolution Active Issues List (Revision R08)
+N4102 C++ Standard Evolution Completed Issues List (Revision R08)
+N4103 C++ Standard Evolution Closed Issues List (Revision R08)
+N4104 Working Draft, Technical Specification for C++ Extensions for Parallelism
+N4105 Information technology – Programming languages, their environments and system software interfaces – Technical Specification for C++ Extensions for Parallelism
+N4106 Parallelism TS Editor's Report, post-Rapperswil
+N4107 Working Draft, Technical Specification for C++ Extensions for Concurrency
+N4108 Concurrency TS Editor's Report, July 2014
+N4109 A proposal to add a utility class to represent expected monad - Revision 1
+N4110 Exploring the design space of contract specifications for C++
+N4111 Static reflection (rev. 2)
+N4112 File System PDTS National Body Comments Record of Response
+N4113 Reflection Type Traits For Classes, Unions and Enumerations (rev 3)
+N4114 Defaulted comparison operators
+N4115 Searching for Types in Parameter Packs
+N4116 Nested Namespace Definition (rev 1)
+N4117 C++ Standard Library Active Issues List (Revision R89)
+N4118 C++ Standard Library Defect Report List (Revision R89)
+N4119 C++ Standard Library Closed Issues List (Revision R89)
+N4120 Null Coalescing Conditional Operator
+N4121 Compile-Time String: std::string_literal<n>
+N4122 AGENDA, PL22.16 Meeting No. 64, WG21 Meeting No. 59, November 3-8, 2014 – Urbana-Champaign, IL
+N4123 Improvements to the Concurrency Technical Specification
+N4124 Toward More Expressive Iterator Tags
+N4125 2014-09 WG21/SG1 Meeting Information
+N4126 Explicitly defaulted comparison operators
+N4127 Checked-dereference conditions
+N4128 Ranges for the Standard Library, Revision 1
+N4129 Source-Code Information Capture
+N4130 Pad Thy Atomics
+N4131 explicit should never be implicit
+N4132 Contiguous Iterators
+N4133 Cleanup for exception-specification and throw-expression
+N4134 Resumable Functions v.2
+N4135 Language Support for Runtime Contract Validation (Revision 8)
+N4136 C Concurrency Challenges Draft
+N4137 Business Plan and Convener's Report
+N4138 Editor's Report — Working Draft, Standard for Programming Language C++
+N4139 Editor's Report — Programming Languages — C++
+N4140 Working Draft, Standard for Programming Language C++
+N4141 Programming Languages — C++
+N4142 Atomic Operations on a Very Large Array
+N4143 Executors and schedulers, revision 4
+N4144 Searching and Manipulation of Parameter Packs
+N4145 Data-Invariant Functions
+N4146 Disposition of Comments, ISO/IEC DIS 14882 C++ 2014
+N4147 Inline variables, or encapsulated expressions
+N4148 Disallowing Inaccessible Operators From Trivially Copyable
+N4149 Categorically qualified classes
+N4150 Alias-Set Attributes: Toward restrict-like aliasing semantics for C++
+N4151 TriviallyCopyable reference_wrapper
+N4152 uncaught_exceptions
+N4153 2015-02 LWG Meeting Invitation and Information
+N4154 Operator assert
+N4155 Non-member size() and more (Revision 1)
+N4156 Light-Weight Execution Agents Revision 3
+N4157 Relaxing Packaging Rules for Exceptions Thrown by Parallel Algorithms
+N4158 Destructive Move (Rev 1)
+N4159 std::function and Beyond
+N4160 Value constraints
+N4161 Uniform Container Erasure (Revision 1)
+N4162 Atomic Smart Pointers, rev. 1
+N4163 Agenda and Meeting Notice for WG21 Telecon Meeting
+N4164 Forwarding References
+N4165 Unified Call Syntax
+N4166 Movable initializer lists
+N4167 Transform Reduce, an Additional Algorithm for C++ Extensions for Parallelism
+N4168 Removing auto_ptr
+N4169 A proposal to add invoke function template (Revision 1)
+N4170 Extend INVOKE to support types convertible to target class (Revision 1)
+N4171 Parameter group placeholders for bind
+N4172 Named arguments
+N4173 Operator Dot
+N4174 Call syntax: x.f(y) vs. f(x,y)
+N4175 Default comparisons
+N4176 Thoughts about Comparisons
+N4177 Multidimensional bounds, index and array_view, revision 4
+N4178 Proposed resolution for Core Issue 330: Qualification conversions and pointers to arrays of pointers
+N4179 Transactional Memory Support for C++: Wording (revision 2)
+N4180 SG5 Transactional Memory Support for C++ Update
+N4182 SG5: Transactional Memory (TM) Meeting Minutes 2014/07/14-2014/10/06
+N4183 Contiguous Iterators: Pointer Conversion & Type Trait
+N4184 SIMD Types: The Vector Type & Operations
+N4185 SIMD Types: The Mask Type & Write-Masking
+N4186 Supporting Custom Diagnostics and SFINAE
+N4187 C++ Ostream Buffers
+N4188 Proposal for classes with runtime size
+N4189 Generic Scope Guard and RAII Wrapper for the Standard Library
+N4190 Removing auto_ptr, random_shuffle(), And Old <functional> Stuff
+N4191 Folding expressions
+N4192 C++ Standard Core Language Active Issues, Revision 91
+N4193 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 91
+N4194 C++ Standard Core Language Closed Issues, Revision 91
+N4195 std::synchronic<T>
+N4196 Attributes for namespaces and enumerators
+N4197 Adding u8 character literals
+N4198 Allow constant evaluation for all non-type template arguments
+N4199 Minutes of Sept. 4-5, 2014 SG1 meeting in Redmond, WA
+N4200 Feature-testing recommendations for C++
+N4201 Alignment Helpers for C++
+N4202 Strongly Typed Bitset
+N4203 Fast ASCII Character Manipulation
+N4204 C++ Latches and Barriers
+N4205 Working Draft, C++ Extensions for Concepts
+N4206 C++ Standard Evolution Active Issues List (Revision R09)
+N4207 C++ Standard Evolution Completed Issues List (Revision R09)
+N4208 C++ Standard Evolution Closed Issues List (Revision R09)
+N4209 A Proposal to Add a Const-Propagating Wrapper to the Standard Library
+N4210 IBM comment on preparing for a Trigraph-adverse future in C++17
+N4211 File System TS Active Issues List (Revision R3)
+N4212 File System TS Closed Issues List (Revision R3)
+N4213 File System TS Defect Report List (Revision R3)
+N4214 A Module System for C++ (Revision 2)
+N4215 Towards Implementation and Use of memory_order_consume
+N4216 Out-of-Thin-Air Execution is Vacuous
+N4217 std::rand replacement
+N4218 Variant: a typesafe union
+N4219 Fixing the specification of universal-character-names (rev. 2)
+N4220 An update to the preprocessor specification (rev. 2)
+N4221 Generalized lifetime extension
+N4222 Minimal Additions to the Array View Library for Performance and Interoperability
+N4223 Response To: Let return {expr} Be Explicit
+N4224 Supplements to C++ Latches
+N4225 Towards uniform handling of subobjects
+N4226 Apply the [[noreturn]] attribute to main as a hint to eliminate global object destructor calls
+N4227 Cleaning-up noexcept in the Library (Rev 2)
+N4228 Refining Expression Evaluation Order for Idiomatic C++
+N4229 Pointer Ordering
+N4230 Nested namespace definition (revision 2)
+N4231 Terms and definitions related to "threads"
+N4232 Stackful Coroutines and Stackless Resumable Functions
+N4233 A Class for Status and Optional Value
+N4234 0-overhead-principle violations in exception handling - part 2
+N4235 Selecting from Parameter Packs
+N4236 A compile-time string library template with UDL operator templates
+N4237 Language Extensions for Vector loop level parallelism
+N4238 An Abstract Model of Vector Parallelism
+N4239 Defaulted Comparison Using Reflection
+N4240 Improved insertion interface for unique-key maps (Revision 2)
+N4241 A proposal to add shared_mutex (untimed) (Revision 3)
+N4242 Executors and Asynchronous Operations, Revision 1
+N4243 Networking Library Proposal (Revision 2)
+N4244 Resumable Lambdas: A language extension for generators and coroutines
+N4245 C++ Standard Library Active Issues List (Revision R90)
+N4246 C++ Standard Library Defect Report List (Revision R90)
+N4247 C++ Standard Library Closed Issues List (Revision R90)
+N4248 Library Preconditions are a Language Feature
+N4249 Networking Primitives: std::experimental::network::htonl Considered Harmful
+N4250 WG21 2014-10-24 Telecon Minutes
+N4251 WG21 2014-11 Urbana Minutes
+N4252 PL22.16 2014-11 Urbana Minutes
+N4253 Language Support for Runtime Contract Validation (Revision 9)
+N4254 User-defined Literals for size_t and ptrdiff_t
+N4255 Proposed resolution for US104: Allocator-aware regular expressions (rev 3)
+N4257 Delimited iterators (rev 4)
+N4258 Cleaning up noexcept in the Library (Rev 3)
+N4259 Wording for std::uncaught_exceptions
+N4260 Wording for Atomic Smart Pointers
+N4261 Proposed resolution for Core Issue 330: Qualification conversions and pointers to arrays of pointers
+N4262 Wording for Forwarding References
+N4263 Toward a concept-enabled standard library
+N4265 Transactional Memory Support for C++: Wording (revision 3)
+N4266 Attributes for namespaces and enumerators
+N4267 Adding u8 character literals
+N4268 Allow constant evaluation for all non-type template arguments
+N4270 Consolidated Revisions to C++ Extensions for Library Fundamentals
+N4272 Working Draft, Technical Specification for C++ Extensions for Transactional Memory
+N4273 Uniform Container Erasure (Revision 2)
+N4274 Relaxing Packaging Rules for Exceptions Thrown by Parallel Algorithms - Proposed Wording (Revision 1)
+N4275 Parallelism PDTS Comment Responses
+N4276 Adding Fused Transform Algorithms to the Parallelism TS
+N4277 TriviallyCopyable reference_wrapper (Revision 1)
+N4279 Improved insertion interface for unique-key maps (Revision 2.3)
+N4280 Non-member size() and more (Revison 2)
+N4282 A Proposal for the World's Dumbest Smart Pointer, v4
+N4284 Contiguous Iterators
+N4285 Cleanup for exception-specification and throw-expression
+N4286 Resumable Functions (revision 3)
+N4287 Threads, Fibers and Couroutines (slides deck)
+N4288 Strike string_view::clear from Library Fundamentals
+N4293 C++ language support for contract programming
+N4294 Arrays of run-time bounds as data members
+N4295 Folding Expressions
+N4296 Working Draft, Standard for Programming Language C++
+N4297 Editor's Report — Programming Languages — C++
+N4298 Agenda and Meeting Notice for WG21 Ballot Resolution Telecon Meeting
+N4301 Working Draft, Technical Specification for C++ Extensions for Transactional Memory
+N4302 Technical Specification for C++ Extensions for Technical Specification for C++ Extensions for Transactional Memory
+N4303 Pointer Safety and Placement New
+N4304 C++ Standard Core Language Active Issues, Revision 92
+N4305 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 92
+N4306 C++ Standard Core Language Closed Issues, Revision 92
+N4307 National Body Comment — ISO/IEC PDTS 19568 — Technical Specification: C++ Extensions for Library Fundamentals
+N4308 National Body Comment — ISO/IEC PDTS 19570 — Technical Specification: C++ Extensions for Parallelism
+N4309 Return type deduction for explicitly-defaulted and deleted special member functions
+N4310 Working Draft, Technical Specification for C++ Extensions for Parallelism
+N4311 Parallelism TS Editor's Report
+N4312 Programming Languages — Technical Specification for C++ Extensions for Parallelism
+N4313 Improvements to the Concurrency Technical Specification, revision 1
+N4314 Data-Invariant Functions (revision 2)
+N4315 make_array, revision 3
+N4316 std::rand replacement, revision 2
+N4317 New Safer Functions to Advance Iterators
+N4318 Proposal to add an absolute difference function to the C++ Standard Library
+N4319 Contracts for C++: What are the Choices
+N4320 Make exception specifications be part of the type system
+N4321 Towards Implementation and Use of memory_order_consume
+N4322 Linux-Kernel Memory Model
+N4323 Out-of-Thin-Air Execution is Vacuous
+N4324 Use Cases for Thread-Local Storage
+N4325 C++ Standard Evolution Active Issues List (Revision R10)
+N4326 C++ Standard Evolution Completed Issues List (Revision R10)
+N4327 C++ Standard Evolution Closed Issues List (Revision R10)
+N4328 C++ Standard Library Issues History for C++14
+N4329 C++ Standard Library Active Issues List (Revision R91)
+N4330 C++ Standard Library Defect Report List (Revision R91)
+N4331 C++ Standard Library Closed Issues List (Revision R91)
+N4332 Networking Library Proposal (Revision 3)
+N4333 Concepts Lite
+N4334 Wording for bool_constant
+N4335 Working Draft, C++ Extensions for Library Fundamentals
+N4336 Working Draft, C++ Extensions for Library Fundamentals, Version 2
+N4337 Editor's Report for the Library Fundamentals TS
+N4338 Editor's Report: Technical Specification for C++ Extensions for Transactional Memory
+N4339 Agenda and Meeting Notice for WG21 Concepts Meeting
+N4340 Remove Deprecated Use of the register Keyword
+N4346 Multidimensional bounds, index and array_view, revision 5
+N4348 Making std::function thread-safe
+N4349 Minutes of WG21 Telecon
+N4350 Agenda and Meeting Notice for WG21 Concepts Meeting Notice (revision 1)
+N4351 Responses to National Body Comments, PDTS 19570, C++ Extensions for Parallelism
+N4352 Parallelism TS
+N4353 Parallelism TS - Editor's Report
+N4354 Parallelism TS - DTS Ballot Document
+N4355 Shared Multidimensional Arrays with Polymorphic Layout
+N4356 Relaxed Array Type Declarator
+N4357 Introduce the [[noexit]] attribute for main as a hint to eliminate destructor calls for objects with static storage duration
+N4358 Unary Folds and Empty Parameter Packs
+N4359 A Proposal to Add vector release method just like unique_ptr release method to the Standard Library
+N4360 Delayed Evaluation Parameters
+N4361 Concepts Lite TS
+N4362 WG21 2015-01 Skillman Minutes
+N4365 Responses to National Body Comments, ISO/IEC PDTS 19568, C++ Extensions for Library Fundamentals
+N4366 LWG 2228: Missing SFINAE rule in unique_ptr templated assignment
+N4367 Comparison in C++
+N4368 Introducing alias size_type for type size_t in class std::bitset
+N4369 Default argument for second parameter of std::advance
+N4370 Networking Library Proposal (Revision 4)
+N4371 Minimal incomplete type support for standard containers, revision 2
+N4372 A Proposal to Add a Const-Propagating Wrapper to the Standard Library
+N4373 Atomic View
+N4374 Linux-Kernel Memory Mode
+N4375 Out-of-Thin-Air Execution is Vacuous
+N4376 Use Cases for Thread-Local Storage
+N4377 C++ Extensions for Concepts PDTS
+N4378 Language Support for Contract Assertions
+N4379 FAQ about N4378, Language Support for Contract Assertions
+N4380 Constant View: A proposal for a std::as_const helper function template
+N4381 Suggested Design for Customization Points
+N4382 Working Draft, C++ extensions for Ranges
+N4383 C++ Standard Library Active Issues List (Revision R92)
+N4384 C++ Standard Library Defect Report List (Revision R92)
+N4385 C++ Standard Library Closed Issues List (Revision R92)
+N4386 Unspecialized std::tuple_size should be defined
+N4387 Improving pair and tuple, revision 3
+N4388 A Proposal to Add a Const-Propagating Wrapper to the Standard Library
+N4389 Wording for bool_constant, revision 1
+N4390 Minimal incomplete type support for standard containers, revision 3
+N4391 make_array, revision 4
+N4392 C++ Latches and Barriers
+N4393 Noop Constructors and Destructors
+N4394 Agenda for Lenexa Meeting
+N4395 SIMD Types: ABI Considerations
+N4396 National Body Comments: PDTS 19841, Transactional Memory
+N4397 A low-level API for stackful coroutines
+N4398 A unified syntax for stackless and stackful coroutines
+N4399 Proposed Working Draft, Technical Specification for C++ Extensions for Concurrency
+N4400 Concurrency TS Editor's Report, May 2015
+N4401 Defaulted comparison operator semantics should be uniform
+N4402 Resumable Functions (revision 4)
+N4403 Draft wording for Resumable Functions
+N4404 Extension to aggregate initialization
+N4405 Type of the accumulaters of standard algorithms std::accumulate and std::inner_product
+N4406 Integrating Executors with Parallel Algorithm Execution
+N4407 Working Draft, Technical Specification for C++ Extensions for Parallelism
+N4408 Parallelism TS Editor's Report
+N4409 Programming Languages — Technical Specification for C++ Extensions for Parallelism
+N4410 Responses to PDTS comments on Transactional Memory
+N4411 Task Block (formerly Task Region) R4
+N4412 Shortcomings of iostreams
+N4414 Executors and Schedulers Revision 5
+N4415 Simple Contracts for C++
+N4416 Don't Move: Vector Can Have Your Non-Moveable Types Covered
+N4417 Source-Code Information Capture
+N4418 Parameter Stringization
+N4419 Potential extensions to Source-Code Information Capture
+N4420 Defining Test Code
+N4421 Evolution Active Issues List (Revision R11)
+N4422 Evolution Completed Issues List (Revision R11)
+N4423 Evolution Closed Issues List (Revision R11)
+N4424 Inline Variables
+N4425 Generalized Dynamic Assumptions
+N4426 Adding [nothrow-] swappable traits
+N4427 Agenda and Meeting Notice for WG21 Pre-Lenexa Telecon Meeting
+N4428 Type Property Queries (rev 4)
+N4429 Core issue 1941 - rewording inherited constructors
+N4430 Core issue 1776 - replacement of class objects containing reference members
+N4431 Working Draft, Standard for Programming Language C++
+N4432 Editor's Report — Working Draft, Standard for Programming Language C++
+N4433 Flexible static_assert messages
+N4434 Tweaks to Streamline Concepts Lite Syntax
+N4435 Proposing Contract Attributes
+N4436 Proposing Standard Library Support for the C++ Detection Idiom
+N4437 Conditionally-supported Special Math Functions, v3
+N4438 Industrial Experience with Transactional Memory at Wyatt Technologies.
+N4439 Light-Weight Execution Agents Revision 3
+N4440 Feature-testing recommendations for C++
+N4441 SG5: Transactional Memory (TM) Meeting Minutes 2015-03-23 and 2015-04-06
+N4442 Default argument for second parameter of std::advance (Rev. 1)
+N4443 Introducing alias size_type for type size_t in class std::bitset (Rev. 1 )
+N4444 Linux-Kernel Memory Model
+N4445 Overly attached promise
+N4446 The missing INVOKE related trait
+N4447 From a type T, gather members name and type information, via variadic template expansion
+N4448 Rounding and Overflow in C++
+N4449 Message Digest Library for C++
+N4450 Variant: a typesafe union (v2)
+N4451 Static reflection
+N4452 Use cases of reflection
+N4453 Resumable Expressions
+N4454 SIMD Types Example: Matrix Multiplication
+N4455 No Sane Compiler Would Optimize Atomics
+N4456 Towards improved support for games, graphics, real-time, low latency, embedded systems
+N4457 C++ Standard Core Language Active Issues, Revision 93
+N4458 C++ Standard Core Language Defect Reports and Accepted Issues, Revision 93
+N4459 C++ Standard Core Language Closed Issues, Revision 93
+N4460 LWG 2424: Atomics, mutexes and condition variables should not be trivially copyable
+N4461 Static if resurrected
+N4462 LWG 2089, Towards more perfect forwarding
+N4463 IO device requirements for C++
+N4464 Pi-calculus syntax for C++ executors
+N4465 A Module System for C++ (Revision 3)
+N4466 Wording for Modules
+N4468 On Quantifying Memory-Allocation Strategies
+N4469 Template Argument Type Deduction
+N4470 Variadic lock_guard
+N4471 Template parameter deduction for constructors (Rev 2)
+N4472 consexpr goto
+N4473 noexcept(auto), again
+N4474 Unified Call Syntax: x.f(y) and f(x,y)
+N4475 Default comparisons (R2)
+N4476 Thoughts about Comparisons (R2)
+N4477 Operator Dot (R2)
+N4478 Networking Library Proposal (Revision 5
+N4479 Merge Fundamentals V1 into v2
+N4480 Programming Languages — C++ Extensions for Library Fundamentals DTS
+N4481 Working Draft, C++ Extensions for Library Fundamentals, Version 2
+N4482 Some notes on executors and the Networking Library Proposal
+N4483 Read-copy-update
+N4484 C++ Standard Library Active Issues List (Revision R93)
+N4485 C++ Standard Library Defect Report List (Revision R93)
+N4486 C++ Standard Library Closed Issues List (Revision R93)
+N4487 Constexpr lambdas
+N4488 Responses to PDTS comments on Transactional Memory, version 2
+N4489 WG21 2015-04-24 Telecon Minutes
+N4490 WG21 2015-05 Lenexa Minutes
+N4491 PL22.16 2015-05 Lenexa Minutes (Draft)
+N4492 Thoughts about C++17
+N4494 Multidimensional bounds, offset and array_view, revision 6
+N4495 Operator dot
+N4496 WG21 2014-11 Urbana Minutes (revision 1)
+N4497 PL22.16 2014-11 Urbana Minutes (Final)
+N4498 Variadic lock_guard (Rev. 2)
+N4499 Draft wording for Coroutines (Revision 2)
+N4501 Working Draft, Technical Specification for C++ Extensions for Concurrency
+N4502 Proposing Standard Library Support for the C++ Detection Idiom, V2
+N4505 Working Draft, Technical Specification for C++ Extensions for Parallelism
+N4506 Parallelism TS Editor's Report
+N4507 Technical Specification for C++ Extensions for Parallelism
+N4508 A proposal to add shared_mutex (untimed) (Revision 4)
+N4509 constexpr atomic::is_always_lock_free
+N4510 Minimal incomplete type support for standard containers, revision 4
+N4511 Adding [nothrow-]swappable traits, revision 1
+N4512 Multidimensional bounds, offset and array_view, revision 7
+N4513 Working Draft Technical Specification for C++ Extensions for Transactional Memory
+N4514 Technical Specification for C++ Extensions for Transactional Memory
+N4515 Editor's Report: Technical Specification for C++ Extensions for Transactional Memory
+N4516 Variant: a type-safe union (v3)
+N4517 Record of Response: National Body Comments ISO/IEC PDTS 19841
+N4518 Make exception specifications be part of the type system, version 2
+N4519 Source-Code Information Capture
+N4521 Merge Fundamentals V1 into V2
+N4522 std::atomic_object_fence(mo, T&&...)
+N4523 constexpr std::thread::hardware_{true,false}_sharing_size
+N4524 Respect vector::reserve(request) Relative to Reallocation
+N4525 C++ Standard Library Issues Resolved Directly In Lenexa
+N4526 Towards improved support for games, graphics, real-time, low latency, embedded systems
+N4527 Working Draft, Standard for Programming Language C++
+N4528 Editor's Report — Working Draft, Standard for Programming Language C++
+N4529 Working Draft, C++ Extensions for Library Fundamentals, Version 2
+N4530 Editor's Report for the Library Fundamentals TS
+N4531 std::rand replacement, revision 3
+N4532 Proposed wording for default comparisons
+N4533 Make exception specifications be part of the type system, version 3
+N4534 Data-Invariant Functions (revision 3)
+N4535 Feature-testing preprocessor predicates for C++17
+N4536 An algorithm to "clamp" a value between a pair of boundary values
+N4537 Adding Symmetry Between shared_ptr and weak_ptr
+N4538 Technical Specification for C++ Extensions for Concurrency
+N4539 Evolution Active Issues List (Revision R12)
+N4540 Evolution Completed Issues List (Revision R12)
+N4541 Evolution Closed Issues List (Revision R12)
+N4542 Variant: a type-safe union (v4).
+N4543 A polymorphic wrapper for all Callable objects
+N4544 October 2015 WG21 Meeting (Kona)
+N4545 PL22.16/WG21 draft agenda: 19-24 Oct 2015, Kona, HI/US
+N4546 Agenda and Meeting Notice for WG21 Concepts Telecon
+N4547 Business Plan and Convener's report
+N4548 WG21 2015-07-20 Telecon Minutes
+N4549 Programming Languages — C++ Extensions for Concepts
+N4550 Record of Response: National Body Comments on ISO/IEC PDTS 19217, Technical Specification: C++ Extensions for Concepts
+N4551 National Body Comments, ISO/IEC PDTS 19571, C++ Extensions for Concurrency
+N4552 Pre-Kona WG21 Telecon
+N4553 Working Draft, C++ extensions for Concepts
+N4554 Editor's report for the Concepts TS
+N4555 February 2016 WG21 Meeting
+N4556 WG21 telecon minutes
+N4557 WG21 2015-07-20 Telecon (revised)
+N4558 Kona WG21 Minutes
+N4559 Kona PL22.16 Minutes
+N4560 Working Draft, C++ Extensions for Ranges
+N4561 Ranges Editor's Report
+N4562 Working Draft, C++ Extensions for Library Fundamentals, Version 2
+N4563 Editor's Report for the Library Fundamentals TS
+N4564 C++ Extensions for Library Fundamentals, Version 2 PDTS
+N4565 Record of Response: National Body Comments ISO/IEC PDTS 19571 Technical Specification: C++ Extensions for Concurrency
+N4566 Editor's Report — Working Draft, Standard for Programming Language C++
+N4567 Working Draft, Standard for Programming Language C++ Note:
+N4568 PL22.16/WG21 draft agenda: 29 Feb-05 Mar 2016, Jacksonville, FL/US
+N4569 Proposed Ranges TS working draft
+N4570 Oulu Meeting Information
+N4571 2016-11 Issaquah meeting information
+N4572 WG21 telecon meeting: Pre-Jacksonville
+N4573 2017-02 Kona WG21 Meeting Information
+N4575 Networking TS Working Draft
+N4576 Networking TS Editor's Report
+N4577 Technical Specification for C++ Extensions for Concurrency
+N4578 Working Draft, Technical Specification for C++ Extensions for Parallelism Version 2
+N4579 Parallelism TS Editor's Report, pre-Jacksonville mailing
+N4580 WG21 2016-02-19 Telecon Minutes
+N4581 Revised WG21 2016-02-19 Telecon Minutes
+N4582 Working Draft, Standard for Programming Language C++
+N4583 Editor's Report — Working Draft, Standard for Programming Language C++
+N4584 Working Draft, C++ Extensions for Library Fundamentals, Version 2
+N4585 Editor's Report for the Library Fundamentals TS
+N4586 WG21 2016-02 Jacksonville Min
+N4587 PL22.16 2016-02 Jacksonville Minutes (Draft)
+N4588 Working Draft, C++ extensions for Networking Note:
+N4589 Networking TS Editor's Report
+N4590 PL22.16/WG21 draft agenda: 20-25 Jun 2016, Oulu, FI
+N4591 WG21 telecon meeting: Pre-Oulu
+N4592 Modules TS Working Draft
+N4593 Editor's Report — Working Draft, Standard for Programming Language C++
+N4594 Working Draft, Standard for Programming Language C++
+N4595 WG21 2016-06-10 Telecon Minutes
+N4596 PL22.16 Jacksonville Minutes (revised)
+N4597 WG21 2016-06 Oulu Minutes
+N4598 PL22.16 2016-06 Oulu Minutes
+N4599 2016-08 LWG Meeting
+N4600 Working Draft, C++ Extensions for Library Fundamentals, Version 2
+N4601 Editor's Report for the Library Fundamentals TS
+N4602 WG21 telecon minutes - pre-Oulu (revised)
+N4603 Editor's Report — Committee Draft, Standard for Programming Language C++
+N4604 C++17 CD Ballot Document
+N4606 Working Draft, Standard for Programming Language C++
+N4607 Toronto Meeting Information
+N4608 PL22.16/WG21 draft agenda: 7-12 Nov 2016, Issaquah, WA, US
+N4609 Business Plan and Convener's Report
+N4610 Working Draft, Extensions to C++ for Modules
+N4611 Editor's Report for the Modules TS
+N4612 Working Draft, C++ extensions for Networking
+N4613 Networking TS - Editor's Report
+N4614 WG21 telecon meeting: Pre-Issaquah
+N4615 WG21 2016-10-28 Telecon Minutes
+N4616 Response to NB Comments: SC22 N5097, ISO/IEC PDTS 19568 Part 2, Library Fundamentals, Part 2
+N4617 Programming Languages — C++ Extensions for Library Fundamentals, Version 2 DTS
+N4618 Working Draft, Standard for Programming Language C++
+N4619 Editor's Report — Working Draft, Standard for Programming Language C++
+N4620 Working Draft, C++ Extensions for Ranges
+N4621 Editor's Report for the Ranges TS
+N4622 Programming Languages — C++ Extensions for Ranges PDTS
+N4623 WG21 2016-11 Issaquah Minutes
+N4624 PL22.16 2016-11 Issaquah Minutes
+N4625 Programming Languages — C++ Extensions for Networking PDTS
+N4626 Working Draft, C++ Extensions for Networking
+N4627 Networking TS - Editor's Report
+N4628 Working Draft, Technical Specification on C++ Extensions for Coroutines
+N4629 Editor's report for the Coroutines TS
+N4630 Working Draft, C++ extensions for Concepts
+N4631 Editor's report for the Concepts TS
+N4632 PL22.16/WG21 draft agenda: 27 Feb - 4 Mar 2017, Kona, HI, US
+N4633 2017-11 Albuquerque WG21 meeting information
+N4634 PL22.16 2016-11 Issaquah Minutes (final)
+N4635 Pre-Kona WG21 Telecon Agenda
+N4636 2017-07-10-15 ISO WG21 C++ Standard Meeting in Toronto
+N4637 Working Draft, Extensions to C++ for Modules
+N4638 Editor's Report for the Module TS
+N4639 Editor's Report — Working Draft, Standard for Programming Language C++
+N4640 Working Draft, Standard for Programming Language C++
+N4641 Working Draft, C++ extensions for Concepts
+N4642 Editor's report for the Concepts TS
+N4643 National Body Comments for PDTS 19216, C++ Extensions for Networking
+N4644 National Body Comments for PDTS 21425, C++ Extensions for Ranges
+N4645 WG21 Telecon Minutes
+N4647 Working Draft, Extensions to C++ for Modules
+N4648 Editor's Report for the Module TS
+N4649 Working Draft, Technical Specification on C++ Extensions for Coroutines
+N4650 Editor's report for the Coroutines TS
+N4651 Working Draft, C++ Extensions for Ranges
+N4652 Editor's Report for the Ranges TS
+N4653 2017-02 Kona Record of Discussion ISO/IEC
+N4654 WG21 2017-02 Kona Minutes
+N4655 PL22.16 2017-02 Kona Minutes
+N4656 Working Draft, C++ Extensions for Networking
+N4657 Networking TS - Editor's Report
+N4658 Alternative accommodation (student residence) for the 2017-07 Toronto WG21 Meeting
+N4659 Working Draft, Standard for Programming Language C++ Note:
+N4660 C++17 DIS Ballot Document
+N4661 Editor's Report — Working Draft, Standard for Programming Language C++
+N4662 PL22.16/WG21 draft agenda: 10-15 Jul 2017, Toronto, ON, CA
+N4663 Coroutines PDTS document
+N4664 Responses to National Body Comments for ISO/IEC CD 14882
+N4665 WG21 telecon meeting: Pre-Toronto
+N4666 National Body Comments, SC22 N 5205, ISO/IEC PDTS 22277, C++ Extensions for Coroutines
+N4667 Working Draft, Extensions to C++ for Modules
+N4668 Editor's Report for the Module TS
+N4669 Working Draft, Technical Specification for C++ Extensions for Parallelism Version 2
+N4670 Parallelism TS Editor's Report, pre-Toronto mailing
+N4671 Working Draft, C++ Extensions for Ranges
+N4672 Editor's Report for the Ranges TS
+N4673 Spring 2018 WG21 Meeting Information (Rapperswil)
+N4674 Working Draft, C++ extensions for Concepts
+N4675 Editor's report for the Concepts TS
+N4676 WG21 Telecon Minutes
+N4677 WG21 / PL22.16 Meeting, Jacksonville, FL, March 12 - 17, 2018
+N4678 National Body Comments for ISO/IEC PDTS 22277, C++ Extensions for Coroutines
+N4679 Editor's report for the Coroutines TS
+N4680 C++ Extensions for Coroutines TS Document
+N4681 Working Draft, Extensions to C++ for Modules
+N4682 Editor's Report for the Module TS
+N4683 Business Plan and Convener's Report
+N4684 Ranges TS Ballot Document
+N4685 Working Draft, C++ Extensions for Ranges
+N4686 Editor's Report for the Ranges TS
+N4687 Working Draft, Standard for Programming Language C++ Note:
+N4688 Editor's Report — Working Draft, Standard for Programming Language C++
+N4689 Extensions to C++ for Modules Ballot Document
+N4690 2017-07 Toronto Record of Discussion
+N4691 WG21 2017-07 Toronto Minutes
+N4692 PL22.16 2017-07 Toronto Minutes
+N4693 PL22.16/WG21 draft agenda: 06-11 Nov 2017, Albuquerque, NM, US
+N4694 Responses to National Body Comments to ISO/IEC PDTS 21425, C++ Extensions for Ranges
+N4697 NB Comments, ISO/IEC PDTS 21544, C++ Extensions for Modules
+N4698 Working Draft, Technical Specification for C++ Extensions for Parallelism Version 2
+N4699 Parallelism TS Editor's Report
+N4700 Working Draft, Standard for Programming Language C++ Note:
+N4701 Editor's Report — Working Draft, Standard for Programming Language C++
+N4704 WG21 telecon meeting: Pre-Albuquerque
+N4705 WG21 2017-10-27 Telecon Minutes
+N4706 Working Draft, Technical Specification for C++ Extensions for Parallelism Version 2
+N4707 Parallelism TS Editor's Report
+N4708 Responses to National Body Comments, ISO/IEC PDTS 19216, C++ Extensions for Networking
+N4709 WG21 2017-11 Albuquerque Minutes
+N4710 PL22.16 2017-11 Albuquerque Minutes
+N4711 Working Draft, C ++ Extensions for Networking
+N4712 Networking TS - Editor's Report
+N4713 Working Draft, Standard for Programming Language C++
+N4714 Editors' Report — Programming Languages — C++
+N4715 2018-11 San Diego Meeting Information
+N4716 PL22.16/WG21 draft agenda: 12-17 March 2018, Jacksonville, FL, US
+N4717 WG21 telecon meeting: Pre-Jacksonville
+N4718 WG21 telecon meeting: Modules TS publication
+N4719 Programming Languages — Extensions to C++ for Modules
+N4720 Working Draft, Extensions to C++ for Modules
+N4721 Editor’s Report for the Module TS
+N4722 Responses to SC22 N5250, ISO/IEC PDTS 21544, C++ Extensions for Modules
+N4723 Working Draft, C++ Extensions for Coroutines
+N4724 Editor's report for the Coroutines TS
+N4725 Working Draft, Technical Specification for C++ Extensions for Parallelism Version 2
+N4726 Parallelism TS Editor’s Report
+N4727 Working Draft, Standard for Programming Language C++
+N4728 Editors' Report — Programming Languages – C++
+N4729 WG21 telecon meeting: Modules TS publication
+N4730 WG21 pre-Jacksonville telecon minutes
+N4731 SC22 WG14 Liaison Report (C Standard)
+N4732 WG21 2018-03 Jacksonville Minutes
+N4734 Working Draft, C ++ Extensions for Networking
+N4735 Networking TS - Editor's Report
+N4736 Working Draft, C ++ Extensions for Coroutines
+N4737 Editor's report for the Coroutines TS
+N4738 C++ Standardization Committee Meeting, HSR Rapperswil – Latest Info
+N4739 Jacksonville 2018 LEWG Summary
+N4740 N4740 Editors' Report - Programming Languages - C++
+N4741 Working Draft, Standard for Programming Language C++
+N4742 Working Draft, Technical Specification for C++ Extensions for Parallelism Version 2
+N4743 Parallelism TS Editor’s Report, post-Jacksonville mailing
+N4744 Programming Languages - Technical Specification for C++ Extensions for Parallelism Version 2
+N4745 PL22.16/WG21 draft agenda: 4-9 June 2018, Rapperswil, Switzerland
+N4746 Working Draft, C++ Extensions for Reflection
+N4747 Reflection TS - Editor’s Report
+N4748 WG21 telecon meeting: Pre-Rapperswil
+N4749 Editors' Report - Programming Languages - C++
+N4750 Working Draft, Standard for Programming Language C++
+N4751 WG21 pre-Rapperswil telecon minutes
+N4752 Responses to National Body Comments for ISO/IEC PDTS 19750, C++ Extensions for Parallelism Version 2
+N4753 WG21 2018-06 Rapperswil Minutes
+N4754 Rapperswil 2018 LEWG Summary
+N4755 Working Draft, C++ Extensions for Parallelism Version 2
+N4756 Parallelism TS Editor’s Report, post-Rapperswil mailing
+N4757 Programming Languages - C++ Extensions for Parallelism Version 2
+N4758 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4759 Editor’s Report: C++ Extensions for Library Fundamentals, Version 3
+N4760 Working Draft, C++ Extensions for Coroutines
+N4761 Editor's report for the Coroutines TS
+N4762 Working Draft, Standard for Programming Language C++
+N4763 Collated Responses to National Body Comments, PDTS 19750, Parallelism, V2
+N4764 Editors' Report - Programming Languages - C++
+N4765 2019 Kona meeting information
+N4766 Working Draft, C++ Extensions for Reflection
+N4767 Reflection TS - Editor’s Report
+N4768 Business Plan and Convener's Report: ISO/IEC JTC1/SC22/WG21 (C++)
+N4769 PL22.16/WG21 draft agenda: 5-10 November 2018, San-Diego, USA
+N4770 2019 Kona meeting information (rev. 1)
+N4771 Working Draft, C++ Extensions for Networking
+N4772 Networking TS - Editor's Report
+N4773 Working Draft, C++ Extensions for Parallelism Version 2
+N4774 Parallelism TS Editor’s Report, pre-San Diego mailing
+N4775 Working Draft, C++ Extensions for Coroutines
+N4776 Editor's report for the Coroutines TS
+N4777 WG21 telecon meeting: Pre-San Diego
+N4778 Working Draft, Standard for Programming Language C++
+N4779 Editors' Report - Programming Languages - C++
+N4780 2019 Cologne Meeting Invitation and Information
+N4781 WG21 2018-06 Rapperswil Minutes
+N4782 WG21 Autumn Meeting - Belfast, Northern Ireland
+N4783 2019 Cologne Meeting Invitation and Information
+N4784 WG21 pre-San Diego telecon minutes
+N4785 San Diego 2018 LEWG Summary
+N4786 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4787 Editor’s Report: C++ Extensions for Library Fundamentals, Version 3
+N4788 
+N4789 
+N4790 WG21 2018-11 San Diego Minutes
+N4791 Working Draft, Standard for Programming Language C++
+N4792 Editors' Report - Programming Languages - C++
+N4793 Working Draft, C++ Extensions for Parallelism Version 2
+N4794 Parallelism TS Editor’s Report, post-San Diego mailing
+N4795 PL22.16/WG21 Draft agenda: 18-23 Febuary 2019, Kona, HI, USA
+N4796 Working Draft, C++ Extensions for Parallelism Version 2
+N4797 Parallelism TS Editor’s Report, pre-Kona mailing
+N4798 WG21 telecon meeting: Pre-Kona
+N4799 Editors' Report - Programming Languages - C++
+N4800 Working Draft, Standard for Programming Language C++
+N4801 WG21 pre-Kona telecon minutes
+N4802 WG21 2018-11 San Diego Minutes
+N4803 Kona 2019 LEWG Summary
+N4805 WG21 2019-02 Kona Minutes of Meeting
+N4806 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4807 Editor’s Report: C++ Extensions for Library Fundamentals, Version 3
+N4808 Working Draft, C++ Extensions for Parallelism Version 2
+N4809 Parallelism TS Editor’s Report, post-Kona mailing
+N4810 Working Draft, Standard for Programming Language C++
+N4811 Editors' Report - Programming Languages - C++
+N4812 Editors' Report - Programming Languages - C++
+N4814 2019 Belfast Meeting Invitation and Information
+N4815 Cologne Agenda
+N4816 WG21 telecon meeting: Pre-Cologne
+N4817 2020 Prague Meeting Invitation and Information
+N4818 Working Draft, C++ Extensions for Reflection
+N4819 Reflection TS - Editor's Report
+N4820 Working Draft, Standard for Programming Language C++
+N4821 Editors' Report - Programming Languages - C++
+N4823 Cologne 2019 LEWG Summary
+N4824 Business plan and convener's report
+N4825 2020 Varna Meeting Information
+N4826 WG21 2019-07 Cologne Minutes of Meeting
+N4827 
+N4828 
+N4829 Editors' Report - Programming Languages - C++
+N4830 Committee Draft, Standard for Programming Language C++
+N4831 2022 Portland Meeting Invitation and Information
+N4832 2021 Kona meeting information
+N4833 Agenda for Belfast
+N4834 WG21 telecon meeting: Pre-Belfast
+N4835 Working Draft, Standard for Programming Language C++
+N4836 Editors’ Report - Programming Languages - C++
+N4837 2020 Varna Meeting Information
+N4838 Pre-Belfast Minutes of Meeting
+N4839 WG21 2019-11 Belfast Minutes of Meeting
+N4840 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4841 Editor's Report: C++ Extensions for Library Fundamentals, Version 3
+N4842 Working Draft, Standard for Programming Language C++
+N4843 Editors' Report - Programming Languages - C++
+N4844 Collated CD 14882 Comments
+N4845 Belfast 2019 LEWG Summary
+N4846 Agenda - Prague, February 2020
+N4847 WG21 telecon meeting: Pre-Prague
+N4848 WG21 Autumn Meeting 2020 - New York, New York, USA
+N4849 Working Draft, Standard for Programming Language C++
+N4850 Editors' Report - Programming Languages - C++
+N4851 Pre-Prague Telco Minutes of Meeting
+N4852 Prague LEWG Summary
+N4853 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4854 Editor's Report: C++ Extensions for Library Fundamentals, Version 3
+N4855 WG21 2020-02 Prague Minutes of Meeting
+N4856 C++ Extensions for Reflection
+N4857 Reflection TS - Responses
+N4858 Disposition of Comments: SC22 5415, ISO/IEC CD 14882
+N4859 Editors' Report - Programming Languages - C++
+N4860 Draft International Standard - Programming Languages - C++
+N4861 Working Draft, Standard for Programming Language C++
+N4862 Business Plan and Convener's Report
+N4863 Agenda for Fall Virtual WG21/PL22.16 Meeting
+N4864 WG21 virtual meeting: Autumn 2020
+N4865 Response to Editorial Comments: ISO/IEC DIS 14882, Programming Language C++
+N4866 WG21 admin telecon meeting: Pre-Autumn 2020
+N4867 Editors' Report - Programming Languages - C++
+N4868 Working Draft, Standard for Programming Language C++
+N4869 WG21 Pre-Autumn 2020 telecon minutes
+N4870 WG21 2020-02 Prague Minutes of Meeting
+N4871 WG21 Pre-Autumn 2020 telecon minutes
+N4873 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4874 Editor's Report: C++ Extensions for Library Fundamentals, Version 3
+N4875 WG21 admin telecon meeting: Winter 2021
+N4876 WG21 virtual meeting: Winter 2021
+N4877 WG21 2020-11 Virtual Meeting Minutes of Meeting
+N4878 Working Draft, Standard for Programming Language C++
+N4879 Editors' Report - Programming Languages - C++
+N4880 PL22.16/WG21 agenda: 22 February 2021, Virtual Meeting
+N4881 WG21 virtual meetings: 2021-02, -06, and -10
+N4882 WG21 admin telecon meetings: 2021-02, -05, and -09
+N4883 WG21 February 2021 admin telecon minutes
+N4884 WG21 2021-02 Virtual Meeting Minutes of Meeting
+N4885 Working Draft, Standard for Programming Language C++
+N4886 Editors’ Report - Programming Languages - C++
+N4887 PL22.16/WG21 agenda: 7 June 2021, Virtual Meeting
+N4888 WG21 virtual meetings: 2021-06, and -10
+N4889 WG21 admin telecon meeting: 2021-09
+N4890 WG21 2021-05 Admin telecon minutes
+N4891 WG21 2021-06 Virtual Meeting Minutes of Meeting
+N4892 Working Draft, Standard for Programming Language C++
+N4893 Editors' Report - Programming Languages - C++
+N4894 Business Plan and Convener's Report
+N4895 Working Draft, Extensions to C++ for Concurrency Version 2
+N4896 PL22.16/WG21 agenda: 4 October 2021, Virtual Meeting
+N4897 WG21 admin telecon meeting: September 2021
+N4898 WG21 2021-10 Virtual Meeting Minutes of Meeting
+N4899 WG21 admin telecon meetings: 2022
+N4900 WG21 virtual plenary meeting(s): 2022
+N4901 Working Draft, Standard for Programming Language C++
+N4902 Editors' Report - Programming Languages - C++
+N4903 PL22.16/WG21 agenda: 7 February 2022, Virtual Meeting
+N4904 WG21 admin telecon meetings: 2022 summer and autumn (revision 1)
+N4905 WG21 2022-01 Admin telecon minutes
+N4906 Transactional Memory TS2
+N4907 WG21 2022-02 Virtual Meeting Minutes of Meeting
+N4908 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4909 Editor's Report: C++ Extensions for Library Fundamentals, Version 3
+N4910 Working Draft, Standard for Programming Language C++
+N4911 Editors’ Report - Programming Languages - C++
+N4912 2022-11 Kona hybrid meeting information
+N4913 PL22.16/WG21 agenda: 25 July 2022, Virtual Meeting
+N4914 WG21 2022-07 Admin telecon minutes
+N4915 Business Plan and Convener's Report: ISO/IEC JTC1/SC22/WG21 (C++)
+N4916 WG21 2022-07 Virtual Meeting Minutes of Meeting
+N4917 Working Draft, Standard for Programming Language C++
+N4918 Editors’ Report - Programming Languages – C++
+N4919 Programming Languages - C++
+N4920 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4921 Editor’s Report: C++ Extensions for Library Fundamentals, Version 3
+N4922 INCITS C++/WG21 agenda: 7-12 November 2022, Kona, HI US
+N4923 Working Draft, Extensions to C++ for Transactional Memory Version 2
+N4924 WG21 2022-10 Admin telecon minutes
+N4925 2023-02 Issaquah meeting information
+N4926 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4927 Editor's Report: C++ Extensions for Library Fundamentals, Version 3
+N4928 Working Draft, Standard for Programming Language C++
+N4929 Editors' Report - Programming Languages - C++
+N4933 WG21 November 2022 Kona Minutes of Meeting
+N4934 2023 WG21 admin telecon meetings
+N4935 2023 Varna Meeting Invitation and Information
+N4936 2023-11 Kona meeting information
+N4937 Programming Languages — C++ Extensions for Library Fundamentals, Version 3
+N4938 Editor's Report: C++ Extensions for Library Fundamentals, Version 3
+N4939 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4940 WG21 2022-11 Kona Minutes of Meeting V2
+N4941 INCITS C++/WG21 Agenda: 6-11 February 2023, Issaquah, WA USA
+N4942 WG21 2023-01 Admin telecon minutes
+N4943 WG21 February 2023 Issaquah Minutes of Meeting
+N4944 Working Draft, Standard for Programming Language C++
+N4945 Editors' Report - Programming Languages - C++
+N4946 2024-03 Tokyo meeting information
+N4947 INCITS C++/WG21 agenda: 12-17 June 2023, Varna, Bulgaria
+N4948 Working Draft, C++ Extensions for Library Fundamentals, Version 3
+N4949 Editor's Report: C++ Extensions for Library Fundamentals, Version 3
+N4950 Working Draft, Standard for Programming Language C++
+N4951 Editors' Report - Programming Languages - C++
+N4953 Concurrency TS2
+N4954 2023 WG21 admin telecon meetings, rev. 1
+N4955 WG21 2023-06 Admin telecon minutes
+N4956 Concurrency TS2 PDTS
+N4957 WG21 June 2023 Varna Minutes of Meeting
+N4958 Working Draft, Programming Languages — C++
+N4959 Editors' Report, Programming Languages — C++
+N4960 Business Plan and Convener's Report: ISO/IEC JTC1/SC22/WG21 (C++)
+N4961 2024-03 Tokyo meeting information
+N4962 WG21 agenda: 6-11 November 2023, Kona, HI
+N4963 2023 WG21 admin telecon meetings, rev. 2
+N4964 Working Draft, Programming Languages — C++
+N4965 Editors' Report, Programming Languages — C++
+N4966 St. Louis Meeting Invitation and Information
+N4967 WG21 2023-10 Admin telecon minutes
+N4970 WG21 2023-11 Kona Minutes of Meeting
+N4971 Working Draft, Programming Languages — C++
+N4972 Editors' Report, Programming Languages — C++
+P0001R0 Removing Deprecated Register Keyword
+P0001R1 Removing Deprecated Register Keyword
+P0002R0 Removing Deprecated Operator++ for bool
+P0002R1 Removing Deprecated Operator++ for bool
+P0003R0 Removing Deprecated Dynamic Exception Specifications
+P0003R1 Removing Deprecated Exception Specifications from C++17
+P0003R2 Removing Deprecated Dynamic Exception Specifications from C++17
+P0003R3 Removing Deprecated Exception Specifications from C++17
+P0003R4 Removing Deprecated Exception Specifications from C++17
+P0003R5 Removing Deprecated Exception Specifications from C++17
+P0004R0 Removing Deprecated Aliases in iostreams
+P0004R1 Removing Deprecated Aliases in iostreams
+P0005R0 Adopt not_fn from Library Fundamentals 2 for C++17
+P0005R1 Adopt not_fn from Library Fundamentals 2 for C++17
+P0005R2 Adopt not_fn from Library Fundamentals 2 for C++17
+P0005R3 Adopt not_fn from Library Fundamentals 2 for C++17
+P0005R4 Adopt not_fn from Library Fundamentals 2 for C++17
+P0006R0 Adopt Type Traits Variable Templates from Library Fundamentals TS for C++17
+P0007R0 Constant View: A proposal for a std::as_const helper function template
+P0007R1 Constant View: A proposal for a std::as_const helper function template
+P0008R0 C++ Executors
+P0009R0 Polymorphic Multidimensional Array View
+P0009R1 Polymorphic Multidimensional Array View
+P0009R2 Polymorphic Multidimensional Array View
+P0009R3 Polymorphic Multidimensional Array View
+P0009R4 Polymorphic Multidimensional Array Reference
+P0009R5 Polymorphic Multidimensional Array Reference
+P0009R6 mdspan: A Non-Owning Multidimensional Array Reference
+P0009R7 mdspan: A Non-Owning Multidimensional Array Reference
+P0009R8 mdspan: A Non-Owning Multidimensional Array Reference
+P0009R9 mdspan: A Non-Owning Multidimensional Array Reference
+P0009R10 mdspan
+P0009R11 MDSPAN
+P0009R12 MDSPAN
+P0009R13 MDSPAN
+P0009R14 MDSPAN
+P0009R15 MDSPAN
+P0009R16 MDSPAN
+P0009R17 MDSPAN
+P0009R18 MDSPAN
+P0010R0 Adding a subsection for concurrent random number generation in C++17
+P0011R0 Additions to Filesystem supporting Relative Paths
+P0012R0 Make exception specifications be part of the type system, version 4
+P0012R1 Make exception specifications be part of the type system, version 5
+P0013R0 Logical Operator Type Traits
+P0013R1 Logical Operator Type Traits (revison 1)
+P0014R0 Proposal to add the multiline option to std::regex for its ECMAScript engine
+P0014R1 Proposal to add the multiline option to std::regex for its ECMAScript engine
+P0015R0 A specialization-friendly std::common_type
+P0017R0 Extension to aggregate initialization
+P0017R1 Extension to aggregate initialization
+P0018R0 Lambda Capture of *this by Value
+P0018R1 Lambda Capture of *this by Value
+P0018R2 Lambda Capture of *this by Value
+P0018R3 Lambda Capture of *this by Value as [=,*this]
+P0019R0 Atomic View
+P0019R1 Atomic View
+P0019R2 Atomic View
+P0019R3 Atomic View
+P0019R4 Atomic View
+P0019R5 Atomic View
+P0019R6 Atomic View
+P0019R7 Atomic Ref
+P0019R8 Atomic Ref
+P0020R0 Floating Point Atomic View
+P0020R1 Floating Point Atomic
+P0020R2 Floating Point Atomic
+P0020R3 Floating Point Atomic View
+P0020R4 Floating Point Atomic
+P0020R5 Floating Point Atomic
+P0020R6 Floating Point Atomic
+P0021R0 Working Draft, C++ Extensions for Ranges
+P0022R0 Proxy Iterators for the Ranges Extensions
+P0022R1 Proxy Iterators for the Ranges Extensions
+P0022R2 Proxy Iterators for the Ranges Extensions
+P0023R0 Relocator: Efficiently moving objects
+P0024R0 The Parallelism TS Should be Standardized
+P0024R1 The Parallelism TS Should be Standardized
+P0024R2 The Parallelism TS Should be Standardized
+P0025R0 An algorithm to "clamp" a value between a pair of boundary values
+P0025R1 An algorithm to "clamp" a value between a pair of boundary values
+P0026R0 multi-range-based for loops
+P0027R0 Named Types
+P0028R0 Using non-standard attributes
+P0028R1 Using non-standard attributes
+P0028R2 Using non-standard attributes
+P0028R3 Using non-standard attributes
+P0028R4 Using attribute namespaces without repetition
+P0029R0 A Unified Proposal for Composable Hashing
+P0030R0 Proposal to Introduce a 3-Argument Overload to std::hypot
+P0030R1 Proposal to Introduce a 3-Argument Overload to std::hypot
+P0031R0 A Proposal to Add Constexpr Modifiers to reverse_iterator, move_iterator, array and Range Access
+P0032R0 Homogeneous interface for variant, any and optional
+P0032R1 Homogeneous interface for variant, any and optional (Revision 1)
+P0032R2 Homogeneous interface for variant, any and optional (Revision 2)
+P0032R3 Homogeneous interface for variant, any and optional (Revision 3)
+P0033R0 Re-enabling shared_from_this
+P0033R1 Re-enabling shared_from_this (revision 1)
+P0034R0 Civil Time for the Standard Library
+P0035R0 Dynamic memory allocation for over-aligned data
+P0035R1 Dynamic memory allocation for over-aligned data
+P0035R2 Dynamic memory allocation for over-aligned data
+P0035R3 Dynamic memory allocation for over-aligned data
+P0035R4 Dynamic memory allocation for over-aligned data
+P0036R0 Unary Folds and Empty Parameter Packs (Revision 1)
+P0037R0 Fixed point real numbers
+P0037R1 Fixed point real numbers
+P0037R2 Fixed-point real numbers
+P0037R3 Fixed-point real numbers
+P0037R4 Fixed-point real numbers
+P0037R5 Fixed-Point Real Numbers
+P0037R6 Fixed-Point Real Numbers
+P0037R7 Fixed-Point Real Numbers
+P0038R0 Flat Containers
+P0039R0 Extending raw_storage_iterator
+P0040R0 Extending memory management tools
+P0040R1 Extending memory management tools
+P0040R2 Extending memory management tools
+P0040R3 Extending memory management tools
+P0041R0 Unstable remove algorithms
+P0042R0 std::recover: undoing type erasure
+P0043R0 Function wrappers with allocators and noexcept
+P0044R0 unwinding_state: safe exception relativity
+P0045R0 Overloaded and qualified std::function
+P0045R1 Qualified std::function signatures
+P0046R0 Change is_transparent to metafunction
+P0046R1 Change is_transparent to metafunction
+P0047R0 Transactional Memory (TM) Meeting Minutes 2015/06/01-2015/09/21
+P0048R0 Games Dev/Low Latency/Financial Trading/Banking Meeting Minutes 2015/08/12-2015/09/23
+P0050R0 C++ generic match function
+P0051R0 C++ generic overload function
+P0051R1 C++ generic overload function (Revision 1)
+P0051R2 C++ generic overload function
+P0051R3 C++ generic overload function
+P0052R0 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R1 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R2 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R3 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R4 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R5 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R6 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R7 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R8 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R9 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0052R10 Generic Scope Guard and RAII Wrapper for the Standard Library
+P0053R0 C++ Synchronized Buffered Ostream
+P0053R1 C++ Synchronized Buffered Ostream
+P0053R2 C++ Synchronized Buffered Ostream
+P0053R3 DRAFT C++ Synchronized Buffered Ostream
+P0053R4 DRAFT C++ Synchronized Buffered Ostream
+P0053R5 C++ Synchronized Buffered Ostream
+P0053R6 C++ Synchronized Buffered Ostream
+P0053R7 C++ Synchronized Buffered Ostream
+P0054R0 Coroutines: reports from the fields
+P0055R0 On Interactions Between Coroutines and Networking Library
+P0055R1 On Interactions Between Coroutines and Networking Library
+P0056R0 Soft Keywords
+P0057R0 Wording for Coroutines (Revision 3)
+P0057R1 Wording for Coroutines
+P0057R2 Wording for Coroutines
+P0057R3 Wording for Coroutines
+P0057R4 Wording for Coroutines
+P0057R5 Wording for Coroutines
+P0057R6 Wording for Coroutines
+P0057R7 Wording for Coroutines
+P0057R8 Working Draft, C++ Extensions for Coroutines
+P0058R0 An Interface for Abstracting Execution
+P0058R1 An Interface for Abstracting Execution
+P0059R0 Add rings to the Standard Library
+P0059R1 Add rings to the Standard Library
+P0059R2 Add rings to the Standard Library
+P0059R3 A proposal to add a ring span to the standard library
+P0059R4 A proposal to add a ring span to the standard library
+P0060R0 Function Object-Based Overloading of Operator Dot
+P0061R0 Feature-testing preprocessor predicates for C++17
+P0061R1 __has_include for C++17
+P0062R0 When should compilers optimize atomics?
+P0062R1 When should compilers optimize atomics?
+P0063R0 C++17 should refer to C11 instead of C99
+P0063R1 C++17 should refer to C11 instead of C99
+P0063R2 C++17 should refer to C11 instead of C99
+P0063R3 C++17 should refer to C11 instead of C99
+P0065R0 Movable initializer lists, rev. 2
+P0066R0 Accessors and views with lifetime extension
+P0067R0 Elementary string conversions
+P0067R1 Elementary string conversions
+P0067R2 Elementary string conversions, revision 2
+P0067R3 Elementary string conversions, revision 2
+P0067R4 Elementary string conversions, revision 4
+P0067R5 Elementary string conversions, revision 5
+P0068R0 Proposal of [[unused]], [[nodiscard]] and [[fallthrough]] attributes
+P0069R0 A C++ Compiler for Heterogeneous Computing
+P0070R0 Coroutines: Return Before Await
+P0071R0 Coroutines: Keyword alternatives
+P0072R0 Light-Weight Execution Agents
+P0072R1 Light-Weight Execution Agents
+P0073R0 On unifying the coroutines and resumable functions proposals
+P0073R1 On unifying the coroutines and resumable functions proposals
+P0073R2 On unifying the coroutines and resumable functions proposals
+P0074R0 Making std::owner_less more flexible
+P0075R0 Template Library for Index-Based Loops
+P0075R1 Template Library for Index-Based Loops
+P0075R2 Template Library for Parallel For Loops
+P0076R0 Vector and Wavefront Policies
+P0076R1 Vector and Wavefront Policies
+P0076R2 Vector and Wavefront Policies
+P0076R3 Vector and Wavefront Policies
+P0076R4 Vector and Wavefront Policies
+P0077R0 is_callable, the missing INVOKE related trait
+P0077R1 is_callable, the missing INVOKE related trai
+P0077R2 is_callable, the missing INVOKE related trai
+P0078R0 The [[pure]] attribute
+P0079R0 Extension methods in C++
+P0080R0 Variant: Discriminated Union with Value Semantics
+P0081R0 A proposal to add sincos to the standard library
+P0082R0 For Loop Exit Strategies (Revision 1)
+P0082R1 For Loop Exit Strategies (Revision 1)
+P0082R2 For Loop Exit Strategies (Revision 3)
+P0083R0 Splicing Maps and Sets (Revision 2)
+P0083R1 Splicing Maps and Sets (Revision 3)
+P0083R2 Splicing Maps and Sets (Revision 4)
+P0083R3 Splicing Maps and Sets (Revision 5)
+P0084R0 Emplace Return Type
+P0084R1 Emplace Return Type (Revision 1)
+P0084R2 Emplace Return Type (Revision 1)
+P0085R0 Oo... adding a coherent character sequence to begin octal-literals
+P0086R0 Variant design review
+P0087R0 Variant: a type-safe union without undefined behavior (v2)
+P0088R0 Variant: a type-safe union that is rarely invalid (v5)
+P0088R1 Variant: a type-safe union that is rarely invalid (v6)
+P0088R2 Variant: a type-safe union for C++17 (v7)
+P0088R3 Variant: a type-safe union for C++17 (v8)
+P0089R0 Quantifying Memory-Allocatiom Strategies
+P0089R1 Quantifying Memory-Allocation Strategies
+P0090R0 Removing result_type, etc.
+P0091R0 Template parameter deduction for constructors (Rev. 3)
+P0091R1 Template parameter deduction for constructors (Rev. 3)
+P0091R2 Template argument deduction for class templates (Rev. 5)
+P0091R3 Template argument deduction for class templates (Rev. 6)
+P0091R4 Template argument deduction for class templates (Rev. 7)
+P0092R0 Polishing <chrono>
+P0092R1 Polishing
+P0093R0 Simply a strong variant
+P0094R0 Simply a basic variant
+P0095R0 The case for a language based variant
+P0095R1 Pattern Matching and Language Variants
+P0095R2 Language Variants
+P0096R0 Feature-testing recommendations for C++
+P0096R1 Feature-testing recommendations for C++
+P0096R2 Feature-testing recommendations for C++
+P0096R3 Feature-testing recommendations for C++
+P0096R4 Feature-testing recommendations for C++
+P0096R5 Feature-testing recommendations for C++
+P0097R0 Use Cases for Thread-Local Storage
+P0098R0 Towards Implementation and Use of memory order consume
+P0098R1 Towards Implementation and Use of memory order consume
+P0099R0 A low-level API for stackful context switching
+P0099R1 A low-level API for stackful context switching
+P0100R0 Comparison in C++
+P0100R1 Comparison in C++
+P0100R2 Comparison in C++
+P0101R0 An Outline of a C++ Numbers Technical Specification,
+P0102R0 C++ Parametric Number Type Aliases
+P0103R0 Overflow-Detecting and Double-Wide Arithmetic Operations
+P0103R1 Overflow-Detecting and Double-Wide Arithmetic Operations
+P0104R0 Multi-Word Integer Operations and Types
+P0104R1 Multi-Word Integer Operations and Types
+P0105R0 Rounding and Overflow in C++
+P0105R1 Rounding and Overflow in C++
+P0106R0 C++ Binary Fixed-Point Arithmetic
+P0107R0 Better support for constexpr in std::array
+P0108R0 Skeleton Proposal for Thread-Local Storage (TLS)
+P0108R1 Skeleton Proposal for Thread-Local Storage (TLS)
+P0109R0 Function Aliases + Extended Inheritance = Opaque Typedefs
+P0110R0 Implementing the strong guarantee for variant<> assignment
+P0112R0 Networking Library (Revision 6)
+P0112R1 Networking Library (Revision 7)
+P0113R0 Executors and Asynchronous Operations, Revision 2
+P0114R0 Resumable Expressions (revision 1)
+P0116R0 Boolean conversion for Standard Library types
+P0117R0 Generic to_string/to_wstring functions
+P0118R0 Concepts-TS editors report
+P0119R0 Overload sets as function arguments
+P0119R1 Overload sets as function arguments
+P0119R2 Overload sets as function arguments
+P0120R0 constexpr unions and common initial sequences
+P0121R0 Working Draft, C++ extensions for Concepts
+P0122R0 array_view: bounds-safe views for sequences of objects
+P0122R1 span: bounds-safe views of objects for sequences
+P0122R2 span: bounds-safe views for sequences of objects
+P0122R3 span: bounds-safe views for sequences of objects
+P0122R4 span: bounds-safe views for sequences of objects
+P0122R5 span: bounds-safe views for sequences of objects
+P0122R6 span: bounds-safe views for sequences of objects
+P0122R7 span: bounds-safe views for sequences of objects
+P0123R0 Unifying the interfaces of string_view and array_view
+P0123R1 string_span: bounds-safe views for sequences of characters
+P0123R2 string_span: bounds-safe views for sequences of objects
+P0124R0 Linux-Kernel Memory Model
+P0124R1 Linux-Kernel Memory Model
+P0124R2 Linux-Kernel Memory Model
+P0124R3 Linux-Kernel Memory Model
+P0124R4 Linux-Kernel Memory Model
+P0124R5 Linux-Kernel Memory Model
+P0124R6 Linux-Kernel Memory Model
+P0124R7 Linux-Kernel Memory Model
+P0124R8 Linux-Kernel Memory Model
+P0125R0 std::bitset inclusion test methods
+P0126R0 std::synchronic
+P0126R1 std::synchronic<T>
+P0126R2 std::synchronic<T>
+P0127R0 Declaring non-type template arguments with auto
+P0127R1 Declaring non-type template arguments with auto
+P0127R2 Declaring non-type template arguments with auto
+P0128R0 constexpr_if
+P0128R1 constexpr_if
+P0129R0 We cannot (realistically) get rid of throwing moves
+P0130R0 Comparing virtual functions
+P0131R0 Unified call syntax concerns
+P0132R0 Non-throwing container operations
+P0132R1 Non-throwing container operations
+P0133R0 Putting noexcept(auto) on hold, again
+P0134R0 Introducing a name for brace-or-equal-initializers for non-static data members
+P0135R0 Guaranteed copy elision through simplified value categories
+P0135R1 Wording for guaranteed copy elision through simplified value categories
+P0136R0 Rewording inheriting constructors (core issue 1941 et al)
+P0136R1 Rewording inheriting constructors (core issue 1941 et al)
+P0137R0 Core Issue 1776: Replacement of class objects containing reference members
+P0137R1 Core Issue 1776: Replacement of class objects containing reference members
+P0138R0 Construction Rules for enum class Values
+P0138R1 Construction Rules for enum class Values
+P0138R2 Construction Rules for enum class Values
+P0141R0 Modules, Componentization, and Transitional Paths
+P0142R0 A Module System for C++ (Revision 4)
+P0143R0 Wording for Modules
+P0143R1 Wording for Modules
+P0143R2 Wording for Modules
+P0144R0 Structured Bindings
+P0144R1 Structured Bindings
+P0144R2 Structured Bindings
+P0145R0 Expression Order of Evaluation
+P0145R1 Refining Expression Evaluation Order for Idiomatic C++ (Revision 2)
+P0145R2 Refining Expression Evaluation Order for Idiomatic C++
+P0145R3 Refining Expression Evaluation Order for Idiomatic C++
+P0146R0 Regular Void
+P0146R1 Regular Void
+P0147R0 The Use and Implementation of Contracts
+P0148R0 memory_resource_ptr: A Limited Smart Pointer for memory_resource Correctness
+P0149R0 Generalised member pointers
+P0151R0 Proposal of Multi-Declarators
+P0152R0 constexpr atomic::is_always_lock_free
+P0152R1 constexpr atomic<T>::is_always_lock_free
+P0153R0 std::atomic_object_fence(mo, T&&...)
+P0154R0 constexpr std::thread::hardware_{true,false}_sharing_size
+P0154R1 constexpr std::thread::hardware_{true,false}_sharing_size
+P0155R0 Task Block R5
+P0156R0 Variadic lock_guard (Rev. 3)
+P0156R1 Variadic lock_guard (Rev. 4)
+P0156R2 Variadic lock_guard (Rev. 4)
+P0157R0 Handling Disappointment in C++
+P0158R0 Couroutines belong in a TS
+P0159R0 Draft of Technical Specification for C++ Extensions for Concurrency
+P0160R0 Wording for removing defaults for unary folds
+P0161R0 Bitset Iterators, Masks, and Container Operations
+P0162R0 A response to "P0055R0: On Interactions Between Coroutines and Networking Library"
+P0163R0 shared_ptr::weak_type
+P0164R0 Core Language Working Group "ready" Issues
+P0165R0 C++ Standard Library Issues to be moved in Kona
+P0165R1 C++ Standard Library Issues to be moved in Jacksonville
+P0165R2 C++ Standard Library Issues to be moved in Oulu
+P0165R3 C++ Standard Library Issues to be moved in Issaquah
+P0165R4 C++ Standard Library Issues to be moved in Kona
+P0166R0 Three interesting questions about contracts
+P0167R0 Core Language Working Group "ready" Issues after the October, 2015 (Kona) meeting
+P0167R1 Core Language Working Group "ready" Issues for the February, 2016 (Jacksonville) meeting
+P0167R2 Core Language Working Group "ready" Issues for the February, 2016 (Jacksonville) meeting
+P0169R0 regex and Unicode character types
+P0170R0 Wording for Constexpr Lambda
+P0170R1 Wording for Constexpr Lambda
+P0171R0 Response To: Resumable Expressions P0114R0
+P0172R0 Abominable Function Types
+P0174R0 Deprecating Vestigial Library Parts in C++17
+P0174R1 Deprecating Vestigial Library Parts in C++17
+P0174R2 Deprecating Vestigial Library Parts in C++17
+P0175R0 Synopses for the C library
+P0175R1 Synopses for the C library
+P0177R0 Cleaning up allocator_traits
+P0177R1 Cleaning up allocator_traits
+P0177R2 Cleaning up allocator_traits
+P0178R0 Allocators and swap
+P0180R0 Reserve a New Library Namespace Future Standardization
+P0180R1 Reserve a New Library Namespace Future Standardization
+P0180R2 Reserve a New Library Namespace Future Standardization
+P0181R0 Ordered By Default
+P0181R1 Ordered By Default
+P0184R0 Generalizing the Range-Based For Loop
+P0185R0 Adding [nothrow-] swappable traits
+P0185R1 Adding [nothrow-]swappable traits, revision 3
+P0186R0 Iterator Facade Library Proposal for Ranges
+P0187R0 Proposal of Bitfield Default Member Initializers
+P0187R1 Proposal/Wording for Bit-field Default Member Initializer Syntax
+P0188R0 Wording for [[fallthrough]] attribute
+P0188R1 Wording for [[fallthrough]] attribute
+P0189R0 Wording for [[nodiscard]] attribute
+P0189R1 Wording for [[nodiscard]] attribute
+P0190R0 Proposal for New memory order consume Definition
+P0190R1 Proposal for New memory order consume Definition
+P0190R2 Proposal for New memory order consume Definition
+P0190R3 Proposal for New memory order consume Definition
+P0190R4 Proposal for New memory order consume Definition
+P0191R1 C++ virtual member function pointer comparison
+P0192R0 Adding a Fundamental Type for Short Float
+P0192R1 Adding a Fundamental Type for Short Float
+P0192R4 `short float` and fixed-size floating point types
+P0193R0 Where is Vectorization in C++‽
+P0193R1 Where is Vectorization in C++‽
+P0194R0 Static reflection (revision 4)
+P0194R1 Static reflection (revision 4)
+P0194R2 Static reflection
+P0194R3 Static reflection
+P0194R4 Static reflection
+P0194R5 Static reflection
+P0194R6 Static reflection
+P0195R0 Modernizing using-declarations
+P0195R1 Modernizing using-declarations
+P0195R2 Pack expansions in using-declarations
+P0196R0 A generic none_t literal type for Nullable types
+P0196R1 Generic none() factories for Nullable types
+P0196R2 Generic none() factories for Nullable types
+P0196R3 Generic none() factories for Nullable types
+P0196R4 Generic none() factories for Nullable types
+P0196R5 Generic none() factories for Nullable types
+P0197R0 Default Tuple-like access
+P0198R0 Default Swap
+P0199R0 Default Hash
+P0200R0 A Proposal to Add Y Combinator to the Standard Library
+P0201R0 A cloning pointer-class for C++
+P0201R1 An indirect value-type for C++
+P0201R2 A polymorphic value-type for C++
+P0201R3 A polymorphic value-type for C++
+P0201R4 A polymorphic value-type for C++
+P0201R5 A polymorphic value-type for C++
+P0201R6 A polymorphic value-type for C++
+P0202R0 Add Constexpr Modifiers to Functions in <algorithm> and <cstring> Headers
+P0202R1 Add Constexpr Modifiers to Functions in <algorithm> and <cstring> Headers
+P0202R2 Add Constexpr Modifiers to Functions in <algorithm> and <cstring> Headers
+P0202R3 Add Constexpr Modifiers to Functions in <algorithm> and <utility> Headers
+P0203R0 Considerations for the design of expressive portable SIMD vectors
+P0205R0 Allow Seeding Random Number Engines With std::random_device
+P0205R1 Efficient Seeding of Random Number Engines
+P0206R0 Discussion about std::thread and RAII
+P0206R1 A joining thread
+P0207R0 Ruminations on lambda captures
+P0208R0 Copy-swap helper
+P0208R1 Copy-swap Transaction
+P0209R0 make_from_tuple: apply for construction
+P0209R1 make_from_tuple: apply for construction
+P0209R2 make_from_tuple: apply for construction
+P0210R0 A light-weight, dynamic array
+P0211R0 Allocator-aware library wrappers for dynamic allocation
+P0211R1 Allocator-aware library wrappers for dynamic allocation
+P0211R2 Allocator-aware library wrappers for dynamic allocation
+P0211R3 Allocator-aware library wrappers for dynamic allocation
+P0212R0 Wording for [[maybe_unused]] attribute
+P0212R1 Wording for [[maybe_unused]] attribute
+P0213R0 Reexamining the Performance of Memory-Allocation Strategies
+P0214R0 Data-Parallel Vector Types & Operations
+P0214R1 Data-Parallel Vector Types & Operations
+P0214R2 Data-Parallel Vector Types & Operations
+P0214R3 Data-Parallel Vector Types & Operations
+P0214R4 Data-Parallel Vector Types & Operations
+P0214R5 Data-Parallel Vector Types & Operations
+P0214R6 Data-Parallel Vector Types & Operations
+P0214R7 Data-Parallel Vector Types & Operations
+P0214R8 Data-Parallel Vector Types & Operations
+P0214R9 Data-Parallel Vector Types & Operations
+P0215R0 A Civil-Time Library
+P0216R0 A Time-Zone Library
+P0217R0 Proposed wording for structured bindings
+P0217R1 Proposed wording for structured bindings
+P0217R2 Proposed wording for structured bindings
+P0217R3 Proposed wording for structured bindings
+P0218R0 Adopt File System TS for C++17
+P0218R1 Adopt File System TS for C++17
+P0219R0 Relative Paths for Filesystem
+P0219R1 Relative Paths for Filesystem
+P0220R0 Adopt Library Fundamentals TS for C++17
+P0220R1 Adopt Library Fundamentals V1 TS Components for C++17 (R1)
+P0221R0 Proposed wording for default comparisons, revision 2
+P0221R1 Proposed wording for default comparisons, revision 3
+P0221R2 Proposed wording for default comparisons, revision 4
+P0222R0 Allowing Anonymous Structs as Return Values
+P0223R0 Class Namespace
+P0224R0 Implicit Return Type
+P0225R0 Why I want Concepts, and why I want them sooner rather than later
+P0226R0 Mathematical Special Functions for C++17, v4
+P0226R1 Mathematical Special Functions for C++17, v5
+P0227R0 Weakening the iterator categories of some standard algorithms
+P0228R0 A Proposal to Add Safe Integer Types to the Standard Library Technical Report
+P0228R3 unique_function: a move-only std::function
+P0228R6 any_invocable
+P0229R0 SG5 Transactional Memory Meeting minutes 2015/11/02-2016/02/08
+P0230R0 SG14 Games Dev/Low Latency/Financial Meeting Minutes 2015/10/14-2015/02/10
+P0231R0 Extending the Transactional Memory Technical Specification to Support Commit Actions
+P0232R0 A Concurrency ToolKit for Structured Deferral/Optimistic Speculation
+P0233R0 Hazard Pointers: Safe Reclamation for Optimistic Concurrency
+P0233R1 Hazard Pointers: Safe Reclamation for Optimistic Concurrency
+P0233R2 Hazard Pointers: Safe Reclamation for Optimistic Concurrency
+P0233R3 Hazard Pointers: Safe Reclamation for Optimistic Concurrency
+P0233R4 Hazard Pointers: Safe Reclamation for Optimistic Concurrency
+P0233R5 Hazard Pointers: Safe Reclamation for Optimistic Concurrency
+P0233R6 Hazard Pointers: Safe Reclamation for Optimistic Concurrency
+P0234R0 Towards Massive Parallelism(aka Heterogeneous Devices/Accelerators/GPGPU) support in C++
+P0235R0 A Packaging System for C++
+P0236R0 Khronos's OpenCL SYCL to support Heterogeneous Devices for C++
+P0237R0 On the standardization of fundamental bit manipulation utilities
+P0237R1 Wording for fundamental bit manipulation utilities
+P0237R2 Wording for fundamental bit manipulation utilities
+P0237R3 Wording for fundamental bit manipulation utilities
+P0237R4 Wording for fundamental bit manipulation utilities
+P0237R5 Wording for fundamental bit manipulation utilities
+P0237R6 Wording for fundamental bit manipulation utilities
+P0237R7 Wording for fundamental bit manipulation utilities
+P0237R8 Wording for fundamental bit manipulation utilities
+P0237R9 Wording for fundamental bit manipulation utilities
+P0237R10 Wording for fundamental bit manipulation utilities
+P0238R0 Return type deduction and SFINAE
+P0238R1 Return type deduction and SFINAE
+P0239R0 valueless_by_exception
+P0240R0 Why I want Concepts, but why they should come later rather than sooner
+P0241R0 Remove Future-Related Explicit Specializations for Void
+P0242R0 Standard Library Support For Void
+P0244R0 Text_view: A C++ concepts and range based character encoding and code point enumeration library
+P0244R1 Text_view: A C++ concepts and range based character encoding and code point enumeration library
+P0244R2 Text_view: A C++ concepts and range based character encoding and code point enumeration library
+P0245R0 Hexadecimal float literals for C++
+P0245R1 Hexadecimal float literals for C++
+P0246R0 Contract Assert Support Merged Proposal
+P0247R0 Criteria for Contract Support
+P0248R0 Concepts in C++17
+P0249R0 Input Devices For 2D Graphics
+P0249R2 Input Devices For 2D Graphics
+P0250R0 Wording improvements for initialization and thread ids (CWG 2046)
+P0250R1 Wording improvements for initialization and thread ids (CWG 2046)
+P0250R2 Wording improvements for initialization and thread ids (CWG 2046, 1784)
+P0250R3 Wording improvements for initialization and thread ids (CWG 2046, 1784)
+P0251R0 Unified Call Syntax Wording
+P0252R0 Operator Dot Wording
+P0252R1 Operator Dot Wording
+P0252R2 Operator Dot Wording
+P0253R0 Fixing a design mistake in the searchers interface in Library Fundamentals
+P0253R1 Fixing a design mistake in the searchers interface in Library Fundamentals
+P0254R0 Integrating std::string_view and std::string
+P0254R1 Integrating std::string_view and std::string
+P0254R2 Integrating std::string_view and std::string
+P0255R0 C++ Static Reflection via template pack expansion
+P0256R0 C++ Reflection Light
+P0257R0 A byte type for the standard library.
+P0257R1 A byte type for increased type safety
+P0258R0 is_contiguous_layout
+P0258R1 is_contiguous_layout
+P0258R2 has_unique_object_representations - wording
+P0259R0 fixed_string: a compile-time string
+P0260R0 C++ Concurrent Queues
+P0260R1 C++ Concurrent Queues
+P0260R2 C++ Concurrent Queues
+P0260R3 C++ Concurrent Queues
+P0260R4 C++ Concurrent Queues
+P0260R5 C++ Concurrent Queues
+P0260R6 C++ Concurrent Queues
+P0260R7 C++ Concurrent Queues
+P0261R0 C++ Distributed Counters
+P0261R1 C++ Distributed Counters
+P0261R2 C++ Distributed Counters
+P0261R3 C++ Distributed Counters
+P0261R4 C++ Distributed Counters
+P0262R0 A Class for Status and Optional Value
+P0262R1 A Class for Status and Optional Value
+P0263R0 Core Language Working Group "tentatively ready" Issues for the February, 2016 (Jacksonville) Meeting
+P0263R1 Core Language Working Group "tentatively ready" Issues for the February, 2016 (Jacksonville) Meeting
+P0264R0 auto operator= considered dangerous
+P0265R0 SG5 is NOT proposing Transactional Memory for C++17
+P0266R0 Removing Restrictions on requires-Expressions
+P0266R1 Removing Restrictions on requires-Expressions
+P0266R2 Lifting Restrictions on requires-Expressions
+P0267R0 A Proposal to Add 2D Graphics Rendering and Display to C++,
+P0267R1 A Proposal to Add 2D Graphics Rendering and Display to C++,
+P0267R2 A Proposal to Add 2D Graphics Rendering and Display to C++,
+P0267R3 A Proposal to Add 2D Graphics Rendering and Display to C++,
+P0267R4 A Proposal to Add 2D Graphics Rendering and Display to C++,
+P0267R5 A Proposal to Add 2D Graphics Rendering and Display to C++,
+P0267R6 A Proposal to Add 2D Graphics Rendering and Display to C++,
+P0267R7 A Proposal to Add 2D Graphics Rendering and Display to C++
+P0267R8 A Proposal to Add 2D Graphics Rendering and Display to C++
+P0267R9 A Proposal to Add 2D Graphics Rendering and Display to C++
+P0267R10 A Proposal to Add 2D Graphics Rendering and Display to C++
+P0268R0 up-to expression
+P0269R0 Allocator-aware regular expressions
+P0270R0 Removing C dependencies from signal handler wording
+P0270R1 Removing C dependencies from signal handler wording
+P0270R2 Removing C dependencies from signal handler wording
+P0270R3 Removing C dependencies from signal handler wording
+P0271R0 std::direct_init<T> for plugging the metaprogramming constructor hole
+P0272R0 Give 'std::string' a non-const '.data()' member function
+P0272R1 Give 'std::string' a non-const '.data()' member function
+P0273R0 Proposed modules changes from implementation and deployment experience
+P0273R1 Proposed modules changes from implementation and deployment experience
+P0274R0 Clump - A Vector-like Sequence Container with Embedded Storage
+P0275R0 A Proposal to add Classes and Functions Required for Dynamic Library Load
+P0275R1 A Proposal to add Classes and Functions Required for Dynamic Library Load
+P0275R2 A Proposal to add Classes and Functions Required for Dynamic Library Load
+P0275R3 A Proposal to add Classes and Functions Required for Dynamic Library Load
+P0275R4 A Proposal to add Classes and Functions Required for Dynamic Library Load
+P0276R0 A Proposal to add Attribute [[visible]]
+P0277R0 const Inheritance
+P0277R1 const Inheritance
+P0278R0 volatile solutions
+P0279R0 Read-Copy Update (RCU) for C++
+P0279R1 Read-Copy Update (RCU) for C++
+P0280R0 Initialize unspecified aggregate members with direct list initialization
+P0281R0 Remove comma elision in variadic function declarations
+P0282R0 Const-preserving overloads for the strtox family of functions
+P0283R0 Standard and non-standard attributes
+P0283R1 Standard and non-standard attributes
+P0283R2 Standard and non-standard attributes
+P0284R0 Unqualified enumerators in case labels
+P0285R0 Using customization points to unify executors
+P0286R0 A networking library extension to support co_await-based coroutines
+P0287R0 Simple Contracts for C++
+P0288R0 A polymorphic wrapper for all Callable objects
+P0288R1 A polymorphic wrapper for all Callable objects
+P0288R4 any_invocable
+P0288R5 any_invocable
+P0288R6 any_invocable
+P0288R7 any_invocable
+P0288R8 move_only_function (was any_invocable)
+P0288R9 move_only_function (was any_invocable)
+P0289R0 Forward declarations of nested classes
+P0290R0 apply() for synchronized_value<T>
+P0290R1 apply() for synchronized_value<T>
+P0290R2 apply() for synchronized_value<T>
+P0290R3 apply() for synchronized_value
+P0290R4 apply() for synchronized_value
+P0292R0 constexpr if: A slightly different syntax
+P0292R1 constexpr if: A slightly different syntax
+P0292R2 constexpr if: A slightly different syntax
+P0293R0 Template deduction for nested classes
+P0295R0 Adopt Selected Library Fundamentals V2 Components for C++17
+P0296R0 Forward progress guarantees: Base definitions
+P0296R1 Forward progress guarantees: Base definitions
+P0296R2 Forward progress guarantees: Base definitions
+P0298R0 A byte type definition
+P0298R1 A byte type definition
+P0298R2 A byte type definition
+P0298R3 A byte type definition
+P0299R0 Forward progress guarantees for the Parallelism TS v2
+P0299R1 Forward progress guarantees for the Parallelism TS features
+P0301R0 Wording for Unified Call Syntax
+P0301R1 Wording for Unified Call Syntax (revision 1)
+P0302R0 Deprecating Allocator Support in std::function
+P0302R1 Removing Allocator Support in std::function (rev 1)
+P0303R0 Extensions to C++ for Short Float Type
+P0304R0 C++ Standard Library Issues Resolved Directly In Jacksonville
+P0304R1 C++ Standard Library Issues Resolved Directly In Issaquah
+P0305R0 If statement with initializer
+P0305R1 Selection statements with initializer
+P0306R0 Comma elision and comma deletion
+P0306R1 Comma elision and comma deletion
+P0306R2 Comma elision and comma deletion
+P0306R3 Comma elision and comma deletion
+P0306R4 Comma elision and comma deletion
+P0307R0 Making Optional Greater Equal Again
+P0307R2 Making Optional Greater Equal Again
+P0308R0 Valueless Variants Considered Harmful
+P0309R0 Partial class
+P0310R0 Splitting node and array allocation in allocators
+P0311R0 A Unified Vision for Manipulating Tuple-like Objects
+P0312R0 Make Pointers to Members Callable
+P0312R1 Make Pointers to Members Callable
+P0313R0 Comparison operators in fold-expressions
+P0314R0 Querying the alignment of an object
+P0315R0 Lambdas in unevaluated context
+P0315R1 Lambdas in unevaluated context
+P0315R2 Lambdas in unevaluated context
+P0315R3 Lambdas in unevaluated context
+P0315R4 Wording for lambdas in unevaluated contexts
+P0316R0 allocate_unique and allocator_delete
+P0317R0 Directory Entry Caching for Filesystem
+P0317R1 Directory Entry Caching for Filesystem
+P0318R0 decay_unwrap and unwrap_reference
+P0318R1 unwrap_ref_decay and unwrap_reference
+P0319R0 Adding Emplace functions for promise<T>/future<T>
+P0319R1 Adding Emplace functions for promise<T>/future<T>
+P0319R2 Adding Emplace functions for promise<T>/future<T> (revision 2)
+P0320R0 Thread Constructor Attributes
+P0320R1 Thread Constructor Attributes
+P0322R0 exception_list
+P0323R0 A proposal to add a utility class to represent expected monad (Revision 2)
+P0323R1 A proposal to add a utility class to represent expected object (Revision 3)
+P0323R2 A proposal to add a utility class to represent expected object (Revision 4)
+P0323R3 Utility class to represent expected object
+P0323R4 std::expected
+P0323R5 std::expected
+P0323R6 std::expected
+P0323R7 std::expected
+P0323R8 std::expected
+P0323R9 std::expected
+P0323R10 std::expected
+P0323R11 std::expected
+P0323R12 std::expected
+P0324R0 One Concept Definition Syntax
+P0325R0 Propose to adopt make_array in C++17
+P0325R1 Propose to adopt make_array into the IS
+P0325R2 to_array from LFTS with updates
+P0325R3 to_array from LFTS with updates
+P0325R4 to_array from LFTS with updates
+P0326R0 Structured binding: customization point issues
+P0327R0 Product types access
+P0327R1 Product types access
+P0327R2 Product types access
+P0327R3 Product types access
+P0329R0 Designated Initialization
+P0329R1 Designated Initialization Wording
+P0329R2 Designated Initialization Wording
+P0329R3 Designated Initialization Wording
+P0329R4 Designated Initialization Wording
+P0330R0 User-Defined Literals for size_t
+P0330R1 User-Defined Literals for size_t
+P0330R2 Literal Suffixes for ptrdiff_t and size_t
+P0330R3 Literal Suffixes for ptrdiff_t and size_t
+P0330R4 Literal Suffixes for ptrdiff_t and size_t
+P0330R5 Literal Suffixes for ptrdiff_t and size_t
+P0330R6 Literal Suffixes for ptrdiff_t and size_t
+P0330R7 Literal Suffixes for ptrdiff_t and size_t
+P0330R8 Literal Suffixes for (signed) size_t
+P0331R0 Motivation and Examples for Multidimensional Array
+P0332R0 Relaxed Incomplete Multidimensional Array Type Declaration
+P0332R1 Relaxed Incomplete Multidimensional Array Type Declaration
+P0332R2 Relaxed Incomplete Multidimensional Array Type Declaration
+P0333R0 Improving Parallel Algorithm Exception Handling
+P0334R0 Immutable Persistent Containers
+P0335R0 Context Tokens for Parallel Algorithms
+P0335R1 Context Tokens for Parallel Algorithms
+P0336R0 Better Names for Parallel Execution Policies in C++17
+P0336R1 Better Names for Parallel Execution Policies in C++17
+P0337R0 Delete operator= for polymorphic_allocator
+P0338R0 C++ generic factories
+P0338R1 C++ generic factories
+P0338R2 C++ generic factories
+P0338R3 C++ generic factories
+P0339R0 polymorphic_allocator<void> as a vocabulary type
+P0339R1 polymorphic_allocator<void> as a vocabulary type
+P0339R2 polymorphic_allocator<void> as a vocabulary type
+P0339R3 polymorphic_allocator<void> as a vocabulary type
+P0339R4 polymorphic_allocator<> as a vocabulary type
+P0339R5 polymorphic_allocator<> as a vocabulary type
+P0339R6 polymorphic_allocator<> as a vocabulary type
+P0340R0 Making std::underlying_type SFINAE-friendly
+P0340R1 Making std::underlying_type SFINAE-friendly
+P0340R2 Making std::underlying_type SFINAE-friendly
+P0340R3 Making std::underlying_type SFINAE-friendly
+P0341R0 parameter packs outside of templates
+P0342R0 Timing barriers
+P0342R1 What does "current time" mean?
+P0342R2 pessimize_hint
+P0343R0 Meta-programming High-Order Functions
+P0343R1 Meta-programming High-Order Functions
+P0345R0 Allowing any unsigned integral type as parameter type for literal operators
+P0346R0 A <random> Nomenclature Tweak
+P0346R1 A <random> Nomenclature Tweak
+P0347R0 Simplifying simple uses of <random>
+P0347R1 Simplifying simple uses of <random>
+P0348R0 Validity testing issues
+P0349R0 Assumptions about the size of datapar
+P0350R0 Integrating datapar with parallel algorithms and executors
+P0350R1 Integrating simd with parallel algorithms
+P0350R2 Integrating simd with parallel algorithms
+P0350R3 Integrating simd with parallel algorithms
+P0350R4 Integrating simd with parallel algorithms
+P0352R0 Smart References through Delegation: An Alternative to N4477's Operator Dot
+P0352R1 Smart References through Delegation (2nd revision)
+P0353R0 Unicode Encoding Conversions for the Standard Library
+P0353R1 Unicode Friendly Encoding Conversions for the Standard Library
+P0354R0 default == is >, default < is < so
+P0355R0 Extending <chrono> to Calendars and Time Zones
+P0355R1 Extending <code><chrono></code> to Calendars and Time Zones
+P0355R2 Extending <chrono> to Calendars and Time Zones
+P0355R3 Extending <code><chrono></code> to Calendars and Time Zones
+P0355R4 Extending <code><chrono></code> to Calendars and Time Zones
+P0355R5 Extending <chrono> to Calendars and Time Zones
+P0355R6 Extending chrono to Calendars and Time Zones
+P0355R7 Extending <chrono> to Calendars and Time Zones
+P0356R0 Simplified partial function application
+P0356R1 Simplified partial function application
+P0356R2 Simplified partial function application
+P0356R3 Simplified partial function application
+P0356R4 Simplified partial function application
+P0356R5 Simplified partial function application
+P0357R0 reference_wrapper for incomplete types
+P0357R1 reference_wrapper for incomplete types
+P0357R2 'reference_wrapper' for incomplete types
+P0357R3 'reference_wrapper' for incomplete types
+P0358R0 Fixes for not_fn
+P0358R1 Fixes for not_fn
+P0359R0 SG5: Transactional Memory (TM) Meeting Minutes 2016/02/22-2016/05/23
+P0360R0 SG14: Low Latency Meeting Minutes 2016/02/17-2015/05/25
+P0361R0 Invoking Algorithms asynchronously
+P0361R1 Invoking Algorithms asynchronously
+P0362R0 Towards support for Heterogeneous Devices in C++ (Concurrency aspects)
+P0363R0 Towards support for Heterogeneous Devices in C++ (Language aspects)
+P0364R0 Report on Exception Handling Lite (Disappointment) from SG14
+P0365R0 Report on SG14, a year later and future directions
+P0366R0 Extending the Transactional Memory Technical Specification with an in_transaction Statemen
+P0367R0 a C++ standard library class to qualify data accesses
+P0369R0 2017-07 Toronto ISO WG21 C++ Standard Meeting information
+P0370R0 Ranges TS Design Updates Omnibus
+P0370R1 Ranges TS Design Updates Omnibus
+P0370R2 Ranges TS Design Updates Omnibus
+P0370R3 Ranges TS Design Updates Omnibus
+P0371R0 Temporarily deprecate memory_order_consume
+P0371R1 Temporarily discourage memory_order_consume
+P0372R0 A type for utf-8 data
+P0373R0 Proposal of File Literals
+P0374R0 Stream parallelism patterns
+P0375R0 [[exhaustive]] attribute for enums
+P0376R0 A Single Generalization of std::invoke, std::apply, and std::visit
+P0377R0 std::integral_constant with a Deduced Value Type
+P0379R0 Why a joining thread from P0206 is a Bad Idea
+P0380R0 A Contract Design
+P0380R1 A Contract Design
+P0381R0 Numeric Width
+P0381R1 Numeric Width
+P0382R0 Comments on P0119: Overload sets as function arguments
+P0384R0 Core Language Working Group "tentatively ready" Issues for the June, 2016 (Oulu) meeting
+P0385R0 Static reflection: Rationale, design and evolution
+P0385R1 Static reflection: Rationale, design and evolution
+P0385R2 Static reflection: Rationale, design and evolution
+P0386R0 Inline Variables
+P0386R2 Inline Variables
+P0387R0 Memory Model Issues for Concurrent Data Structures
+P0387R1 Memory Model Issues for Concurrent Data Structures
+P0388R0 Permit conversions to arrays of unknown bound
+P0388R1 Permit conversions to arrays of unknown bound
+P0388R2 Permit conversions to arrays of unknown bound
+P0388R3 Permit conversions to arrays of unknown bound
+P0388R4 Permit conversions to arrays of unknown bound
+P0389R0 template keyword in unqualified-ids
+P0390R0 A Proposal to Add Pointer Cast Functions with Move Semantics to the Standard Library
+P0391R0 Introducing the term "templated entity"
+P0392R0 Adapting string_view by filesystem paths
+P0393R3 Making Variant Greater Equal
+P0394R4 Hotel Parallelifornia: terminate() for Parallel Algorithms Exception Handling
+P0396R0 C++ Concepts Active Issues List (Snapshot of Revision 4)
+P0397R0 C++ Standard Library Priority 1 Issues Resolved Directly In Oulu
+P0398R0 Core issue 1518: Explicit default constructors and copy-list-initialization
+P0399R0 Networking TS & Threadpools
+P0400R0 Wording for Order of Evaluation of Function Arguments
+P0401R0 Extensions to the Allocator interface
+P0401R1 Providing size feedback in the Allocator interface
+P0401R2 Providing size feedback in the Allocator interface
+P0401R3 Providing size feedback in the Allocator interface
+P0401R4 Providing size feedback in the Allocator interface
+P0401R5 Providing size feedback in the Allocator interface
+P0401R6 Providing size feedback in the Allocator interface
+P0403R0 Literal suffixes for basic_string_view
+P0403R1 Literal suffixes for basic_string_view
+P0404R0 Matching Types: 404 Syntax Not found
+P0405R0 Wording for Networking TS changes from Kona
+P0406R1 Intrusive Containers
+P0407R0 Allocator-aware basic stringbuf
+P0407R1 Allocator-aware basic stringbuf
+P0407R2 Allocator-aware basic_stringbuf
+P0408R0 Efficient Access to basic stringbuf's Buffer
+P0408R1 Efficient Access to basic stringbuf's Buffer
+P0408R2 Efficient Access to basic stringbuf's Buffer
+P0408R3 Efficient Access to basic_stringbuf's Buffer
+P0408R4 Efficient Access to basic_stringbuf’s Buffer
+P0408R5 Efficient Access to basic_stringbuf’s Buffer
+P0408R6 Efficient Access to basic_stringbuf’s Buffer
+P0408R7 Efficient Access to basic_stringbuf’s Buffer
+P0409R0 Allow lambda capture [=, this]
+P0409R1 Allow lambda capture [=, this]
+P0409R2 Allow lambda capture [=, this]
+P0411R0 Separating Library Requirements and Preconditions
+P0412R0 Benchmarking primitives
+P0413R0 Updating Parallel Execution Policy Names in the Parallelism TS
+P0414R0 Merging shared_ptr changes from Library Fundamentals to C++17
+P0414R1 Merging shared_ptr changes from Library Fundamentals to C++17
+P0414R2 Merging shared_ptr changes from Library Fundamentals to C++17
+P0415R0 Constexpr for std::complex
+P0415R1 Constexpr for std::complex
+P0416R0 Operator Dot (R3)
+P0416R1 Operator Dot (R3)
+P0417R0 C++17 should refer to ISO/IEC 10646 2014 instead of 1994
+P0417R1 C++17 should refer to ISO/IEC 10646 2014 instead of 1994 (R1)
+P0418R1 Fail or succeed: there is no atomic lattice
+P0418R2 Fail or succeed: there is no atomic lattice
+P0421R0 Static class constructor
+P0422R0 Out-of-Thin-Air Execution is Vacuous
+P0423R0 Variable templates for Networking TS traits
+P0424R0 Reconsidering literal operator templates for strings
+P0424R1 Reconsidering literal operator templates for strings
+P0424R2 String literals as non-type template parameters
+P0425R0 Metaprogramming by design, not by accident
+P0426R0 Constexpr for std::char_traits
+P0426R1 Constexpr for std::char_traits
+P0428R0 Familiar template syntax for generic lambdas
+P0428R1 Familiar template syntax for generic lambdas
+P0428R2 Familiar template syntax for generic lambdas
+P0429R0 A Standard flat_map
+P0429R1 A Standard flat_map
+P0429R2 A Standard flat_map
+P0429R3 A Standard flat_map
+P0429R4 A Standard flatmap
+P0429R5 A Standard flat_map
+P0429R6 A Standard flatmap
+P0429R7 A Standard flat_map
+P0429R8 A Standard flat_map
+P0429R9 A Standard flat_map
+P0430R0 File system library on non-POSIX-like operating systems
+P0430R1 File system library on non-POSIX-like operating systems
+P0430R2 File system library on non-POSIX-like operating systems
+P0431R0 Correcting Evaluation Order for C++
+P0432R0 Implicit and Explicit Default Comparison Operators
+P0433R0 Toward a resolution of US7 and US14: Integrating template deduction for class templates into the standard library
+P0433R1 Toward a resolution of US7 and US14: Integrating template deduction for class templates into the standard library
+P0433R2 Toward a resolution of US7 and US14: Integrating template deduction for class templates into the standard library
+P0433R3 Toward a resolution of US7 and US14: Integrating template deduction for class templates into the standard library
+P0434R0 Portable Interrupt Library
+P0435R0 Resolving LWG Issues re common_type
+P0435R1 Resolving LWG Issues re common_type
+P0436R0 An Extensible Approach to Obtaining Selected Operators
+P0436R1 An Extensible Approach to Obtaining Selected Operators
+P0437R0 Numeric Traits for the Next Standard Library
+P0437R1 Numeric Traits for the Standard Library
+P0438R0 Toward a <random> Technical Specification
+P0439R0 Make memory_order a scoped enumeration
+P0440R0 Floating Point Atomic View
+P0440R1 Floating Point Atomic View
+P0441R0 Ranges: Merging Writable and MoveWritable
+P0441R1 Ranges: Merging Writable and MoveWritable
+P0443R0 A Unified Executors Proposal for C++
+P0443R1 A Unified Executors Proposal for C++
+P0443R2 A Unified Executors Proposal for C++
+P0443R3 A Unified Executors Proposal for C++
+P0443R4 A Unified Executors Proposal for C++
+P0443R5 A Unified Executors Proposal for C++
+P0443R6 A Unified Executors Proposal for C++
+P0443R7 A Unified Executors Proposal for C++
+P0443R9 A Unified Executors Proposal for C++
+P0443R10 A Unified Executors Proposal for C++
+P0443R11 A Unified Executors Proposal for C++
+P0443R12 A Unified Executors Proposal for C++
+P0443R13 A Unified Executors Proposal for C++
+P0443R14 A Unified Executors Proposal for C++
+P0444R0 Unifying suspend-by-call and suspend-by-return
+P0445R0 SG14: Low Latency Meeting Minutes 2016/09/21-2016/10/13
+P0446R0 SG5: Transactional Memory (TM) Meeting Minutes 2016/07/18-2016/10/10
+P0447R0 Introduction of std::colony to the standard library
+P0447R1 Introduction of std::colony to the standard library
+P0447R2 Introduction of std::colony to the standard library
+P0447R3 Introduction of std::colony to the standard library
+P0447R4 Introduction of std::colony to the standard library
+P0447R8 Introduction of std::colony to the standard library
+P0447R9 Introduction of std::colony to the standard library
+P0447R10 Introduction of std::colony to the standard library
+P0447R11 Introduction of std::colony to the standard library
+P0447R12 Introduction of std::colony to the standard library
+P0447R13 Introduction of std::colony to the standard library
+P0447R14 Introduction of std::colony to the standard library
+P0447R15 Introduction of std::hive to the standard library
+P0447R16 Introduction of std::hive to the standard library
+P0447R17 Introduction of std::hive to the standard library
+P0447R18 Introduction of std::hive to the standard library
+P0447R19 Introduction of std::hive to the standard library
+P0447R20 Introduction of std::hive to the standard library
+P0447R21 Introduction of std::hive to the standard library
+P0447R22 Introduction of std::hive to the standard library
+P0447R23 Introduction of std::hive to the standard library
+P0447R24 Introduction of std::hive to the standard library
+P0447R25 Introduction of std::hive to the standard library
+P0447R26 Introduction of std::hive to the standard library
+P0448R0 A strstream replacement using span<charT> as
+P0448R1 A strstream replacement using span<charT> as
+P0448R2 A strstream replacement using span<charT> as buffer
+P0448R3 A strstream replacement using span as buffer
+P0448R4 A strstream replacement using span as buffer
+P0451R0 Future-Proofing Parallel Algorithms Exception Handling
+P0452R0 Binary transform_reduce(): The Missing Overload
+P0452R1 Unifying <numeric> Parallel Algorithms
+P0454R0 Wording for a Minimal mdspan
+P0457R0 String Prefix and Suffix Checking
+P0457R1 String Prefix and Suffix Checking
+P0457R2 String Prefix and Suffix Checking
+P0458R0 Checking for Existence of an Element in Associative Containers
+P0458R1 Checking for Existence of an Element in Associative Containers
+P0458R2 Checking for Existence of an Element in Associative Containers
+P0459R0 C++ Extensions for Ranges, Speculative Combined Proposal Document
+P0460R0 Flat containers wording
+P0461R0 Proposed RCU C++ API
+P0461R1 Proposed RCU C++ API
+P0461R2 Proposed RCU C++ API
+P0462R0 Marking memory order consume Dependency Chains
+P0462R1 Marking memory order consume Dependency Chains
+P0463R0 endian, Just endian
+P0463R1 endian, Just endian
+P0464R0 Revisiting the meaning of "foo(ConceptName,ConceptName)"
+P0464R1 Revisiting the meaning of "foo(ConceptName,ConceptName)"
+P0464R2 Revisiting the meaning of "foo(ConceptName,ConceptName)"
+P0465R0 Procedural Function Interfaces
+P0466R0 Layout-compatibility and Pointer-interconvertibility Traits
+P0466R1 Layout-compatibility and Pointer-interconvertibility Traits
+P0466R2 Layout-compatibility and Pointer-interconvertibility Traits
+P0466R3 Layout-compatibility and Pointer-interconvertibility Traits
+P0466R4 Layout-compatibility and Pointer-interconvertibility Traits
+P0466R5 Layout-compatibility and Pointer-interconvertibility Traits
+P0467R0 Iterator Concerns for Parallel Algorithms
+P0467R1 Iterator Concerns for Parallel Algorithms
+P0467R2 Iterator Concerns for Parallel Algorithms
+P0468R0 A Proposal to Add an Intrusive Smart Pointer to the C++ Standard Library
+P0468R1 An Intrusive Smart Pointer
+P0469R0 Sample in place
+P0471R0 Single argument std::inserter
+P0472R0 Move 'std::monostate' to <utility>
+P0473R0 + for std::vector concatenation
+P0474R0 Comparison in C++: Basic Facilities
+P0475R0 LWG 2511: guaranteed copy elision for piecewise construction
+P0475R1 LWG 2511: guaranteed copy elision for piecewise construction
+P0476R0 Bit-casting object representations
+P0476R1 Bit-casting object representations
+P0476R2 Bit-casting object representations
+P0477R0 std::monostate_function<>
+P0478R0 Template argument deduction for non-terminal function parameter packs
+P0479R0 Attributes for Likely and Unlikely Branches
+P0479R1 Attributes for Likely and Unlikely Branches
+P0479R2 Attributes for Likely and Unlikely Branches
+P0479R4 Proposed wording for likely and unlikely attributes
+P0479R5 Proposed wording for likely and unlikely attributes
+P0480R0 Explicit type checking with structured bindings
+P0480R1 Structured bindings with explicit types
+P0481R0 Bravely Default
+P0482R0 char8_t: A type for UTF-8 characters and strings
+P0482R1 char8_t: A type for UTF-8 characters and strings
+P0482R2 char8_t: A type for UTF-8 characters and strings
+P0482R3 char8_t: A type for UTF-8 characters and strings (Revision 3)
+P0482R4 char8_t: A type for UTF-8 characters and strings
+P0482R5 char8_t: A type for UTF-8 characters and strings
+P0482R6 char8_t: A type for UTF-8 characters and strings (Revision 6)
+P0483R0 Extending Memory Management Tools, And a Bit More
+P0483R2 static_vector
+P0484R0 Enhancing Thread Constructor Attributes
+P0484R1 Enhancing Thread Constructor Attributes
+P0485R0 Amended rules for Partial Ordering of function templates
+P0486R0 for_each_iter algorithm proposal
+P0487R0 Fixing operator>> (basic_istream&, CharT*) (LWG 2499)
+P0487R1 Fixing operator>>(basic_istream&, CharT*) (LWG 2499)
+P0488R0 WG21 Working paper: NB Comments, ISO/IEC CD 14882
+P0489R0 WG21 Working paper: Late Comments on CD 14882
+P0490R0 Core language changes addressing National Body comments for CD C++17
+P0492R0 Proposed Resolution of C++17 National Body Comments for Filesystem
+P0492R1 Proposed Resolution of C++17 National Body Comments for Filesystem
+P0492R2 Proposed Resolution of C++17 National Body Comments for Filesystem
+P0493R0 Atomic maximum/minimum
+P0493R1 Atomic maximum/minimum
+P0493R2 Atomic maximum/minimum
+P0493R3 Atomic maximum/minimum
+P0493R4 Atomic maximum/minimum
+P0494R0 contiguous_container proposal
+P0495R0 Concurrency Safety in C++ Data Structures
+P0497R0 Fixes to shared_ptr support for arrays
+P0500R0 Resolved Module TS (N4610) Issues
+P0501R0 C++ Module TS Issues List
+P0501R1 C++ Module TS Issues List
+P0501R2 C++ Module TS Issues List
+P0501R3 C++ Module TS Issues List
+P0502R0 Throwing out of a parallel algorithm terminates--but how?
+P0503R0 Correcting library usage of "literal type"
+P0504R0 Revisiting in-place tag types for any/optional/variant
+P0505R0 Wording for GB 50
+P0506R0 use string_view for library function parameters instead of const string & / const char *
+P0506R1 use string_view for library function parameters instead of const string & / const char *
+P0506R2 use string_view for library function parameters instead of const string & / const char *
+P0507R0 Core Issue 1343: Sequencing of non-class initialization
+P0508R0 Wording for GB 58
+P0509R1 Updating "Restrictions on exception handling"
+P0510R0 Disallowing references, incomplete types, arrays, and empty variants
+P0511R0 Deduction guide for std::array
+P0511R1 Deduction guide for std::array
+P0512R0 Class Template Argument Deduction Assorted NB resolution and issues
+P0513R0 Poisoning the Hash
+P0514R0 Enhancing std::atomic_flag for waiting
+P0514R1 Enhancing std::atomic_flag for waiting
+P0514R2 Efficient waiting for concurrent programs
+P0514R3 Efficient concurrent waiting for C++20
+P0514R4 Efficient concurrent waiting for C++20
+P0515R0 Consistent comparison
+P0515R1 Consistent comparison
+P0515R2 Consistent comparison
+P0515R3 Consistent comparison
+P0516R0 Clarify That shared_future's Copy Operations have Wide Contracts
+P0517R0 Make future_error Constructible
+P0518R0 Allowing copies as arguments to function objects given to parallel algorithms in response to CH11
+P0518R1 Allowing copies as arguments to function objects given to parallel algorithms in response to CH11
+P0519R0 Core Language Working Group "ready" Issues for the November, 2016 (Issaquah) meeting
+P0520R0 Core Language Working Group "tentatively ready" Issues for the November, 2016 (Issaquah) meeting
+P0521R0 Proposed Resolution for CA 14 (shared_ptr use_count/unique)
+P0522R0 DR: Matching of template template-arguments excludes compatible templates
+P0523R0 Wording for CH 10: Complexity of parallel algorithms
+P0523R1 Wording for CH 10: Complexity of parallel algorithms
+P0527R0 Implicitly move from rvalue references in return statements
+P0527R1 Implicitly move from rvalue references in return statements
+P0528R0 The Curious Case of Padding Bits, Featuring Atomic Compare-and-Exchange
+P0528R1 The Curious Case of Padding Bits, Featuring Atomic Compare-and-Exchange
+P0528R2 The Curious Case of Padding Bits, Featuring Atomic Compare-and-Exchange
+P0528R3 The Curious Case of Padding Bits, Featuring Atomic Compare-and-Exchange
+P0529R0 Wording changes for proposed Modules TS extensions
+P0532R0 On std::launder()
+P0533R0 constexpr for <cmath> and <cstdlib>
+P0533R1 constexpr for <cmath> and <cstdlib>
+P0533R2 constexpr for <cmath> and <cstdlib>
+P0533R3 constexpr for <cmath> and <cstdlib>
+P0533R4 constexpr for <cmath> and <cstdlib>
+P0533R5 constexpr for <cmath> and <cstdlib>
+P0533R6 constexpr for <cmath> and <cstdlib>
+P0533R7 constexpr for cmath and cstdlib
+P0533R8 constexpr for cmath and cstdlib
+P0533R9 constexpr for cmath and cstdlib
+P0534R0 call/cc (call-with-current-continuation): A low-level API for stackful context switching
+P0534R1 call/cc (call-with-current-continuation): A low-level API for stackful context switching
+P0534R2 call/cc (call-with-current-continuation): A low-level API for stackful context switching
+P0534R3 call/cc (call-with-current-continuation): A low-level API for stackful context switching
+P0535R0 Generalized Unpacking and Parameter Pack Slicing
+P0536R0 Implicit Return Type and Allowing Anonymous Types as Return Values
+P0537R0 Allow Attributes on Template Explicit Instantiations
+P0538R0 A Qualified Replacement for #pragma once
+P0539R0 Wide Integer Class
+P0539R1 A Proposal to add wide_int Template Class
+P0539R2 A Proposal to add wide_int Template Class
+P0539R3 A Proposal to add wide_int Template Class
+P0539R4 A Proposal to add wide_int Template Class
+P0539R5 A Proposal to add wide_int Template Class
+P0540R0 A Proposal to Add split/join of string/string_view to the Standard Library
+P0540R1 A Proposal to Add split/join of string/string_view to the Standard Library
+P0541R0 Post-Increment on Input and Output Iterators
+P0541R1 Ranges TS: Post-Increment on Input and Output Iterators
+P0542R0 Support for contract based programming in C++
+P0542R1 Support for contract based programming in C++
+P0542R2 Support for contract based programming in C++
+P0542R3 Support for contract based programming in C++
+P0542R4 Support for contract based programming in C++
+P0542R5 Support for contract based programming in C++
+P0543R0 Saturation arithmetic
+P0543R1 Saturation arithmetic
+P0543R2 Saturation arithmetic
+P0543R3 Saturation arithmetic
+P0544R0 User Injection of Filesystems
+P0545R0 Supporting offsetof for Stable-layout Classes
+P0546R0 Span - foundation for the future
+P0546R1 Span - foundation for the future
+P0546R2 Span - foundation for the future
+P0547R0 Assorted Object Concept Fixes
+P0547R1 Ranges TS: Assorted Object Concept Fixes
+P0547R2 Ranges TS: Assorted Object Concept Fixes
+P0548R0 common_type and duration
+P0548R1 common_type and duration
+P0549R0 Adjuncts to std::hash
+P0549R1 Adjuncts to std::hash
+P0549R2 Adjuncts to std::hash
+P0549R3 Adjuncts to std::hash
+P0549R4 Adjuncts to std::hash
+P0549R5 Adjuncts to std::hash
+P0549R6 Adjuncts to std::hash
+P0549R7 Adjuncts to std::hash
+P0550R0 Transformation Trait uncvref
+P0550R1 Transformation Trait uncvref
+P0550R2 Transformation Trait remove_cvref
+P0551R0 Thou Shalt Not Specialize std Function Templates!
+P0551R1 Thou Shalt Not Specialize std Function Templates!
+P0551R2 Thou Shalt Not Specialize std Function Templates!
+P0551R3 Thou Shalt Not Specialize std Function Templates!
+P0552R0 enable_if vs. requires
+P0553R0 Bit Operations
+P0553R1 Bit Operations
+P0553R2 Bit operations
+P0553R3 Bit operations
+P0553R4 Bit operations
+P0554R0 Composition of Arithmetic Types
+P0554R1 Composition of Arithmetic Types
+P0555R0 string_view for source_location
+P0556R0 Integral power-of-2 operations
+P0556R1 Integral power-of-2 operations
+P0556R2 Integral power-of-2 operations
+P0556R3 Integral power-of-2 operations
+P0557R0 Concepts: The Future of Generic Programming
+P0558R0 Resolving atomic<T> named base class inconsistencies
+P0558R1 Resolving atomic<T> named base class inconsistencies
+P0559R0 Operating principles for evolving C++
+P0560R0 Class template deduction guides for "diamond operators"
+P0561R0 RAII Interface for Deferred Reclamation
+P0561R1 RAII Interface for Deferred Reclamation
+P0561R2 RAII Interface for Deferred Reclamation
+P0561R3 An RAII Interface for Deferred Reclamation
+P0561R4 An RAII Interface for Deferred Reclamation
+P0561R5 An RAII Interface for Deferred Reclamation
+P0561R6 An RAII Interface for Deferred Reclamation
+P0562R0 Initialization List Symmetry
+P0563R0 Vector Front Operations
+P0564R0 Wording for three-way comparisons
+P0565R0 Prefix for operator as a pack generator and postfix operator[] for pack indexing
+P0566R0 Proposed Wording for Concurrent Data Structures: Hazard Pointer and Read-Copy-Update (RCU)
+P0566R1 Proposed Wording for Concurrent Data Structures: Hazard Pointer and Read-Copy-Update (RCU)
+P0566R2 Proposed Wording for Concurrent Data Structures: Hazard Pointer and Read-Copy-Update (RCU)
+P0566R3 Proposed Wording for Concurrent Data Structures: Hazard Pointer and Read-Copy-Update (RCU)
+P0566R4 Proposed Wording for Concurrent Data Structures: Hazard Pointer and Read-Copy-Update (RCU)
+P0566R5 Proposed Wording for Concurrent Data Structures: Hazard Pointer and Read­Copy­Update (RCU)
+P0567R0 Asynchronous managed pointer for Heterogeneous computing
+P0567R1 Asynchronous managed pointer for Heterogeneous computing
+P0568R0 Towards Better Embedded programming support for C++ and an update on the status of SG14, two years later
+P0569R0 SG5: Transactional Memory (TM) Meeting Minutes 2016/07/18-2016/10/10
+P0570R0 SG14: Low Latency Meeting Minutes 2016/12/14-2017/02/01
+P0571R0 Type Requirements for <numeric> Algorithms
+P0571R1 Type Requirements for <numeric> Algorithms
+P0571R2 Type Requirements for <numeric> Algorithms
+P0572R0 bit_sizeof and bit_offsetof
+P0572R1 bit_sizeof and bit_offsetof
+P0572R2 Static reflection of bit fields
+P0573R0 Abbreviated Lambdas for Fun and Profit
+P0573R1 Abbreviated Lambdas for Fun and Profit
+P0573R2 Abbreviated Lambdas for Fun and Profit
+P0574R0 Algorithm Complexity Constraints and Parallel Overloads
+P0574R1 Algorithm Complexity Constraints and Parallel Overloads
+P0575R0 Core Language Working Group "ready" Issues for the February, 2016 (Kona) meeting
+P0575R1 Core Language Working Group "ready" Issues for the February, 2016 (Kona) meeting
+P0575R2 Core Language Working Group "ready" Issues for the February, 2016 (Kona) meeting
+P0576R0 Core Language Working Group "tentatively ready" Issues for the February, 2016 (Kona) meeting
+P0576R1 Core Language Working Group "tentatively ready" Issues for the February, 2016 (Kona) meeting
+P0577R0 Keep that Temporary!
+P0577R1 Kept-value statement for guard objects
+P0578R0 Static Reflection in a Nutshell
+P0578R1 Static Reflection in a Nutshell
+P0579R0 Constexpr for <experimental/ranges/iterator>
+P0579R1 Constexpr for <experimental/ranges/iterator>
+P0581R0 Standard Library Modules
+P0581R1 Standard Library Modules
+P0582R0 Modules: Contexts of template instantiations and name lookup
+P0583R0 std::byte is the correct name
+P0584R0 Module Interface and Preamble
+P0586R0 Safe integral comparisons
+P0586R1 Safe integral comparisons
+P0586R2 Safe integral comparisons
+P0587R0 Concepts TS revisited
+P0588R0 Simplifying implicit lambda capture
+P0588R1 Simplifying implicit lambda capture
+P0589R0 Tuple-based for loops
+P0590R0 A design static reflection
+P0591R0 Utility functions to implement uses-allocator construction
+P0591R1 Utility functions to implement uses-allocator construction
+P0591R2 Utility functions to implement uses-allocator construction
+P0591R3 Utility functions to implement uses-allocator construction
+P0591R4 Utility functions to implement uses-allocator construction
+P0592R0 To boldly suggest an overall plan for C++20
+P0592R1 To boldly suggest an overall plan for C++23
+P0592R2 To boldly suggest an overall plan for C++23
+P0592R3 To boldly suggest an overall plan for C++23
+P0592R4 To boldly suggest an overall plan for C++23
+P0592R5 To boldly suggest an overall plan for C++26
+P0593R0 What to do with buffers that are not arrays, and undefined behavior thereof?
+P0593R1 Implicit creation of objects for low-level object manipulation
+P0593R2 Implicit creation of objects for low-level object manipulation
+P0593R3 Implicit creation of objects for low-level object manipulation
+P0593R4 Implicit creation of objects for low-level object manipulation
+P0593R5 Implicit creation of objects for low-level object manipulation
+P0593R6 Implicit creation of objects for low-level object manipulation
+P0594R0 Relative comparisons and std::less<T*>
+P0595R0 The "constexpr" Operator
+P0595R1 std::is_constant_evaluated()
+P0595R2 std::is_constant_evaluated
+P0596R0 std::constexpr_trace and std::constexpr_assert
+P0596R1 Side-effects in constant evaluation: Output and consteval variables
+P0597R0 std::constexpr_vector<T>
+P0598R0 Reflect Through Values Instead of Types
+P0599R0 US140: noxecept for hash functions
+P0599R1 US140: noxecept for hash functions
+P0600R0 applying [[nodiscard]] for C++17
+P0600R1 [[nodiscard]] in the Library
+P0601R0 Establishing a direction for SIMD-enabled functions
+P0602R0 variant and optional should propagate copy/move triviality
+P0602R1 variant and optional should propagate copy/move triviality
+P0602R2 variant and optional should propagate copy/move triviality
+P0602R3 variant and optional should propagate copy/move triviality
+P0602R4 variant and optional should propagate copy/move triviality
+P0603R0 safe memcpy: A simpler implementation primitive for seqlock and friends
+P0604R0 Resolving GB 55, US 84, US 85, US 86
+P0606R0 Concepts Are Ready
+P0607R0 Inline Variables for the Standard Library
+P0608R0 A sane variant converting constructor (LEWG 227)
+P0608R1 A sane variant converting constructor
+P0608R2 A sane variant converting constructor
+P0608R3 A sane variant converting constructor
+P0609R0 Attributes for Structured Bindings
+P0609R1 Attributes for Structured Bindings
+P0609R2 Attributes for Structured Bindings
+P0610R0 C++ Standard Library "Review" Issues Resolved in Kona
+P0611R0 More Better Operators
+P0612R0 NB comment CH 2: volatile
+P0613R0 NB comment GB15: Resolution of Core Issue 2011
+P0614R0 Range-based for statements with initializer
+P0614R1 Range-based for statements with initializer
+P0615R0 Renaming for structured bindings
+P0616R0 de-pessimize legacy <numeric> algorithms with std::move
+P0618R0 Deprecating <codecvt>
+P0619R0 Reviewing Deprecated Facilities of C++17 for C++20
+P0619R1 Reviewing Deprecated Facilities of C++17 for C++20
+P0619R2 Reviewing Deprecated Facilities of C++17 for C++20
+P0619R3 Reviewing Deprecated Facilities of C++17 for C++20
+P0619R4 Reviewing Deprecated Facilities of C++17 for C++20
+P0620R0 Drafting for class template argument deduction issues
+P0621R0 Ready Ranges TS Issues
+P0622R0 Additional Core Language Working Group "ready" and "tentatively ready" Issues for the February, 2017 (Kona) meeting
+P0623R0 Final C++17 Parallel Algorithms Fixes
+P0624R0 Default constructible stateless lambdas
+P0624R1 Default constructible stateless lambdas
+P0624R2 Default constructible and assignable stateless lambdas
+P0625R0 C++ Standard Library Issues Resolved Directly In Kona
+P0627R0 Attribute to mark unreachable code
+P0627R1 Attribute to mark unreachable code
+P0627R3 Function to mark unreachable code
+P0627R5 Function to mark unreachable code
+P0627R6 Function to mark unreachable code
+P0629R0 Module interface vs. imiplementation
+P0630R0 To boldly suggest a pub crawl for C++ Toronto
+P0631R0 Math Constants
+P0631R1 Math Constants
+P0631R2 Math Constants
+P0631R3 Math Constants
+P0631R4 Math Constants
+P0631R5 Math Constants
+P0631R6 Math Constants
+P0631R7 Math Constants
+P0631R8 Math Constants
+P0632R0 Proposal of [[uninitialized]] attribute
+P0633R0 Exploring the design space of metaprogramming and reflection
+P0634R0 Down with `typename`!
+P0634R1 Down with `typename`!
+P0634R2 Down with typename!
+P0634R3 Down with typename!
+P0635R0 Add c_array method to std::array
+P0636R0 Changes between C++14 and C++17
+P0636R1 Changes between C++14 and C++17
+P0636R2 Changes between C++14 and C++17
+P0636R3 Changes between C++14 and C++17
+P0637R0 Capture *this with initialize
+P0638R0 Crochemore-Perrin search algorithm for std::search
+P0639R0 Changing attack vector of the constexpr_vector
+P0640R0 User-defined exception information and diagnostic information in exception objects
+P0641R0 Resolving Core Issue #1331 (const mismatch with defaulted copy constructor)
+P0641R1 Resolving Core Issue #1331 (const mismatch with defaulted copy constructor)
+P0641R2 Resolving Core Issue #1331 (const mismatch with defaulted copy constructor)
+P0642R0 Structural Support for C++ Concurrency
+P0642R1 Structural Support for C++ Concurrency
+P0642R2 The Concurrent Invocation Library
+P0642R3 The Concurrent Invocation Library
+P0642R4 The Concurrent Invocation Library
+P0643R0 Omnibus paper:Toronto 2017 meeting
+P0644R0 Forward without forward
+P0644R1 Forward without forward
+P0645R0 Text Formatting
+P0645R1 Text Formatting
+P0645R2 Text Formatting
+P0645R3 Text Formatting
+P0645R4 Text Formatting
+P0645R5 Text Formatting
+P0645R7 Text Formatting
+P0645R9 Text Formatting
+P0645R10 Text Formatting
+P0646R0 Improving the Return Value of Erase-Like Algorithms
+P0646R1 Improving the Return Value of Erase-Like Algorithms I: list/forward list
+P0647R0 Floating point value access for std::ratio
+P0647R1 Floating point value access for std::ratio
+P0648R0 Extending Tuple-like algorithms to Product-Typ
+P0649R0 Other Product-Type algorithms
+P0650R0 C++ Monadic interface
+P0650R1 C++ Monadic interface
+P0650R2 C++ Monadic interface
+P0651R0 Switch the Ranges TS to Use Variable Concepts
+P0651R1 Switch the Ranges TS to Use Variable Concepts
+P0652R0 Concurrent associative data structure with unsynchronized view
+P0652R1 Concurrent associative data structure with unsynchronized view
+P0652R2 Concurrent associative data structure with unsynchronized view
+P0652R3 Concurrent associative data structure with unsynchronized view
+P0653R0 pointer_traits utility to convert to raw pointer
+P0653R1 Utility to convert a pointer to a raw pointer
+P0653R2 Utility to convert a pointer to a raw pointer
+P0654R0 Explicit struct
+P0655R0 visit<R>: Explicit Return Type for visit
+P0655R1 visit<R>: Explicit Return Type for visit
+P0656R0 Reducing <ratio>
+P0657R0 Deprecate Certain Declarations in the Global Namespace
+P0657R1 Deprecate Certain Declarations in the Global Namespace
+P0657R2 Deprecate Certain Declarations in the Global Namespace
+P0658R0 Proposal for adding alias declarations to concepts
+P0658R1 Proposal for adding alias declarations to concepts
+P0659R0 Adding status() to std::future
+P0660R0 A Cooperatively Interruptible Joining Thread
+P0660R2 A Cooperatively Interruptible Joining Thread, Rev 2
+P0660R3 A Cooperatively Interruptible Joining Thread
+P0660R4 A Cooperatively Interruptible Joining Thread
+P0660R5 A Cooperatively Interruptible Joining Thread
+P0660R6 A Cooperatively Interruptible Joining Thread, Rev 6
+P0660R7 Interrupt Tokens and a Joining Thread, Rev 7
+P0660R8 Stop Tokens and a Joining Thread
+P0660R9 Stop Token and Joining Thread
+P0660R10 Stop Token and Joining Thread
+P0661R0 slot_map Container in C++
+P0662R0 Wording for Ranges TS Issue 345 / US-2: Update ranged-for-loop wording
+P0663R0 Ranges TS "Ready" Issues for the July 2017 (Toronto) meeting
+P0664R0 Coroutines TS Issues
+P0664R1 Coroutines TS Issues
+P0664R2 C++ Coroutine TS Issues
+P0664R3 C++ Coroutine TS Issues
+P0664R4 C++ Coroutine TS Issues
+P0664R5 C++ Coroutine TS Issues
+P0664R6 C++ Coroutine TS Issues
+P0664R7 C++ Coroutine TS Issues
+P0664R8 C++ Coroutine TS Issues
+P0665R0 Allowing Class Template Specializations in Unrelated Namespaces
+P0665R1 Allowing Class Template Specializations in Associated Namespaces (revision 1)
+P0666R0 C++ Latches and Barriers
+P0666R1 Revised Latches and Barriers for C++20
+P0666R2 Revised Latches and Barriers for C++20
+P0667R0 The future of std::future extensions
+P0668R0 Revising the C++ memory model
+P0668R1 Revising the C++ memory model
+P0668R2 Revising the C++ memory model
+P0668R3 Revising the C++ memory model
+P0668R4 Revising the C++ memory model
+P0668R5 Revising the C++ memory model
+P0669R0 Why We Should Standardize 2D Graphics for C++
+P0670R0 Static reflection of functions
+P0670R1 Static reflection of functions
+P0670R2 Static reflection of functions
+P0670R3 Function reflection
+P0670R4 Function reflection
+P0671R0 Parametric Functions
+P0671R1 Parametric Functions
+P0671R2 Self-explanatory Function Arguments
+P0672R0 Implicit Evaluation of "auto" Variables
+P0673R0 Merge Concurrency TS atomic pointers into C++20 working draft
+P0674R0 Extending make_shared to Support Arrays
+P0674R1 Extending make_shared to Support Arrays
+P0675R0 Numeric Traits for Type Composition
+P0676R0 Towards a Good Future
+P0678R0 Business Requrements for Modules
+P0679R0 Forward progress vs. futures and continuations
+P0680R0 SG1 efficiency
+P0681R0 Precise Semantics for Assertions
+P0682R0 Repairing elementary string conversions
+P0682R1 Repairing elementary string conversions
+P0683R0 Default member initializers for bit-fields
+P0683R1 Default member initializers for bit-fields
+P0684R0 C++ Stability, Velocity, and Deployment Plans
+P0684R1 C++ Stability, Velocity, and Deployment Plans
+P0684R2 C++ Stability, Velocity, and Deployment Plans
+P0685R0 SG5: Transactional Memory (TM) Meeting Minutes 2017/01/30-2017/06/05
+P0686R0 SG14: Low Latency Meeting Minutes 2017/03/09-2017/06/14
+P0687R0 Data Movement in C++
+P0688R0 A Proposal to Simplify the Unified Executors Design
+P0689R0 A Word about Modules
+P0690R0 Tearable Atomics
+P0690R1 Tearable Atomics
+P0691R0 Integrating Concepts: "Open" items for consideration
+P0692R0 Access Specifiers and Specializations
+P0692R1 Access Checking on Specializations
+P0694R0 Function declarations using concepts
+P0695R0 Alternative concepts
+P0696R0 Remove abbreviated functions and template-introduction syntax from the Concepts TS
+P0696R1 Remove abbreviated functions and template-introduction syntax from the Concepts TS
+P0697R0 Clarifying the status of feature test macros
+P0698R0 C++ Standard Library Issues to be moved in Toronto
+P0699R0 C++ Standard Library Issues Resolved Directly In Toronto
+P0700R0 Alternatives to operator dot
+P0701R0 Back to the std2::future
+P0701R1 Back to the std2::future
+P0701R2 Back to the std2::future Part II
+P0702R0 Language support for Constructor Template Argument Deduction
+P0702R1 Language support for Constructor Template Argument Deduction
+P0703R0 Networking TS Issues
+P0704R0 Fixing const-qualified pointers to members
+P0704R1 Fixing const-qualified pointers to members
+P0705R0 Implicit and Explicit conversions
+P0706R0 Efficient headers for modules (or not)
+P0707R0 Metaclasses
+P0707R1 Metaclasses: Generative C++
+P0707R2 Metaclasses: Generative C++
+P0707R3 Metaclasses: Generative C++
+P0707R4 Metaclasses: Generative C++
+P0709R0 Zero-overhead deterministic exceptions: Throwing values
+P0709R1 Zero-overhead deterministic exceptions: Throwing values
+P0709R2 Zero-overhead deterministic exceptions: Throwing values
+P0709R3 Zero-overhead deterministic exceptions: Throwing values
+P0709R4 Zero-overhead deterministic exceptions: Throwing values
+P0710R0 Core Language Working Group "ready" Issues for the July, 2017 (Toronto) meeting
+P0710R1 Core Language Working Group "ready" Issues for the July, 2017 (Toronto) meeting
+P0711R0 Core Language Working Group "tentatively ready" Issues for the July, 2017 (Toronto) meeting
+P0712R0 Implementing language support for compile-time programming
+P0713R0 Identifying Module Source Code
+P0713R1 Identifying Module Source
+P0714R0 Identically Named Namespaces and non-Exported Symbols
+P0715R0 Exporting Using Directives
+P0716R0 Unified concept definition syntax
+P0717R0 Semantic constraint matching for concepts
+P0717R1 Semantic constraint matching for concepts
+P0718R0 Revising atomic_shared_ptr for C++20
+P0718R2 Revising atomic_shared_ptr for C++20
+P0721R0 Exporting Using Declarations
+P0722R0 Controlling destruction in delete expressions
+P0722R1 Efficient sized delete for variable sized classes
+P0722R2 Efficient sized delete for variable sized classes
+P0722R3 Efficient sized delete for variable sized classes
+P0723R0 Response to "Clarifying the status of feature test macros"
+P0724R0 Merge the Concepts TS Working Draft into the C++20 working draft
+P0725R0 Remove the requirement for constrained-type-specifiers to be deduced to the same type from the Concepts TS
+P0726R0 Does the Concepts TS Improve on C++17?
+P0727R0 Core Issue 1299: Temporary objects vs temporary expressions
+P0728R0 Wording for Networking PDTS ballot comment 005
+P0729R0 Proposed wording for Networking TS NB comment GB 9
+P0730R0 Options for addressing requires-clause syntax ambiguities
+P0730R1 Options for addressing requires-clause syntax ambiguities
+P0731R0 Module Interface Imports
+P0732R0 Class Types in Non-Type Template Parameters
+P0732R1 Class Types in Non-Type Template Parameters
+P0732R2 Class Types in Non-Type Template Parameters
+P0734R0 Wording Paper, C++ extensions for Concepts
+P0735R0 Interaction of memory_order_consume with release sequences
+P0735R1 Interaction of memory_order_consume with release sequences
+P0736R0 Nameless parameters and unutterable specializations
+P0736R1 Nameless parameters and unutterable specializations
+P0737R0 Execution Context of Execution Agents
+P0738R0 I Stream, You Stream, We All Stream for istream_iterator
+P0738R1 I Stream, You Stream, We All Stream for istream_iterator
+P0738R2 I Stream, You Stream, We All Stream for istream_iterator
+P0739R0 Some improvements to class template argument deduction integration into the standard library
+P0740R0 Ranges TS "Immediate" Issues from the July 2017 (Toronto) meeting
+P0742R0 Wording for Networking PDTS ballot comment resolutions
+P0745R0 Concepts in-place syntax
+P0745R1 Concepts in-place syntax
+P0746R0 Wording for Networking PDTS ballot comment 011 (US-10)
+P0747R0 Wording for Networking PDTS ballot comments 026 (GB-15) and 027 (GB-16)
+P0747R1 Wording for Networking PDTS ballot comment 026 (GB-15), but not 027 (GB-16)
+P0748R0 Wording for Networking PDTS ballot comments on reentrancy
+P0749R0 Namespace Pervasiveness & Modules
+P0750R0 Consume
+P0750R1 Consume
+P0752R0 std::vector Destruction Order
+P0753R0 Manipulators for C++ Synchronized Buffered Ostream
+P0753R1 Manipulators for C++ Synchronized Buffered Ostream
+P0753R2 Manipulators for C++ Synchronized Buffered Ostream
+P0754R0 <version>
+P0754R1 <version>
+P0754R2 <version>
+P0756R0 Lambda syntax should be more liberal in what it accepts
+P0757R0 regex_iterator should be iterable
+P0758R0 Implicit conversion traits and utility functions
+P0758R1 Implicit conversion traits and utility functions
+P0759R0 fpos Requirements
+P0759R1 fpos requirements
+P0761R0 Executors Design Document
+P0761R1 Executors Design Document
+P0761R2 Executors Design Document
+P0762R0 Concerns about expected<T, E> from the Boost.Outcome peer review
+P0766R0 Fixing small-ish functionality gaps in constraints
+P0766R1 Fixing small-ish functionality gaps in constraints
+P0767R0 Expunge POD
+P0767R1 Deprecate POD
+P0768R0 Library Support for the Spaceship (Comparison) Operaton
+P0768R1 Library Support for the Spaceship (Comparison) Operator
+P0769R0 Add shift to <algorithm>
+P0769R1 Add shift to <algorithm>
+P0769R2 Add shift to <algorithm>
+P0770R0 A Proposal to Specify Behavior in Case of Exception Allocation Failure
+P0771R0 std::function move operations should be noexcept
+P0771R1 std::function move constructor should be noexcept
+P0772R0 Execution-Agent Local Storage
+P0772R1 Execution Agent Local Storage
+P0773R0 Towards meaningful fancy pointers
+P0774R0 Module-decl location
+P0775R0 module partitions
+P0776R0 Rebase the Concurrency TS onto C++17 Standard
+P0776R1 Rebase the Parallelism TS onto the C++17 Standard
+P0777R0 Treating Unnecessary decay
+P0777R1 Treating Unnecessary decay
+P0778R0 Module Names
+P0779R0 Proposing operator try() (with added native C++ macro functions!)
+P0780R0 Allow pack expansion in lambda init-capture
+P0780R1 Allow pack expansion in lambda init-capture
+P0780R2 Allow pack expansion in lambda init-capture
+P0781R0 A Modern C++ Signature for main
+P0782R0 A Case for Simplifying/Improving Natural Syntax Concepts
+P0782R1 Constraining Concepts Overload Sets
+P0782R2 Constraining Concepts Overload Sets
+P0783R0 Continuations without overcomplicating the future
+P0784R0 Standard containers and constexpr
+P0784R1 Standard containers and constexpr
+P0784R2 Standard containers and constexpr
+P0784R3 More constexpr containers
+P0784R4 More constexpr containers
+P0784R5 More constexpr containers
+P0784R6 More constexpr containers
+P0784R7 More constexpr containers
+P0785R0 Runtime-sized arrays and a C++ wrapper
+P0786R0 SuccessOrFailure, ValuedOrError and ValuedOrNone types
+P0786R1 ValuedOrError and ValueOrNone types
+P0787R0 Proclaimed Ownership
+P0788R0 Standard Library Specification in a Concepts and Contracts World
+P0788R1 Standard Library Specification in a Concepts and Contracts World
+P0788R2 Standard Library Specification in a Concepts and Contracts World
+P0788R3 Standard Library Specification in a Concepts and Contracts World
+P0789R0 Range Adaptors and Utilities
+P0789R1 Range Adaptors and Utilities
+P0789R2 Range Adaptors and Utilities
+P0789R3 Range Adaptors and Utilities
+P0790R0 Effect of operator<=> on the C++ Standard Library
+P0790R1 Effect of operator<=> on the C++ Standard Library
+P0790R2 Effect of operator<=> on the C++ Standard Library
+P0791R0 Concepts are Adjectives, not Nouns
+P0792R0 function_ref: a non-owning reference to a Callable
+P0792R1 function_ref: a non-owning reference to a Callable
+P0792R2 function_ref: a non-owning reference to a Callable
+P0792R3 function_ref: a non-owning reference to a Callable
+P0792R4 function_ref: a non-owning reference to a Callable
+P0792R5 function_ref: a non-owning reference to a Callable
+P0792R6 function_ref: a non-owning reference to a Callable
+P0792R7 function_ref: a non-owning reference to a Callable
+P0792R8 function_ref: a non-owning reference to a Callable
+P0792R9 function_ref: a non-owning reference to a Callable
+P0792R10 function_ref: a non-owning reference to a Callable
+P0792R11 function_ref: a non-owning reference to a Callable
+P0792R12 function_ref: a non-owning reference to a Callable
+P0792R13 function_ref: a non-owning reference to a Callable
+P0792R14 function_ref: a non-owning reference to a Callable
+P0793R0 SG5: Transactional Memory (TM) Meeting Minutes 2017/06/19-2017/10/09
+P0794R0 SG14: Low Latency Meeting Minutes 2017/08/09-2017/10/11
+P0795R0 From Vulkan with love: a plea to reconsider the Module Keyword to be contextual
+P0796R0 Supporting Heterogeneous & Distributed Computing Through Affinity
+P0796R1 Supporting Heterogeneous & Distributed Computing Through Affinity
+P0796R2 Supporting Heterogeneous & Distributed Computing Through Affinity
+P0796R3 Supporting Heterogeneous & Distributed Computing Through Affinity
+P0797R0 Exception Handling in Parallel STL Algorithms
+P0797R1 Handling Concurrent Exceptions with Executors
+P0797R2 Handling Concurrent Exceptions with Executors
+P0798R0 Monadic operations for std::optional
+P0798R2 Monadic operations for std::optional
+P0798R3 Monadic operations for std::optional
+P0798R4 Monadic operations for std::optional
+P0798R6 Monadic operations for std::optional
+P0798R8 Monadic operations for std::optional
+P0799R0 Programming vulnerabilities for C++ (part of WG23 N0746)
+P0799R1 Vulnerability descriptions for the programming language C++
+P0800R0 The Concepts TS improves upon C++
+P0801R0 Extensions for Disambiguation Tags
+P0802R0 Applying Concepts to the Standard Library
+P0803R0 Endian Library Request for Comments
+P0804R0 Impact of the Modules TS on the C++ tools ecosystem
+P0805R0 Comparing containers
+P0805R1 Comparing Containers
+P0805R2 Comparing Containers
+P0806R0 Deprecate Implicit Capture of thist
+P0806R1 Deprecate implicit capture of this via [=]
+P0806R2 Deprecate implicit capture of this via [=]
+P0807R0 An Adjective Syntax for Concepts
+P0808R0 Ranges Naming
+P0809R0 Comparing Unordered Containers
+P0810R0 constexpr in Practice
+P0811R0 Well-behaved interpolation for numbers and pointers
+P0811R1 Well-behaved interpolation for numbers and pointers
+P0811R2 Well-behaved interpolation for numbers and pointers
+P0811R3 Well-behaved interpolation for numbers and pointers
+P0812R0 copy-list-initialization is inherently un-=
+P0813R0 construct() shall Return the Replaced Address
+P0813R1 construct() shall Return the Replaced Address
+P0814R0 hash_combine() Again
+P0814R2 hash_combine() Again
+P0815R0 C++ Standard Library Issues to be moved in Albuquerque
+P0816R0 No More Nested Namespaces in Library Design
+P0817R0 Core Language Working Group "ready" Issues for the November, 2017 (Albuquerque) meeting
+P0818R0 Core Language Working Group "tentatively ready" Issues for the November, 2017 (Albuquerque) meeting
+P0818R1 Core Language Working Group "tentatively ready" Issues for the November, 2017 (Albuquerque) meeting
+P0819R0 Formally Supporting Feature Macros
+P0820R0 Feedback on P0214R5
+P0820R1 Feedback on P0214r6
+P0820R2 Feedback on P0214
+P0820R3 Feedback on P0214
+P0820R4 Feedback on P0214
+P0821R0 Teaching Concepts TS Online
+P0822R0 C++ Modules Are a Tooling Opportunity
+P0824R0 Summary of SG14 discussion on <system_error>: towards exception-less error handling
+P0824R1 Summary of SG14 discussion on <system_error>
+P0825R0 A friendlier tuple get
+P0825R1 A friendlier tuple get
+P0826R0 SFINAE-friendly std::bind
+P0827R0 General-Purpose Constant Value Type
+P0828R0 Elastic Integers
+P0828R1 Elastic Integers
+P0829R0 Freestanding proposal
+P0829R1 Freestanding Proposal
+P0829R2 Freestanding Proposal
+P0829R3 Freestanding Proposal
+P0829R4 Freestanding Proposal
+P0830R0 Using Concepts and requires in the C++ Standard Library
+P0831R0 Keep alias syntax extendable
+P0832R0 Module TS Does Not Support Intended Use Case
+P0834R0 Lifting overload sets into objects
+P0835R0 Adopt SD-6 feature macros into the C++20 working draft
+P0836R0 Introduce Parallelism to the Ranges TS
+P0836R1 Introduce Parallelism to the Ranges TS
+P0837R0 Ruminations on modular macros
+P0838R0 A conditional transform algorithm for C++
+P0839R0 Recursive Lambdas
+P0840R0 Lamguage support for empty objects
+P0840R1 Language support for empty objects
+P0840R2 Language support for empty objects
+P0841R0 Modules at scale
+P0842R0 Unknown Exports by Example
+P0843R0 fixed_capacity_vector
+P0843R1 fixed_capacity_vector
+P0843R2 static_vector
+P0843R3 static_vector
+P0843R4 static_vector
+P0843R5 static_vector
+P0843R6 static_vector
+P0843R7 inplace_vector
+P0843R8 inplace_vector
+P0843R9 inplace_vector
+P0844R0 Type functions and beyond
+P0845R0 Common Subset of C++03 and C++17: Binders
+P0846R0 ADL and Function Templates that are not Visible
+P0847R0 Deducing this
+P0847R1 Deducing this
+P0847R2 Deducing this
+P0847R4 Deducing this
+P0847R5 Deducing this
+P0847R6 Deducing this
+P0847R7 Deducing this
+P0848R0 Conditionally Trivial Special Member Functions
+P0848R1 Conditionally Trivial Special Member Functions
+P0848R2 Conditionally Trivial Special Member Functions
+P0848R3 Conditionally Trivial Special Member Functions
+P0849R0 auto(x): DECAY_COPY in the language
+P0849R1 auto(x): decay-copy in the language
+P0849R2 auto(x): decay-copy in the language
+P0849R3 auto(x): decay-copy in the language
+P0849R4 auto(x): decay-copy in the language
+P0849R5 auto(x): decay-copy in the language
+P0849R6 auto(x): decay-copy in the language
+P0849R7 auto(x): decay-copy in the language
+P0849R8 auto(x): decay-copy in the language
+P0851R0 simd<T> is neither a product type nor a container type
+P0856R0 Restrict Access Property for mdspan and span
+P0857R0 Wording for "functionality gaps in constraints"
+P0858R0 Constexpr iterator requirements
+P0859R0 Core Issue 1581: When are constexpr member functions defined?
+P0860R0 Atomic Access Property for span and mdspan
+P0860R1 Atomic Access Property for mdspan
+P0863R0 Fixing the partial_order comparison algorithm
+P0863R1 Fixing the partial_order comparison algorithm
+P0864R0 C++ Standard Library Issues Resolved Directly In Albuquerque
+P0866R0 Response to “Fibers under the magnifying glass”
+P0867R0 'Module Interface' is Misleading
+P0868R0 Selected RCU Litmus Tests
+P0868R1 Selected RCU Litmus Tests
+P0868R2 Selected RCU Litmus Tests
+P0870R0 A proposal for a type trait to detect narrowing conversions
+P0870R1 A proposal for a type trait to detect narrowing conversions
+P0870R2 A proposal for a type trait to detect narrowing conversions
+P0870R3 A proposal for a type trait to detect narrowing conversions
+P0870R4 A proposal for a type trait to detect narrowing conversions
+P0870R5 A proposal for a type trait to detect narrowing conversions
+P0872R0 Discussion Summary: Applying Concepts to the Standard Library
+P0873R0 A plea for a consistent, terse and intuitive declaration syntax
+P0873R1 A plea for a consistent, terse and intuitive declaration syntax
+P0874R0 Syntax to anonymously refer to the current declaration contexts
+P0875R0 WG21 2017-11 Albuquerque Record of Discussion
+P0876R0 fibers without scheduler
+P0876R2 fiber_context - fibers without scheduler
+P0876R3 fiber_handle - fibers without scheduler
+P0876R5 fiber_context - fibers without scheduler
+P0876R6 fiber_context - fibers without scheduler
+P0876R8 fiber_context - fibers without scheduler
+P0876R9 fiber_context - fibers without scheduler
+P0876R10 fiber_context - fibers without scheduler
+P0876R11 fiber_context - fibers without scheduler
+P0876R12 fiber_context - fibers without scheduler
+P0876R13 fiber_context - fibers without scheduler
+P0876R14 fiber_context - fibers without scheduler
+P0877R0 A proposal for modular macros
+P0878R0 Subobjects copy elision
+P0879R0 Constexpr for swap and swap related functions
+P0880R0 Numbers interaction
+P0880R1 Numbers interaction
+P0880R2 Numbers interaction
+P0881R0 A Proposal to add stack trace library
+P0881R1 A Proposal to add stack trace library
+P0881R2 A Proposal to add stack trace library
+P0881R3 A Proposal to add stacktrace library
+P0881R4 A Proposal to add stacktrace library
+P0881R5 A Proposal to add stacktrace library
+P0881R6 A Proposal to add stacktrace library
+P0881R7 A Proposal to add stacktrace library
+P0882R0 User-defined Literals for std::filesystem::path
+P0883R0 Fixing Atomic Initialization
+P0883R1 Fixing Atomic Initialization
+P0883R2 Fixing Atomic Initialization
+P0884R0 Extending the noexcept Policy
+P0886R0 The assume aligned attribute
+P0887R0 The identity metafunction
+P0887R1 The identity metafunction
+P0888R0 C++ Standard Library Issues to be moved in Jacksonville
+P0889R0 Ultimate copy elision
+P0889R1 Ultimate copy elision
+P0891R0 Let strong_order Truly Be a Customization Point!
+P0891R1 Everyone Deserves a Little Order
+P0891R2 Make strong_order a Customization Point!
+P0892R0 explicit(bool)
+P0892R1 explicit(bool)
+P0892R2 explicit(bool)
+P0893R0 Chaining Comparisons
+P0893R1 Chaining Comparisons
+P0894R0 `realloc()` for C++
+P0894R1 realloc() for C++
+P0895R0 Renaming cell<> to latest<>
+P0896R0 Merging the Ranges TS
+P0896R1 Merging the Ranges TS
+P0896R2 The One Ranges Proposal
+P0896R3 The One Ranges Proposal
+P0896R4 The One Ranges Proposal
+P0897R0 Supporting offsetof for All Classes
+P0898R0 Standard Library Concepts
+P0898R1 Standard Library Concepts
+P0898R2 Standard Library Concepts
+P0898R3 Standard Library Concepts
+P0899R0 LWG 3016 is Not a Defect
+P0899R1 LWG 3016 is Not a Defect
+P0900R0 An Ontology for Properties of mdspan
+P0901R0 Size feedback in operator new
+P0901R1 Size feedback in operator new
+P0901R2 Size feedback in operator new
+P0901R3 Size feedback in operator new
+P0901R4 Size feedback in operator new
+P0901R5 Size feedback in operator new
+P0901R6 Size feedback in operator new
+P0901R7 Size feedback in operator new
+P0901R8 Size feedback in operator new
+P0901R9 Size feedback in operator new
+P0901R10 Size feedback in operator new
+P0901R11 Size feedback in operator new
+P0902R0 Move-only iterators
+P0903R0 Define basic_string_view(nullptr) and basic_string(nullptr)
+P0903R1 Define basic_string_view(nullptr)
+P0903R2 Define basic_string_view(nullptr)
+P0904R0 A strawman Future API
+P0905R0 Symmetry for spaceship
+P0905R1 Symmetry for spaceship
+P0906R0 Improvement suggestions for the Modules TS
+P0906R1 Improvement suggestions for the Modules TS
+P0907R0 Signed Integers are Two’s Complement
+P0907R1 Signed Integers are Two’s Complement
+P0907R2 Signed Integers are Two’s Complement
+P0907R3 Signed Integers are Two’s Complement
+P0907R4 Signed Integers are Two’s Complement
+P0908R0 Offsetof for Pointers to Members
+P0909R0 Module TS Supports Legacy Integration
+P0911R0 Rebase the Coroutines TS onto the C++17 Standard
+P0911R1 Rebase the Coroutines TS onto the C++17 Standard
+P0912R0 Merge Coroutines TS into C++20 working draft
+P0912R1 Merge Coroutines TS into C++20 working draft
+P0912R2 Merge Coroutines TS into C++20 working draft
+P0912R3 Merge Coroutines TS into C++20 working draft
+P0912R4 Merge Coroutines TS into C++20 working draft
+P0912R5 Merge Coroutines TS into C++20 working draft
+P0913R0 Add symmetric coroutine control transfer
+P0913R1 Add symmetric coroutine control transfer
+P0914R0 Add parameter preview to coroutine promise constructor
+P0914R1 Add parameter preview to coroutine promise constructor
+P0915R0 Concept-constrained auto
+P0916R0 Naming implementation-defined simd_abi tag types
+P0917R0 Making operator?: overloadable
+P0917R1 Making operator?: overloadable
+P0917R2 Making operator?: overloadable
+P0917R3 Making operator?: overloadable
+P0918R0 More simd<> Operations
+P0918R1 More simd<> Operations
+P0918R2 More simd<> Operations
+P0919R0 Heterogeneous lookup for unordered containers
+P0919R1 Heterogeneous lookup for unordered containers
+P0919R2 Heterogeneous lookup for unordered containers
+P0919R3 Heterogeneous lookup for unordered containers
+P0920R0 Precalculated hash values in lookup
+P0920R1 Precalculated hash values in lookup
+P0920R2 Precalculated hash values in lookup
+P0921R0 Standard Library Compatibility Promises
+P0921R2 Standard Library Compatibility
+P0922R0 LEWG wishlist for EWG
+P0923R0 Modules: Dependent ADL
+P0923R1 Modules:Dependent ADL
+P0924R0 Modules: Context-Sensitive Keyword
+P0924R1 Modules:Context-Sensitive Keyword
+P0925R0 Modules: Unqualified Using Declarations
+P0927R0 Towards A (Lazy) Forwarding Mechanism for C++
+P0927R1 Towards A (Lazy) Forwarding Mechanism for C++
+P0927R2 Towards A (Lazy) Forwarding Mechanism for C++
+P0928R0 Mitigating Speculation Attacks in C++
+P0928R1 Mitigating Spectre v1 Attacks in C++
+P0929R0 Checking for abstract class types
+P0929R1 Checking for abstract class types
+P0929R2 Checking for abstract class types
+P0930R0 Semifying Awaitables
+P0931R0 Structured bindings with polymorphic lambas
+P0932R0 Tightening the constraints on std::function
+P0932R1 Tightening the constraints on std::function
+P0933R0 Runtime type introspection with std::exception ptr
+P0933R1 Runtime type introspection with std::exception_ptr
+P0934R0 A Modest Proposal: Fixing ADL
+P0935R0 Eradicating unnecessarily explicit default constructors from the standard library
+P0936R0 Bind Returned/Initialized Objects to the Lifetime of Parameters
+P0937R0 SG5: Transactional Memory (TM) Meeting Minutes 2017/10/23-2018/1/29
+P0938R0 SG14: Low Latency Meeting Minutes 2017/12/13-2018/01/10
+P0939R0 Direction for ISO C++
+P0939R1 Directions for ISO C++
+P0939R2 Direction for ISO C++
+P0939R3 Direction for ISO C++
+P0939R4 Direction for ISO C++
+P0940R0 Concurrency TS is growing: Concurrent Utilities and Data Structures
+P0940R1 Concurrency TS is growing: Concurrent Utilities and Data Structures
+P0940R2 Concurrency TS is growing: Concurrent Utilities and Data Structures
+P0940R3 Concurrency TS is growing: Concurrent Utilities and Data Structures
+P0941R0 Integrating feature-test macros into the C++ WD
+P0941R1 Integrating feature-test macros into the C++ WD
+P0941R2 Integrating feature-test macros into the C++ WD
+P0942R0 Introducing a <smart_ptr> header
+P0943R0 Support C atomics in C++
+P0943R1 Support C atomics in C++
+P0943R2 Support C atomics in C++
+P0943R3 Support C atomics in C++
+P0943R4 Support C atomics in C++
+P0943R5 Support C atomics in C++
+P0943R6 Support C atomics in C++
+P0944R0 Contiguous Ranges
+P0945R0 Generalizing alias declarations
+P0946R0 Towards consistency between <=> and other comparison operators
+P0947R0 Another take on Modules
+P0947R1 Another take on Modules
+P0949R0 Adding support for type-based metaprogramming to the standard library
+P0952R0 A new specification for std::generate_canonical
+P0952R1 A new specification for std::generate_canonical
+P0952R2 A new specification for std::generate_canonical
+P0953R0 constexpr reflexpr
+P0953R1 constexpr reflexpr
+P0953R2 constexpr reflexpr
+P0954R0 What do we want to do with reflection?
+P0955R0 Modules and macros
+P0956R0 Answers to concept syntax suggestions
+P0957R0 PFA: A Generic, Extendable and Efficient Solution for Polymorphic Programming
+P0957R1 PFA: A Generic, Extendable and Efficient Solution for Polymorphic Programming
+P0957R2 PFA: A Generic, Extendable and Efficient Solution for Polymorphic Programming
+P0957R3 PFA: A Generic, Extendable and Efficient Solution for Polymorphic Programming
+P0957R4 PFA: A Generic, Extendable and Efficient Solution for Polymorphic Programming
+P0957R5 Proxy: A Polymorphic Programming Library
+P0957R6 Proxy: A Polymorphic Programming Library
+P0957R7 Proxy: A Polymorphic Programming Library
+P0957R8 Proxy: A Polymorphic Programming Library
+P0957R9 Proxy: A Polymorphic Programming Library
+P0958R0 Networking TS changes to support proposed Executors TS
+P0958R1 Networking TS changes to support proposed Executors TS
+P0958R2 Networking TS changes to support proposed Executors TS
+P0958R3 Networking TS changes to support proposed Executors TS
+P0959R0 A Proposal for a Universally Unique Identifier Library
+P0959R1 A Proposal for a Universally Unique Identifier Library
+P0959R2 A Proposal for a Universally Unique Identifier Library
+P0960R0 Allow initializing aggregates from a parenthesized list of values
+P0960R1 Allow initializing aggregates from a parenthesized list of values
+P0960R2 Allow initializing aggregates from a parenthesized list of values
+P0960R3 Allow initializing aggregates from a parenthesized list of values
+P0961R0 Relaxing the structured bindings customization point finding rules
+P0961R1 Relaxing the structured bindings customization point finding rules
+P0962R0 Relaxing the range-for loop customization point finding rules
+P0962R1 Relaxing the range-for loop customization point finding rules
+P0963R0 Structured binding declaration as a condition
+P0963R1 Structured binding declaration as a condition
+P0964R0 Finding the right set of traits for simd<T>
+P0964R1 Finding the right set of traits for simd<T>
+P0964R2 Finding the right set of traits for simd<T>
+P0965R0 Initializers of objects with automatic and dynamic storage duration have funny inconsistencies
+P0966R0 string::reserve Should Not Shrink
+P0966R1 string::reserve Should Not Shrink
+P0968R0 Core Language Working Group "tentatively ready" Issues for the March, 2018 (Jacksonville) meeting
+P0969R0 Allow structured bindings to accessible members
+P0970R0 Better, Safer Range Access Customization Points
+P0970R1 Better, Safer Range Access Customization Points
+P0972R0 <chrono> zero(), min(), and max() should be noexcept
+P0973R0 Coroutines TS Use Cases and Design Issues
+P0974R0 A Function Returning Whether An Underlying Type Value Is a Valid Enumerator of a Given Enumeration
+P0975R0 Impact of coroutines on current and upcoming library facilities
+P0976R0 The Evils of Paradigms
+P0977R0 Remember the Vasa!
+P0978R0 A Response to "P0973r0: Coroutines TS Use Cases and Design Issues"
+P0980R0 Making std::string constexpr
+P0980R1 Making std::string constexpr
+P0981R0 Halo: coroutine Heap Allocation eLision Optimization: the joint response
+P0982R0 Weaken Release Sequences
+P0982R1 Weaken release sequences
+P0983R0 Plan of Record for Making C++ Modules Available in C++ Standards
+P0984R0 All (*)()-Pointers Replaced by Ideal Lambdas
+P0985R0 LWG Chair post-meeting report
+P0985R1 LWG Chair post-meeting report
+P0985R2 LWG Chair post-meeting report
+P0985R3 LWG Chair post-meeting report
+P0985R4 LWG Chair post-meeting report
+P0986R0 Comparison of Modules Proposals
+P0987R0 polymorphic_allocator<byte> instead of type-erasure
+P0987R1 polymorphic_allocator instead of type-erasure
+P0987R2 polymorphic_allocator instead of type-erasure
+P0988R0 Ruminations on 2D graphics in the C++ International Standard
+P0989R0 Standardizing Extended Integers
+P0990R0 Rebuttal of Implementation Concerns for Bit Entanglement
+P0991R0 Comparison of Stackful Coroutine Proposals
+P0992R0 Translation and evaluation
+P0993R0 Value-based Reflection
+P0994R0 String View Conversion for Function Arguments
+P0995R0 Improving atomic_flag
+P0995R1 Improving atomic_flag
+P0996R1 Rebase Library Fundamentals TS on C++17
+P0997R0 Retire Pernicious Language Constructs in Module Contexts
+P0999R0 More Natural Arithmetic in C++
+P1000R0 C++ IS schedule
+P1000R1 C++ IS schedule
+P1000R2 C++ IS schedule
+P1000R3 C++ IS schedule
+P1000R4 C++ IS schedule
+P1000R5 C++ IS schedule
+P1001R0 Target Vectorization Policies from Parallelism V2 TS to C++20
+P1001R1 Target Vectorization Policies from Parallelism V2 TS to C++20
+P1001R2 Target Vectorization Policies from Parallelism V2 TS to C++20
+P1002R0 Try-catch blocks in constexpr functions
+P1002R1 Try-catch blocks in constexpr functions
+P1003R0 C++ Standard Library Issues Resolved Directly In Jacksonville
+P1004R0 Making std::vector constexpr
+P1004R1 Making std::vector constexpr
+P1004R2 Making std::vector constexpr
+P1005R0 namespace std { namespace fs = filesystem; }
+P1005R1 namespace std { namespace fs = filesystem; }
+P1006R0 Constexpr in std::pointer_traits
+P1006R1 Constexpr in std::pointer_traits
+P1007R0 std::assume_aligned
+P1007R1 std::assume_aligned
+P1007R2 std::assume_aligned
+P1007R3 std::assume_aligned
+P1008R0 Prohibit aggregate types with user-declared constructors
+P1008R1 Prohibit aggregates with user-declared constructors
+P1009R0 Array size deduction in new-expressions
+P1009R1 Array size deduction in new-expressions
+P1009R2 Array size deduction in new-expressions
+P1010R0 Container support for implicit lifetime types
+P1010R1 Container support for implicit lifetime types
+P1011R0 Constant Pointer View - std::as_const Strikes Back!
+P1012R0 Ternary Right Fold Expression
+P1012R1 Ternary Right Fold Expression
+P1013R0 Explicit concept expressions
+P1013R1 Explicit concept expressions
+P1014R0 A Unit Type for C++
+P1015R0 WG21 2018-03 Jacksonville Record of Discussion
+P1016R0 A few additional type manipulation utilities
+P1017R0 Executors should be variadic
+P1018R0 Evolution status after Jacksonville 2018
+P1018R1 Evolution status after Rapperswil 2018
+P1018R2 Evolution status after San Diego 2018
+P1018R3 Evolution status after Kona 2019
+P1018R4 Evolution status after Cologne 2019
+P1018R5 Language Evolution status after Belfast 2019
+P1018R6 Language Evolution status after Prague 2020
+P1018R7 C++ Language Evolution status - pandemic edition - 2020/03–2020/10
+P1018R8 C++ Language Evolution status - pandemic edition – 2020/11-2021/01
+P1018R9 C++ Language Evolution status - pandemic edition - 2021/01–2021/03
+P1018R10 C++ Language Evolution status - pandemic edition - 2021/04
+P1018R11 C++ Language Evolution status - pandemic edition - 2021/05
+P1018R12 C++ Language Evolution status - pandemic edition – 2021/06-2021/08
+P1018R13 C++ Language Evolution status - pandemic edition – 2021/06-2021/08
+P1018R14 C++ Language Evolution status - pandemic edition - 2021/09-2022/01
+P1018R15 C++ Language Evolution status - pandemic edition – 2022/01-2022/02
+P1018R16 C++ Language Evolution status - pandemic edition – 2022/02-2022/06
+P1018R17 C++ Language Evolution status - pandemic edition - 2022/06-2022/07
+P1018R18 C++ Language Evolution status - pandemic edition – 2022/07-2022/11
+P1018R19 C++ Language Evolution status
+P1019R0 Integrating Executors with Parallel Algorithms
+P1019R1 Integrating Executors with Parallel Algorithms
+P1019R2 Integrating Executors with Parallel Algorithms
+P1020R0 Smart pointer creation with default initialization
+P1020R1 Smart pointer creation with default initialization
+P1021R0 Extensions to Class Template Argument Deduction
+P1021R1 Filling holes in Class Template Argument Deduction
+P1021R2 Filling holes in Class Template Argument Deduction
+P1021R3 Filling holes in Class Template Argument Deduction
+P1021R4 Filling holes in Class Template Argument Deduction
+P1021R5 Filling holes in Class Template Argument Deduction
+P1021R6 Filling holes in Class Template Argument Deduction
+P1022R0 Material for 2018 JAX Discussions of Hazard Pointer and Read-Copy-Update (RCU)
+P1023R0 constexpr comparison operators for std::array
+P1024R0 Usability Enhancements for std::span
+P1024R1 Usability Enhancements for std::span
+P1024R2 Usability Enhancements for std::span
+P1024R3 Usability Enhancements for std::span
+P1025R0 Update The Reference To The Unicode Standard
+P1025R1 Update The Reference To The Unicode Standard
+P1026R0 A call for a Data Persistence (iostream v2) study group
+P1026R1 A call for an `Elsewhere Memory' study group
+P1028R0 SG14 status_code and standard error object for P0709 Zero-overhead deterministic exceptions
+P1028R1 status_code and standard error object for P0709 Zero-overhead deterministic exceptions
+P1028R2 SG14 status_code and standard error object for P0709 Zero-overhead deterministic exceptions
+P1028R3 SG14 status_code and standard error object
+P1028R4 SG14 status_code and standard error object
+P1028R5 SG14 status_code and standard error object
+P1028R6 SG14 status_code and standard error object
+P1029R0 SG14 [[move_relocates]]
+P1029R1 [[move_relocates]]
+P1029R2 move = relocates
+P1029R3 move = bitcopies
+P1030R0 std::filesystem::path_view
+P1030R1 std::filesystem::path_view
+P1030R2 std::filesystem::path_view
+P1030R3 std::filesystem::path_view
+P1030R4 std::filesystem::path_view
+P1030R5 std::filesystem::path_view
+P1030R6 std::filesystem::path_view
+P1031R0 Low level file i/o library
+P1031R1 Low level file i/o library
+P1031R2 Low level file i/o library
+P1032R0 Misc constexpr bits
+P1032R1 Misc constexpr bits
+P1033R0 Rangify the uninitialised memory algorithms!
+P1033R1 Rangify the uninitialised memory algorithms!
+P1035R0 Input range adaptors
+P1035R1 Input range adaptors
+P1035R2 Input range adaptors
+P1035R3 Input range adaptors
+P1035R4 Input range adaptors
+P1035R5 Input Range Adaptors
+P1035R6 Input Range Adaptors
+P1035R7 Input Range Adaptors
+P1037R0 Deep Integration of the Ranges TS
+P1039R0 I got you, FAM: Flexible Array Members for C++
+P1040R0 std::embed
+P1040R1 std::embed
+P1040R2 std::embed
+P1040R3 std::embed
+P1040R4 std::embed
+P1040R5 std::embed and #depend
+P1040R6 std::embed and #depend
+P1041R0 Make char16_t/char32_t string literals be UTF-16/32
+P1041R1 Make char16_t/char32_t string literals be UTF-16/32
+P1041R3 Make char16_t/char32_t string literals be UTF-16/32
+P1041R4 Make char16_t/char32_t string literals be UTF-16/32
+P1042R0 __VA_OPT__ wording clarifications
+P1042R1 __VA_OPT__ wording clarifications
+P1043R0 Narrow contracts in string_view versus P0903R1
+P1044R0 std::async() in an Executors World
+P1045R0 constexpr Function Parameters
+P1045R1 constexpr Function Parameters
+P1046R0 Automatically Generate More Operators
+P1046R1 Automatically Generate More Operators
+P1046R2 Automatically Generate More Operators
+P1048R0 A proposal for a type trait to detect scoped enumerations
+P1048R1 A proposal for a type trait to detect scoped enumerations
+P1050R0 Fractional Numeric Type
+P1050R1 Fractional Numeric Type
+P1051R0 std::experimental::expected LWG design issues
+P1052R0 Modules, Macros, and Build Systems
+P1053R0 Future-proofing continuations for executors
+P1053R1 Future-proofing continuations for executors
+P1054R0 A Unified Futures Proposal for C++
+P1055R0 A Modest Executor Proposal
+P1056R0 Add coroutine task type
+P1056R1 Add lazy coroutine (coroutine task) type
+P1059R0 Adapting Asio to use std::expected
+P1061R0 Structured Bindings can introduce a Pack
+P1061R1 Structured Bindings can introduce a Pack
+P1061R2 Structured Bindings can introduce a Pack
+P1061R3 Structured Bindings can introduce a Pack
+P1061R4 Structured Bindings can introduce a Pack
+P1061R5 Structured Bindings can introduce a Pack
+P1061R6 Structured Bindings can introduce a Pack
+P1062R0 Diet Graphics
+P1063R0 Core Coroutines
+P1063R1 Core Coroutines
+P1063R2 Core Coroutines
+P1064R0 Allowing Virtual Function Calls in Constant Expressions
+P1065R0 constexpr INVOKE
+P1065R1 constexpr INVOKE
+P1065R2 constexpr INVOKE
+P1066R0 How to catch an exception_ptr without even try-ing
+P1066R1 How to catch an exception_ptr without even try-ing
+P1067R0 C++ Dependency Management: Package Consumption vs Development
+P1068R0 Vector API for random number generation
+P1068R1 Vector API for random number generation
+P1068R2 Vector API for random number generation
+P1068R3 Vector API for random number generation
+P1068R4 Vector API for random number generation
+P1068R5 Vector API for random number generation
+P1068R6 Vector API for random number generation
+P1068R7 Vector API for random number generation
+P1068R8 Vector API for random number generation
+P1068R9 Vector API for random number generation
+P1068R10 Vector API for random number generation
+P1069R0 Refining standard library support for Class Template Argument Deduction
+P1069R1 Inferencing heap objects
+P1070R0 SG5: Transactional Memory (TM) Meeting Minutes 2018/04/09
+P1071R0 SG14: Low Latency Meeting Minutes 2018/04/11- 2018/05/02
+P1072R0 Default Initialization for basic_string
+P1072R1 Optimized Initialization for basic_string and vector
+P1072R2 basic_string::resize_default_init
+P1072R3 basic_string::resize_default_init
+P1072R4 basic_string::resize_default_init
+P1072R5 basic_string::resize_default_init
+P1072R6 basic_string::resize_and_overwrite
+P1072R7 basic_string::resize_and_overwrite
+P1072R8 basic_string::resize_and_overwrite
+P1072R9 basic_string::resize_and_overwrite
+P1072R10 basic_string::resize_and_overwrite
+P1073R0 constexpr! functions
+P1073R1 constexpr! functions
+P1073R2 Immediate functions
+P1073R3 Immediate functions
+P1074R0 CWG defect Defined Behavior of Invalid Pointers
+P1076R0 Editorial clause reorganization
+P1076R1 Editorial clause reorganization
+P1077R0 Allowing Virtual Destructors to be “Trivial”
+P1079R0 A minimal solution to the concepts syntax problems
+P1080R0 SG16: Unicode meeting summaries 2018/03/28 - 2018/04/25
+P1081R0 On empty structs in the standard library
+P1082R0 C++ Standard Library Issues to be moved in Rapperswil
+P1083R0 Move resource_adaptor from Library TS to the C++ WP
+P1083R1 Move resource_adaptor from Library TS to the C++ WP
+P1083R2 Move resource_adaptor from Library TS to the C++ WP
+P1083R3 Move resource_adaptor from Library TS to the C++ WP
+P1083R4 Move resource_adaptor from Library TS to the C++ WP
+P1083R5 Move resource_adaptor from Library TS to the C++ WP
+P1083R6 Move resource_adaptor from Library TS to the C++ WP
+P1083R7 Move resource_adaptor from Library TS to the C++ WP
+P1084R0 Today's return-type-requirements Are Insufficient
+P1084R1 Today's return-type-requirements Are Insufficient
+P1084R2 Today's return-type-requirements Are Insufficient
+P1085R0 Should Span be Regular?
+P1085R1 Should Span be Regular?
+P1085R2 Should Span be Regular?
+P1086R0 Natural Syntax: Keep It Simple
+P1087R0 Modules for Standard C++
+P1089R0 Sizes Should Only span Unsigned
+P1089R2 Sizes Should Only span Unsigned
+P1090R0 Aggregate initialization in the presence of deleted constructors
+P1091R0 Extending structured bindings to be more like variable declarations
+P1091R1 Extending structured bindings to be more like variable declarations
+P1091R2 Extending structured bindings to be more like variable declarations
+P1091R3 Extending structured bindings to be more like variable declarations
+P1093R0 Is undefined behaviour preserved?
+P1094R0 Nested Inline Namespaces
+P1094R1 Nested Inline Namespaces
+P1094R2 Nested Inline Namespaces
+P1095R0 Zero overhead deterministic failure - A unified mechanism for C and C++
+P1096R0 Simplify the customization point for structured bindings
+P1097R0 Named character escapes
+P1097R1 Named character escapes
+P1097R2 Named character escapes
+P1099R0 Using Enum
+P1099R2 Using Enum
+P1099R3 Using Enum
+P1099R4 Using Enum
+P1099R5 Using Enum
+P1100R0 Efficient composition with DynamicBuffer
+P1101R0 Vector Length Agnostic SIMD
+P1102R0 Down with ()!
+P1102R1 Down with ()!
+P1102R2 Down with ()!
+P1103R0 Merging Modules
+P1103R1 Merging Modules
+P1103R2 Merging Modules
+P1103R3 Merging Modules
+P1105R0 Leaving no room for a lower-level language: A C++ Subset
+P1105R1 Leaving no room for a lower-level language: A C++ Subset
+P1108R0 web_view
+P1108R1 web_view
+P1108R2 web_view
+P1108R3 web_view
+P1108R4 web_view
+P1109R0 WG21 2018-06 Rapperswil Record of Discussion
+P1109R1 WG21 2018-06 Rapperswil Record of Discussion
+P1110R0 A placeholder with no name
+P1111R0 Resolutions to NB Comments on the Parallelism TS v2
+P1112R0 Language support for class layout control
+P1112R1 Language support for class layout control
+P1112R2 Language support for class layout control
+P1112R3 Language support for class layout control
+P1112R4 Language support for class layout control
+P1113R0 Core Language Working Group "ready" Issues for the June, 2018 (Rapperswil) meeting
+P1114R0 Core Language Working Group "tentatively ready" Issues for the June, 2018 (Rapperswil) meeting
+P1115R0 Improving the Return Value of Erase-Like Algorithms II: Free erase/erase if
+P1115R1 Improving the Return Value of Erase-Like Algorithms II: Free erase/erase if
+P1115R2 Improving the Return Value of Erase-Like Algorithms II: Free erase/erase if
+P1115R3 Improving the Return Value of Erase-Like Algorithms II: Free erase/erase if
+P1116R0 Re-Gaining Exclusive Ownership from shared_ptrs
+P1118R0 Concat and Split on simd<> objects
+P1119R0 ABI for std::hardware_{constructive,destructive}_interference_size
+P1120R0 Consistency improvements for <=> and other comparison operators
+P1121R0 Hazard Pointers: Proposed Interface and Wording for Concurrency TS 2
+P1121R1 Hazard Pointers: Proposed Interface and Wording for Concurrency TS 2
+P1121R2 Hazard Pointers: Proposed Interface and Wording for Concurrency TS 2
+P1121R3 Hazard Pointers: Proposed Interface and Wording for Concurrency TS 2
+P1122R0 Proposed Wording for Concurrent Data Structures: Read-Copy-Update (RCU)
+P1122R1 Proposed Wording for Concurrent Data Structures: Read-Copy-Update (RCU)
+P1122R2 Proposed Wording for Concurrent Data Structures: Read-Copy-Update (RCU)
+P1122R3 Proposed Wording for Concurrent Data Structures: Read-Copy-Update (RCU)
+P1122R4 Proposed Wording for Concurrent Data Structures: Read-Copy-Update (RCU)
+P1123R0 Editorial Guidance for merging P0019r8 and P0528r3
+P1128R0 Summer 2018 WG21 Batavia LWG Meeting Information
+P1130R1 Module Resource Requirement Propagation
+P1131R0 Core Issue 2292: simple-template-id is ambiguous between class-name and type-name
+P1131R1 Core Issue 2292: simple-template-id is ambiguous between class-name and type-name
+P1131R2 Core Issue 2292: simple-template-id is ambiguous between class-name and type-name
+P1132R0 out_ptr - a scalable output pointer abstraction
+P1132R1 out_ptr - a scalable output pointer abstraction
+P1132R2 out_ptr - a scalable output pointer abstraction
+P1132R3 out_ptr - a scalable output pointer abstraction
+P1132R4 out_ptr - a scalable output pointer abstraction
+P1132R5 out_ptr - a scalable output pointer abstraction
+P1132R6 out_ptr - a scalable output pointer abstraction
+P1132R7 out_ptr - a scalable output pointer abstraction
+P1132R8 out_ptr - a scalable output pointer abstraction
+P1133R0 Networking TS Associations For Call Wrappers
+P1135R0 The C++20 Synchronization Library
+P1135R1 The C++20 Synchronization Library
+P1135R2 The C++20 Synchronization Library
+P1135R3 The C++20 Synchronization Library
+P1135R4 The C++20 Synchronization Library
+P1135R5 The C++20 Synchronization Library
+P1135R6 The C++20 Synchronization Library
+P1136R0 2018-09 Bellevue ad-hoc meeting information
+P1137R0 SG16: Unicode meeting summaries 2018/05/16 - 2018/06/20
+P1138R0 Deprecating ATOMIC_VAR_INIT
+P1139R0 Address wording issues related to ISO 10646
+P1139R1 Address wording issues related to ISO 10646
+P1139R2 Address wording issues related to ISO 10646
+P1141R0 Yet another approach for constrained declarations
+P1141R1 Yet another approach for constrained declarations
+P1141R2 Yet another approach for constrained declarations
+P1142R0 Thoughts on a conservative terse syntax for constraints
+P1143R0 Adding the `[[constinit]]` attribute
+P1143R1 Adding the constinit keyword
+P1143R2 Adding the constinit keyword
+P1144R0 Object relocation in terms of move plus destroy
+P1144R1 Object relocation in terms of move plus destroy
+P1144R2 Object relocation in terms of move plus destroy
+P1144R3 Object relocation in terms of move plus destroy
+P1144R4 Object relocation in terms of move plus destroy
+P1144R5 Object relocation in terms of move plus destroy
+P1144R6 Object relocation in terms of move plus destroy
+P1144R7 std::is_trivially_relocatable
+P1144R8 std::is_trivially_relocatable
+P1144R9 std::is_trivially_relocatable
+P1145R0 Buffer Sequence Adaptors
+P1147R0 Printing `volatile` Pointers
+P1147R1 Printing `volatile` Pointers
+P1148R0 Cleaning up Clause 20
+P1149R0 Constexpr regex
+P1152R0 Deprecating volatile
+P1152R1 Deprecating volatile
+P1152R2 Deprecating volatile
+P1152R3 Deprecating volatile
+P1152R4 Deprecating volatile
+P1153R0 Copying volatile subobjects is not trivial
+P1154R0 Type traits for structural comparison
+P1154R1 Type traits for structural comparison
+P1154R2 Type traits for structural comparison
+P1155R0 More implicit moves
+P1155R1 More implicit moves
+P1155R2 More implicit moves
+P1155R3 More implicit moves
+P1156R0 Merged Modules and Tooling
+P1157R0 Multi-argument constrained-parameter
+P1158R0 Concept-defined placeholder types
+P1159R0 Type Erased Iterators for modern C++
+P1160R0 Add Test Polymorphic Memory Resource to the Standard Library
+P1160R1 Add Test Polymorphic Memory Resource to the Standard Library
+P1161R0 Deprecate uses of the comma operator in subscripting expressions
+P1161R1 Deprecate uses of the comma operator in subscripting expressions
+P1161R2 Deprecate uses of the comma operator in subscripting expressions
+P1161R3 Deprecate uses of the comma operator in subscripting expressions
+P1163R0 Explicitly Implicifying explicit Constructors
+P1164R0 Make create_directory() Intuitive
+P1164R1 Make create_directory() intuitive
+P1165R0 Fixing allocator usage for operator+(basic_string)
+P1165R1 Make stateful allocator propagation more consistent for operator+(basic_string)
+P1166R0 What do we need from a linear algebra library?
+P1167R0 Improving function templates with Class Template Argument Deduction
+P1168R0 How to make Terse Notation soar with Class Template Argument Deduction
+P1169R0 static operator()
+P1169R1 static operator()
+P1169R2 static operator()
+P1169R3 static operator()
+P1169R4 static operator()
+P1170R0 Overload sets as function parameters
+P1171R0 Synchronously waiting on asynchronous operations
+P1172R0 The Concept of Memory Allocator
+P1172R1 The Concept of Memory Allocator
+P1175R0 A simple and practical optional reference for C++
+P1177R0 Package Ecosystem Plan
+P1177R1 Package Ecosystem Plan
+P1178R0 C++ Compile
+P1179R0 Lifetime safety: Preventing common dangling
+P1179R1 Lifetime safety: Preventing common dangling
+P1180R0 Response to P1156
+P1181R0 Proposing unless
+P1182R0 New names for the power-of-2 templates (and their header)
+P1184R0 A Module Mapper
+P1184R1 A Module Mapper
+P1184R2 A Module Mapper
+P1185R0 <=> != ==
+P1185R1 <=> != ==
+P1185R2 <=> != ==
+P1186R0 When do you actually use <=>?
+P1186R1 When do you actually use <=>?
+P1186R2 When do you actually use <=>?
+P1186R3 When do you actually use <=>?
+P1187R0 A type trait for std::compare_3way()'s type
+P1188R0 Library utilities for <=>
+P1189R0 Adding <=> to library
+P1190R0 I did not order this! Why is it on my bill?
+P1191R0 Adding operator<=> to types that are not currently comparable
+P1192R0 Experience report - integrating Executors with Parallel Algorithms
+P1192R1 Experience report - integrating Executors with Parallel Algorithms
+P1193R0 Explicitly Specified Returns for (Implicit) Conversions
+P1194R0 The Compromise Executors Proposal: A lazy simplification of P0443
+P1195R0 Making <system_error> constexpr
+P1196R0 Value-based std::error_category comparison
+P1197R0 A non-allocating overload of error_category::message()
+P1198R0 Adding error_category::failed()
+P1199R0 A simple proposal for unifying generic and object-oriented programming
+P1200R0 High noon for the 2D Graphics proposal
+P1201R0 Variant direct comparisons
+P1202R0 Asymmetric fences
+P1202R1 Asymmetric Fences
+P1202R2 Asymmetric Fences
+P1202R3 Asymmetric Fences
+P1202R4 Asymmetric Fences
+P1202R5 Asymmetric Fences
+P1203R0 Modular main()
+P1204R0 Canonical Project Structure
+P1205R0 Teleportation via co_await
+P1206R0 Range constructors for standard containers and views
+P1206R1 ranges::to: A function to convert any range to a container
+P1206R2 ranges::to: A function to convert any range to a container
+P1206R3 ranges::to: A function to convert any range to a container
+P1206R4 Conversions from ranges to containers
+P1206R5 Conversions from ranges to containers
+P1206R6 Conversions from ranges to containers
+P1206R7 Conversions from ranges to containers
+P1207R0 Movability of Single-pass Iterators
+P1207R1 Movability of Single-pass Iterators
+P1207R2 Movability of Single-pass Iterators
+P1207R3 Movability of Single-pass Iterators
+P1207R4 Movability of Single-pass Iterators
+P1208R0 Adopt source_location from Library Fundamentals V3 for C++20
+P1208R1 Adopt source_location from Library Fundamentals V3 for C++20
+P1208R3 Source-Code Information Capture
+P1208R4 Adopt source location from Library Fundamentals V3 for C++20
+P1208R5 Adopt source location from Library Fundamentals V3 for C++20
+P1208R6 Adopt source location from Library Fundamentals V3 for C++20
+P1209R0 Adopt Consistent Container Erasure from Library Fundamentals 2 for C++20
+P1210R0 Completing the Rebase of Library Fundamentals, Version 3, Working Draft
+P1212R0 Modules and Freestanding
+P1213R0 Global Module Fragment is Unnecessary
+P1213R1 Global Module Fragment Is Unnecessary
+P1214R0 Pointer to Member Functions and Member Objects are just Callables!
+P1217R0 Out-of-thin-air, revisited, again
+P1217R1 Out-of-thin-air, revisited, again
+P1217R2 Out-of-thin-air, revisited, again
+P1218R0 Redefinitions in Legacy Imports
+P1219R0 Homogeneous variadic function parameters
+P1219R1 Homogeneous variadic function parameters
+P1219R2 Homogeneous variadic function parameters
+P1220R0 Controlling When Inline Functions are Emitted
+P1221R0 Parametric Expressions
+P1221R1 Parametric Expressions
+P1222R0 A Standard flat_set
+P1222R1 A Standard flatset
+P1222R2 A Standard flat_set
+P1222R3 A Standard flat_set
+P1222R4 A Standard flat_set
+P1223R0 find_backward
+P1223R1 find_backward
+P1223R2 find_backward
+P1223R3 find_last
+P1223R4 find_last
+P1223R5 find_last
+P1224R0 C++ Standard Library Issues to be moved in San Diego
+P1225R0 Feedback on 2D Graphics
+P1227R0 Signed size() functions
+P1227R1 Signed ssize() functions, unsigned size() functions
+P1227R2 Signed ssize() functions, unsigned size() functions
+P1228R1 A proposal to add an efficient string concatenation routine to the Standard Library
+P1229R0 Labelled Parameters
+P1230R0 Recursive Type Template Instantiation
+P1231R0 Proposal for Study Group: C++ Education
+P1232R0 Integrating executors with the standard library through customization
+P1233R0 Shift-by-negative in shift_left and shift_right
+P1233R1 Shift-by-negative in shift_left and shift_right
+P1235R0 Implicit constexpr
+P1236R0 Alternative Wording for P0907R4 Signed Integers are Two's Complement
+P1236R1 Alternative Wording for P0907R4 Signed Integers are Two's Complement
+P1237R0 SG16: Unicode meeting summaries 2018/07/11 - 2018/10/03
+P1238R0 SG16: Unicode Direction
+P1238R1 SG16: Unicode Direction
+P1239R0 Placed Before
+P1240R0 Scalable Reflection in C++
+P1240R1 Scalable Reflection in C++
+P1240R2 Scalable Reflection
+P1241R0 In support of merging coroutines into C++20
+P1242R0 Single-file modules with the Atom semantic properties rule
+P1242R1 Single-file modules with the Atom semantic properties rule
+P1243R0 Rangify New Algorithms
+P1243R1 Rangify New Algorithms
+P1243R2 Rangify New Algorithms
+P1243R3 Rangify New Algorithms
+P1243R4 Rangify New Algorithms
+P1244R0 Dependent Execution for a Unified Executors Proposal for C++
+P1245R0 export module containing [[attribute]];
+P1246R0 The no_float function attribute
+P1247R0 Disabling static destructors: introducing no_destroy and always_destroy attributes
+P1248R0 Fixing 'Relation's
+P1248R1 Remove CommonReference requirement from StrictWeakOrdering
+P1249R0 std::forward from std::initializer_list
+P1250R0 Extension by inspecting members of User Defined Types?
+P1251R0 A more constexpr bitset
+P1251R1 A more constexpr bitset
+P1252R0 Ranges Design Cleanup
+P1252R1 Ranges Design Cleanup
+P1252R2 Ranges Design Cleanup
+P1253R0 Guidelines for when a WG21 proposal should be reviewed by SG16, the text and Unicode study group
+P1254R0 Notes on C++ Package Management
+P1255R0 A view of 0 or 1 elements: view::maybe
+P1255R1 A view of 0 or 1 elements: view::maybe
+P1255R2 A view of 0 or 1 elements: view::maybe
+P1255R3 A view of 0 or 1 elements: view::maybe
+P1255R4 A view of 0 or 1 elements: view::maybe
+P1255R5 A view of 0 or 1 elements: views::maybe
+P1255R6 A view of 0 or 1 elements: views::maybe
+P1255R7 A view of 0 or 1 elements: views::maybe
+P1255R8 A view of 0 or 1 elements: views::maybe
+P1255R9 A view of 0 or 1 elements: views::maybe
+P1255R10 A view of 0 or 1 elements: views::maybe
+P1255R11 A view of 0 or 1 elements: views::maybe
+P1255R12 A view of 0 or 1 elements: views::maybe
+P1256R0 Executors Should Go To A TS
+P1257R0 Implementation experience on trying to implement concurrent data and control structures with executors
+P1258R0 Don't Make C++ Unimplementable On Small CPUs
+P1259R0 Merge most of Networking TS into C++ Working Draft
+P1259R1 Merge most of Networking TS into C++ Working Draft
+P1260R0 Pattern Matching
+P1261R0 Supporting Pipelines in C++
+P1263R0 Controlling the instantiation of vtables and RTTI
+P1264R0 Revising the wording of stream input operations
+P1264R1 Revising the wording of stream input operations
+P1264R2 Revising the wording of stream input operations
+P1267R0 Custom Constraint Diagnostics
+P1269R0 Three Years with the Networking TS
+P1271R0 Move resource_adaptor from Library TS to the C++ WP
+P1272R0 Byteswapping for fun&&nuf
+P1272R1 Byteswapping for fun&&nuf
+P1272R2 Byteswapping for fun&&nuf
+P1272R3 Byteswapping for fun&&nuf
+P1272R4 Byteswapping for fun&&nuf
+P1273R0 86 The Absurd (From Exceptions)
+P1274R0 Bang For The Buck
+P1275R0 Desert Sessions: Improving hostile environment interactions
+P1276R0 Void Main
+P1277R0 Subscripts On Parade
+P1278R0 offsetof For the Modern Era
+P1279R0 std::breakpoint
+P1280R0 Integer Width Literals
+P1280R1 Integer Width Literals
+P1280R2 Integer Width Literals
+P1281R0 Feature Presentation
+P1282R0 Ceci N’est Pas Une Pipe: Adding a workflow operator to C++
+P1283R0 Sharing is Caring
+P1284R0 Allowing Inlining of Replaceable Functions
+P1285R0 Improving Completeness Requirements for Type Traits
+P1286R0 Contra CWG DR1778
+P1286R1 Contra CWG DR1778
+P1286R2 Contra CWG DR1778
+P1287R0 Supporting async use-cases for interrupt_token
+P1288R0 Coroutine concepts and metafunctions
+P1289R0 Access control in contract conditions
+P1289R1 Access control in contract conditions
+P1290R0 Avoiding undefined behavior in contracts
+P1290R1 Avoiding undefined behavior in contracts
+P1290R2 Avoiding undefined behavior in contracts
+P1290R3 Avoiding undefined behavior in contracts
+P1291R0 std::ranges::less<> Should Be More!
+P1292R0 Customization Point Functions
+P1293R0 ostream_joiner
+P1293R1 ostream_joiner
+P1293R2 ostream_joiner
+P1294R0 Proposed resolution for US104: Allocator-aware regular expressions (rev 3)
+P1295R0 Spaceship library update
+P1296R0 [[assert: std::disjoint(A,nA, B,nB)]]: Contract assertions as an alternate spelling of ‘restrict’
+P1298R0 Reserve more freedom for atomic_ref<> implementers
+P1299R0 Module Preamble is Unnecessary
+P1299R1 Module Preamble is Unnecessarily Fragile
+P1299R2 Replacement for placeholder
+P1299R3 Module Preamble is Unnecessarily Fragile
+P1300R0 Remember the FORTRAN
+P1301R0 nodiscard should have a reason
+P1301R1 [[nodiscard("should have a reason")]]
+P1301R2 [[nodiscard("should have a reason")]]
+P1301R3 [[nodiscard("should have a reason")]]
+P1301R4 [[nodiscard("should have a reason")]]
+P1302R0 Implicit Module Partition Lookup
+P1302R1 Implicit Module Partition Lookup
+P1303R0 Inline Module Partitions
+P1304R0 Simplifying Extern Template
+P1305R0 Deprecate The Addressof Operator
+P1306R0 Expansion statements
+P1306R1 Expansion statements
+P1307R0 weak_equality considered harmful
+P1308R0 Pattern Matching
+P1310R0 Unifying the many ways to compare
+P1312R0 Comparison Concepts
+P1313R0 Let's Talk About Package Specification
+P1314R0 unique_val: a default-on-move
+P1314R1 unique_val: a default-on-move type
+P1315R0 secure_val: a secure-clear-on-move type
+P1315R1 secure_val: a secure-clear-on-move type
+P1315R2 secure_clear
+P1315R3 secure_clear
+P1315R4 secure_clear
+P1315R5 secure_clear
+P1315R6 secure_clear (update to N2599)
+P1315R7 secure_clear
+P1316R0 A when_all() operator for coroutines
+P1317R0 Remove return type deduction in std::apply
+P1318R0 Tuple application traits
+P1319R0 Changes between C++11 and C++14
+P1320R0 Allowing contract predicates on non-first declarations
+P1320R1 Allowing contract predicates on non-first declarations
+P1320R2 Allowing contract predicates on non-first declarations
+P1321R0 UB in contract violations
+P1322R0 Networking TS enhancement to enable custom I/O executors
+P1322R1 Networking TS enhancement to enable custom I/O executors
+P1322R2 Networking TS enhancement to enable custom I/O executors
+P1322R3 Networking TS enhancement to enable custom I/O executors
+P1323R0 Contract postconditions and return type deduction
+P1323R1 Contract postconditions and return type deduction
+P1323R2 Contract postconditions and return type deduction
+P1324R0 RE: Yet another approach for constrained declarations
+P1324R1 RE: Yet another approach for constrained declarations
+P1327R0 Allowing dynamic_cast, polymorphic typeid in Constant Expressions
+P1327R1 Allowing dynamic_cast, polymorphic typeid in Constant Expressions
+P1328R0 Making std::type_info::operator== constexpr
+P1328R1 Making std::type_info::operator== constexpr
+P1329R0 On the Coroutines TS
+P1330R0 Changing the active member of a union inside constexpr
+P1331R0 Permitting trivial default initialization in constexpr contexts
+P1331R1 Permitting trivial default initialization in constexpr contexts
+P1331R2 Permitting trivial default initialization in constexpr contexts
+P1332R0 Contract Checking in C++: A (long-term) Road Map
+P1333R0 Assigning Concrete Semantics to Contract-Checking Levels at Compile Time
+P1334R0 Specifying Concrete Semantics Directly in Contract-Checking Statements
+P1335R0 "Avoiding undefined behavior in contracts" [P1290R0] Explained
+P1337R0 Aliasing the standard library as a means to save C++
+P1338R0 WG21 2018-11 San Diego Record of Discussion
+P1338R1 WG21 2018-11 San Diego Record of Discussion
+P1339R0 Disallowing the friending of names in namespace std
+P1339R1 Disallowing the friending of names in namespace std
+P1341R0 Unifying Asynchronous APIs in the Standard Library
+P1342R0 Unifying Coroutines TS and Core Coroutines
+P1344R0 Pre/Post vs. Enspects/Exsures
+P1344R1 Pre/Post vs. Enspects/Exsures
+P1344R2 pre/post with WD wording
+P1347R0 Modules: ADL & Internal Linkage
+P1347R1 Modules: ADL & Internal Linkage
+P1348R0 An Executor Property for Occupancy of Execution Agents
+P1349R0 Better Integration of Sender Executors
+P1350R0 Core Language Working Group "tentatively ready" Issues for the November, 2018 (San Diego) meeting
+P1351R0 Intrusive smart pointer feedback
+P1353R0 Missing Feature Test Macros
+P1354R0 SG7 Guidelines for Review of Proposals
+P1355R0 Exposing a narrow contract for ceil2
+P1355R1 Exposing a narrow contract for ceil2
+P1355R2 Exposing a narrow contract for ceil2
+P1356R0 Coroutine TS ready issues (25 and 27)
+P1357R0 Traits for [Un]bounded Arrays
+P1357R1 Traits for [Un]bounded Arrays
+P1358R0 Core "ready" Issues
+P1359R0 Core "tentatively ready" Issues
+P1360R0 Towards Machine Learning for C++: Study Group 19
+P1361R0 Integration of chrono with text formatting
+P1361R1 Integration of chrono with text formatting
+P1361R2 Integration of chrono with text formatting
+P1362R0 Incremental Approach: Coroutine TS + Core Coroutines
+P1364R0 Fibers under the magnifying glass
+P1365R0 Using Coroutine TS with zero dynamic allocations
+P1367R0 Not All Agents Have TLS
+P1367R1 Not All Agents Have TLS
+P1368R0 Multiplication and division of fixed-point numbers
+P1368R1 Multiplication and division of fixed-point numbers
+P1369R0 Guidelines for Formulating Library Semantics Specifications
+P1370R0 Generic numerical algorithm development with(out) numeric_limits
+P1370R1 Generic numerical algorithm development with(out) numeric_limits
+P1371R0 Pattern Matching
+P1371R1 Pattern Matching
+P1371R2 Pattern Matching
+P1371R3 Pattern Matching
+P1372R0 Giving atomic_ref implementers more flexibility by providing customization points for non-lock-free implementation
+P1373R0 Syntax alternatives for modules
+P1374R0 Resolving LWG #2307 for C++20: Consistently Explicit Constructors
+P1375R0 More Constrained: Apples or Oranges? On the road to semantic constraint matching
+P1375R1 More Constrained: Apples or Oranges? On the road to semantic constraint matching
+P1375R2 More Constrained: Apples or Oranges?
+P1376R0 Summary of freestanding evening session discussions
+P1377R0 Summary of Dec 2018 SG14 freestanding discussions
+P1378R0 std::string_literal
+P1380R0 Ambiguity and Insecurities with Three-Way Comparison
+P1380R1 Ambiguity and Insecurities with Three-Way Comparison
+P1381R0 Reference capture of structured bindings
+P1381R1 Reference capture of structured bindings
+P1382R0 volatile_load<T> and volatile_store<T>
+P1382R1 volatile_load<T> and volatile_store<T>
+P1383R0 More constexpr for <cmath> and <complex>
+P1383R1 More constexpr for cmath and complex
+P1383R2 More constexpr for cmath and complex
+P1385R0 A proposal to add linear algebra support to the C++ standard library
+P1385R1 A proposal to add linear algebra support to the C++ standard library
+P1385R2 A proposal to add linear algebra support to the C++ standard library
+P1385R3 A proposal to add linear algebra support to the C++ standard library
+P1385R4 A proposal to add linear algebra support to the C++ standard library
+P1385R5 A proposal to add linear algebra support to the C++ standard library
+P1385R6 A proposal to add linear algebra support to the C++ standard library
+P1385R7 A proposal to add linear algebra support to the C++ standard library
+P1386R0 A Standard Audio API for C++: Motivation, Scope, and Basic Design
+P1386R1 A Standard Audio API for C++: Motivation, Scope, and Basic Design
+P1386R2 A Standard Audio API for C++: Motivation, Scope, and Basic Design
+P1388R0 2019-01-11 SG20 Telecon Minutes
+P1389R0 Standing Document for SG20: Guidelines for Teaching C++ to Beginners
+P1389R1 Standing Document for SG20: Guidelines for Teaching C++ to Beginners
+P1390R0 Suggested Reflection TS NB Resolutions
+P1390R1 Reflection TS NB comment resolutions: summary and rationale
+P1391R0 Range constructor for std::string_view
+P1391R1 Range constructor for std::string_view
+P1391R2 Range constructor for std::string_view
+P1391R3 Range constructor for std::string_view
+P1391R4 Range constructor for std::string_view
+P1392R0 Differences Between Functions and Function Templates
+P1393R0 A General Property Customization Mechanism
+P1394R0 Range constructor for std::span
+P1394R1 Range constructor for std::span
+P1394R2 Range constructor for std::span
+P1394R3 Range constructor for std::span
+P1394R4 Range constructor for std::span
+P1395R0 Modules: Partitions Are Not a Panacea
+P1401R0 Narrowing contextual conversions to bool
+P1401R1 Narrowing contextual conversions to bool
+P1401R2 Narrowing contextual conversions to bool
+P1401R3 Narrowing contextual conversions to bool
+P1401R4 Narrowing contextual conversions to bool
+P1401R5 Narrowing contextual conversions to bool
+P1402R0 std::cstring_view - a C compatible std::string_view adapter
+P1403R0 Experience Report: Implementing a Coroutines TS Frontend to an Existing Tasking Library
+P1404R0 bad_alloc is not out-of-memory!
+P1404R1 bad_alloc is not out-of-memory!
+P1405R0 C++20 Executors are Resilient to ABI Breakage
+P1406R0 Add more std::hash specializations
+P1406R1 Add more std::hash specializations
+P1407R0 Tell Programmers About Signed Integer Overflow Behavior
+P1407R1 Tell Programmers About Signed Integer Overflow Behavior
+P1408R0 Abandon observer_ptr
+P1410R0 Remove deprecated strstream
+P1411R0 Please reconsider <scope> for C++20
+P1412R0 Class Natures for Safety Critical Code: On user-declared and user-defined special member functions
+P1413R0 A safer interface for std::aligned_storage
+P1413R1 Deprecate std::aligned_storage and std::aligned_union
+P1413R2 Deprecate std::aligned_storage and std::aligned_union
+P1413R3 Deprecate std::aligned_storage and std::aligned_union
+P1415R0 SG19 Machine Learning Layered List
+P1415R1 SG19 Machine Learning Layered List
+P1416R0 SG19 Linear Algebra for Data Science and Machine Learning
+P1417R0 Historical lessons for C++ linear algebra library standardization
+P1419R0 A SFINAE-friendly trait to determine the extent of statically sized containers
+P1421R0 Assigning semantics to different Contract Checking Statements
+P1422R0 SG16: Unicode meeting summaries 2018/10/17 - 2019/01/09
+P1423R0 char8_t backward compatibility remediation
+P1423R1 char8_t backward compatibility remediation
+P1423R2 char8_t backward compatibility remediation
+P1423R3 char8_t backward compatibility remediation
+P1424R0 'constexpr' feature macro concerns
+P1424R1 'constexpr' feature macro concerns
+P1425R0 Iterators pair constructors for stack and queue
+P1425R1 Iterators pair constructors for stack and queue
+P1425R2 Iterators pair constructors for stack and queue
+P1425R3 Iterators pair constructors for stack and queue
+P1425R4 Iterators pair constructors for stack and queue
+P1426R0 Pull the Plug on Contracts?
+P1427R0 Concerns about module toolability
+P1428R0 Subscripts and sizes should be signed
+P1429R0 Contracts That Work
+P1429R1 Contracts That Work
+P1429R2 Contracts That Work
+P1429R3 Contracts That Work
+P1430R0 First-class symmetric coroutines in C++
+P1430R1 First-class symmetric coroutines in C++
+P1433R0 Compile Time Regular Expressions
+P1434R0 Discussing Pointer Provenance
+P1436R0 Executor properties for affinity-based execution
+P1436R1 Executor properties for affinity-based execution
+P1436R2 Executor properties for affinity-based execution
+P1436R3 Executor properties for affinity-based execution
+P1438R0 A Rational Number Library for C++
+P1438R1 A Rational Number Library for C++
+P1439R0 Charset Transcoding, Transformation, and Transliteration
+P1439R1 Charset Transcoding, Transformation, and Transliteration
+P1440R0 is_clamped
+P1441R0 Are modules fast?
+P1441R1 Are modules fast?
+P1442R0 A Medley of Networking TS improvements
+P1443R0 SG14: Low Latency Meeting Minutes 2018/07/11 - 2019/01/09
+P1444R0 SG19: Machine Learning 2018/12/14 - 2019/01/11
+P1445R0 Concurrency TS: to update or not update
+P1446R0 Reconsider the Networking TS for inclusion in C++20
+P1447R0 constexpr C++ is not constexpr C
+P1448R0 Simplifying Mixed Contract Modes
+P1449R0 Towards Tree and Graph Data Structures for C++
+P1450R0 Enriching type modification traits
+P1450R1 Enriching type modification traits
+P1450R2 Enriching type modification traits
+P1450R3 Enriching type modification traits
+P1452R0 On the non-uniform semantics of return-type-requirements
+P1452R1 On the non-uniform semantics of return-type-requirements
+P1452R2 On the non-uniform semantics of return-type-requirements
+P1453R0 Modularizing the Standard Library is a Reorganization Opportunity
+P1456R0 Move-only views
+P1456R1 Move-only views
+P1457R0 C++ Standard Library Issues to be moved in Kona
+P1458R0 Mandating the Standard Library: Clause 16 - Language support library
+P1458R1 Mandating the Standard Library: Clause 16 - Language support library
+P1459R0 Mandating the Standard Library: Clause 18 - Diagnostics library
+P1459R1 Mandating the Standard Library: Clause 18 - Diagnostics library
+P1460R0 Mandating the Standard Library: Clause 20 - Utilities library
+P1460R1 Mandating the Standard Library: Clause 20 - Utilities library
+P1462R0 Mandating the Standard Library: Clause 20 - Strings library
+P1462R1 Mandating the Standard Library: Clause 20 - Strings library
+P1463R0 Mandating the Standard Library: Clause 21 - Containers library
+P1463R1 Mandating the Standard Library: Clause 21 - Containers library
+P1464R0 Mandating the Standard Library: Clause 22 - Iterators library
+P1464R1 Mandating the Standard Library: Clause 22 - Iterators library
+P1465R0 Function optimization hint attributes: [[always_inline]], [[never_inline]]
+P1466R0 Miscellaneous minor fixes for chrono
+P1466R1 Miscellaneous minor fixes for chrono
+P1466R2 Miscellaneous minor fixes for chrono
+P1466R3 Miscellaneous minor fixes for chrono
+P1467R0 Extended floating-point types
+P1467R1 Extended floating-point types
+P1467R2 Extended floating-point types
+P1467R3 Extended floating-point types
+P1467R4 Extended floating-point types and standard names
+P1467R5 Extended floating-point types and standard names
+P1467R6 Extended floating-point types and standard names
+P1467R7 Extended floating-point types and standard names
+P1467R8 Extended floating-point types and standard names
+P1467R9 Extended floating-point types and standard names
+P1468R0 Fixed-layout floating-point type aliases
+P1468R1 Fixed-layout floating-point type aliases
+P1468R2 Fixed-layout floating-point type aliases
+P1468R3 Fixed-layout floating-point type aliases
+P1468R4 Fixed-layout floating-point type aliases
+P1469R0 Disallow _ Usage in C++20 for Pattern Matching in C++23
+P1470R0 Against a standard concurrent hashmap
+P1471R0 The trouble with coroutine_traits
+P1472R0 SG5: Transactional Memory (TM) Meeting Minutes (June 2018 - January 2019)
+P1473R0 Shadow namespaces
+P1474R0 Helpful pointers for ContiguousIterator
+P1474R1 Helpful pointers for ContiguousIterator
+P1477R0 Coroutines TS Simplifications
+P1477R1 Coroutines TS Simplifications
+P1478R0 Byte-wise atomic memcpy
+P1478R1 Byte-wise atomic memcpy
+P1478R2 Byte-wise atomic memcpy
+P1478R3 Byte-wise atomic memcpy
+P1478R4 Byte-wise atomic memcpy
+P1478R5 Byte-wise atomic memcpy
+P1478R6 Byte-wise atomic memcpy
+P1478R7 Byte-wise atomic memcpy
+P1478R8 Byte-wise atomic memcpy
+P1479R0 ostringstream wrapper
+P1481R0 constexpr structured bindings
+P1482R0 Modules Feedback
+P1484R1 A uniform and predefined mapping from modules to filenames
+P1485R0 Better keywords for the Coroutines TS
+P1485R1 Better keywords for the Coroutines
+P1486R0 United Amendment to Contracts Facility for C++20
+P1486R1 United Amendment to Contracts Facility for C++20
+P1487R0 User Experience with Contracts That Work
+P1490R0 Contract-Related Issues
+P1491R0 Don’t add to the signed/unsigned mess
+P1492R0 Coroutines: Language and Implementation Impact
+P1493R0 Coroutines: Use-cases and Trade-offs
+P1494R0 Partial program correctness
+P1494R1 Partial program correctness
+P1494R2 Partial program correctness
+P1496R0 Formatting of Negative Zero
+P1496R1 Formatting of Negative Zero
+P1496R2 Formatting of Negative Zero
+P1498R0 Constrained Internal Linkage for Modules
+P1498R1 Constrained Internal Linkage for Modules
+P1502R0 Standard library header units for C++20
+P1502R1 Standard library header units for C++20
+P1505R0 Mandating the Standard Library: Clause 30 - Atomic operations library
+P1505R1 Mandating the Standard Library: Clause 31 - Atomic operations library
+P1510R0 Core Language Working Group "tentatively ready" Issues for the July, 2019 (Cologne) meeting
+P1517R0 Contract Requirements for Iterative High-Assurance Systems
+P1518R0 Stop overconstraining allocators in container deduction guides
+P1518R1 Stop overconstraining allocators in container deduction guides
+P1518R2 Stop overconstraining allocators in container deduction guides
+P1520R0 Response to response to “Fibers under the magnifying glass”
+P1522R0 Iterator Difference Type and Integer Overflow
+P1522R1 Iterator Difference Type and Integer Overflow
+P1523R0 Views and Size Types
+P1523R1 Views and Size Types
+P1525R0 One-Way execute is a Poor Basis Operation
+P1525R1 One-Way execute is a Poor Basis Operation
+P1601R0 Recommendations for Specifying “Hidden Friends”
+P1602R0 Make Me A Module
+P1604R0 The inline keyword is not in line with the design of modules.
+P1604R1 The inline keyword is not in line with the design of modules
+P1605R0 Member Layout Control
+P1606R0 Requirements for Contract Roles
+P1607R0 Minimizing Contracts
+P1607R1 Minimizing Contracts
+P1609R0 C++ Should Support Just-in-Time Compilation
+P1609R1 C++ Should Support Just-in-Time Compilation
+P1609R2 C++ Should Support Just-in-Time Compilation
+P1609R3 C++ Should Support Just-in-Time Compilation
+P1610R0 Rename await_resume() to await_result()
+P1611R0 WG21 2019-02 Kona Record of Discussion
+P1612R0 Relocate Endian's Specification
+P1612R1 Relocate Endian's Specification
+P1614R0 The Mothership Has Landed: Adding <=> to the Library
+P1614R1 The Mothership Has Landed: Adding <=> to the Library
+P1614R2 The Mothership Has Landed: Adding <=> to the Library
+P1616R0 Using unconstrained template template parameters with constrained templates
+P1616R1 Using unconstrained template template parameters with constrained templates
+P1619R0 Functions for Testing Boundary Conditions on Integer Operations
+P1619R1 Functions for Testing Boundary Conditions on Integer Operations
+P1619R2 Functions for Testing Boundary Conditions on Integer Operations
+P1622R0 Mandating the Standard Library: Clause 31 - Thread support library
+P1622R1 Mandating the Standard Library: Clause 31 - Thread support library
+P1622R2 Mandating the Standard Library: Clause 32 - Thread support library
+P1622R3 Mandating the Standard Library: Clause 32 - Thread support library
+P1624R0 Resolving technical issues in parameter mapping equivalence and related problems
+P1624R1 Resolving technical issues in parameter mapping equivalence and related problems
+P1625R0 Contracts: why the house is not on fire (i.e. why the status quo is tolerable)
+P1628R0 Unicode characters properties
+P1629R0 Standard Text Encoding
+P1629R1 Transcoding the world - Standard Text Encoding
+P1630R0 Spaceship needs a tune-up: Addressing some discovered issues with P0515 and P1185
+P1630R1 Spaceship needs a tune-up
+P1631R0 Object detachment and attachment
+P1631R1 Object detachment and attachment
+P1633R0 Amendments to the C++20 Synchronization Library
+P1633R1 Amendments to the C++20 Synchronization Library
+P1634R0 Naming guidelines for modules
+P1635R0 A Design for an Inter-Operable and Customizable Linear Algebra Library
+P1636R0 Formatters for library types
+P1636R1 Formatters for library types
+P1636R2 Formatters for library types
+P1638R0 basic_istream_view's iterator should not be copyable
+P1638R1 basic_istream_view's iterator should not be copyable
+P1639R0 Unifying source_location and contract_violation
+P1640R0 Error size benchmarking
+P1640R1 Error size benchmarking: Redux
+P1641R0 Freestanding Library: Rewording the Status Quo
+P1641R1 Freestanding Library: Rewording the Status Quo
+P1641R2 Freestanding Library: Rewording the Status Quo
+P1641R3 Freestanding Library: Rewording the Status Quo
+P1642R0 Freestanding Library: Easy [utilities]
+P1642R1 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R2 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R3 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R4 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R5 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R6 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R7 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R8 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R9 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R10 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1642R11 Freestanding Library: Easy [utilities], [ranges], and [iterators]
+P1643R0 Add wait/notify to atomic_ref<T>
+P1643R1 Add wait/notify to atomic_ref
+P1644R0 Add wait/notify to atomic<shared_ptr<T>>
+P1645R0 constexpr for numeric algorithms
+P1645R1 constexpr for numeric algorithms
+P1648R0 The Concept of Extending Argument and a Support Library
+P1648R1 The Concept of Extending Argument and a Support Library
+P1648R2 A Library for Sink Argument Passing
+P1649R0 A Generic Library for Compile-time Routing
+P1650R0 Output std::chrono::days with 'd' suffix
+P1651R0 bind_front should not unwrap reference_wrapper
+P1652R0 Printf corner cases in std::format
+P1652R1 Printf corner cases in std::format
+P1654R0 ABI breakage - summary of initial comments
+P1654R1 ABI breakage - summary of initial comments
+P1655R0 LEWG Omnibus Design Policy Paper
+P1656R0 "Throws: Nothing" should be noexcept
+P1656R1 "Throws: Nothing" should be noexcept
+P1656R2 "Throws: Nothing" should be noexcept
+P1657R0 String substring checking
+P1658R0 Suggestions for Consensus on Executors
+P1659R0 starts_with and ends_with
+P1659R1 starts_with and ends_with
+P1659R2 starts_with and ends_with
+P1659R3 starts_with and ends_with
+P1660R0 A Compromise Executor Design Sketch
+P1661R0 Remove dedicated precalculated hash lookup interface
+P1661R1 Remove dedicated precalculated hash lookup interface
+P1662R0 Adding async RAII support to coroutines
+P1663R0 Supporting return-value-optimisation in coroutines
+P1664R0 reconstructible_range - a concept for putting ranges back together
+P1664R1 reconstructible_range - a concept for putting ranges back together
+P1664R2 reconstructible_range - a concept for putting ranges back together
+P1664R3 reconstructible_range - a concept for putting ranges back together
+P1664R4 reconstructible_range - a concept for putting ranges back together
+P1664R5 reconstructible_range - a concept for putting ranges back together
+P1664R6 reconstructible_range - a concept for putting ranges back together
+P1664R7 reconstructible_range - a concept for putting ranges back together
+P1665R0 Tag Based Customization Point Functions
+P1666R0 SG16: Unicode meeting summaries 2019/01/23 - 2019/05/22
+P1667R0 Concept-aware noexcept specifiers
+P1668R0 Enabling constexpr Intrinsics By Permitting Unevaluated inline-assembly in constexpr Functions
+P1668R1 Enabling constexpr Intrinsics By Permitting Unevaluated inline-assembly in constexpr Functions
+P1669R0 Callsite Based Inlining Hints: [[always_inline]] and [[never_inline]]
+P1670R0 Side Effects of Checked Contracts and Predicate Elision
+P1671R0 Contract Evaluation in Constant Expressions
+P1672R0 "Axiom" is a False Friend
+P1673R0 A free function linear algebra interface based on the BLAS
+P1673R1 A free function linear algebra interface based on the BLAS
+P1673R2 A free function linear algebra interface based on the BLAS
+P1673R3 A free function linear algebra interface based on the BLAS
+P1673R4 A free function linear algebra interface based on the BLAS
+P1673R5 A free function linear algebra interface based on the BLAS
+P1673R6 A free function linear algebra interface based on the BLAS
+P1673R7 A free function linear algebra interface based on the BLAS
+P1673R8 A free function linear algebra interface based on the BLAS
+P1673R9 A free function linear algebra interface based on the BLAS
+P1673R10 A free function linear algebra interface based on the BLAS
+P1673R11 A free function linear algebra interface based on the BLAS
+P1673R12 A free function linear algebra interface based on the BLAS
+P1673R13 A free function linear algebra interface based on the BLAS
+P1674R0 Evolving a Standard C++ Linear Algebra Library from the BLAS
+P1674R1 Evolving a Standard C++ Linear Algebra Library from the BLAS
+P1674R2 Evolving a Standard C++ Linear Algebra Library from the BLAS
+P1675R0 rethrow_exception must be allowed to copy
+P1675R1 rethrow_exception must be allowed to copy
+P1675R2 rethrow_exception must be allowed to copy
+P1676R0 C++ Exception Optimizations. An experiment.
+P1677R0 Cancellation is not an Error
+P1677R1 Cancellation is not an Error
+P1677R2 Cancellation is not an Error
+P1678R0 Callbacks and Composition
+P1678R1 Callbacks and Composition
+P1678R2 Callbacks and Composition
+P1679R0 String Contains function
+P1679R1 String Contains function
+P1679R2 String Contains function
+P1679R3 String Contains function
+P1680R0 Implementing Contracts in GCC
+P1681R0 Revisiting allocator model for coroutine lazy/task/generator
+P1682R0 std::to_underlying
+P1682R1 std::to_underlying
+P1682R2 std::to_underlying
+P1682R3 std::to_underlying
+P1683R0 References for Standard Library Vocabulary Types - an optional case study
+P1684R0 mdarray: An Owning Multidimensional Array Analog of mdspan
+P1684R1 mdarray: An Owning Multidimensional Array Analog of mdspan
+P1684R2 mdarray: An Owning Multidimensional Array Analog of mdspan
+P1684R3 mdarray: An Owning Multidimensional Array Analog of mdspan
+P1684R4 mdarray: An Owning Multidimensional Array Analog of mdspan
+P1684R5 mdarray: An Owning Multidimensional Array Analog of mdspan
+P1685R0 Make get/set_default_resource replaceable
+P1686R0 Mandating the Standard Library: Clause 27 - Time library
+P1686R1 Mandating the Standard Library: Clause 27 - Time library
+P1686R2 Mandating the Standard Library: Clause 27 - Time library
+P1687R0 Summary of the Tooling Study Group's Pre-Cologne Telecons on Modules Tooling Interactions
+P1687R1 Summary of the Tooling Study Group's Modules Ecosystem Technical Report Telecons
+P1688R0 Towards a C++ Ecosystem Technical Report
+P1689R0 Format for describing dependencies of source files
+P1689R1 Format for describing dependencies of source files
+P1689R2 Format for describing dependencies of source files
+P1689R3 Format for describing dependencies of source files
+P1689R4 Format for describing dependencies of source files
+P1689R5 Format for describing dependencies of source files
+P1690R0 Refinement Proposal for P0919 Heterogeneous lookup for unordered containers
+P1690R1 Refinement Proposal for P0919 Heterogeneous lookup for unordered containers
+P1696R0 Refinement proposal for P0920 Precalculated hash values in lookup
+P1697R0 Require a diagnostic for "declaration changes meaning"
+P1700R0 Target-audience tables
+P1701R0 Inline Namespaces: Fragility Bites
+P1701R1 Inline Namespaces: Fragility Bites
+P1701R2 Inline Namespaces: Fragility Bites
+P1702R0 Annex D Means Deprecated
+P1703R0 Recognizing Header Unit Imports Requires Full Preprocessing
+P1703R1 Recognizing Header Unit Imports Requires Full Preprocessing
+P1704R0 Undefined functions in axiom-level contract statements
+P1705R0 Enumerating Core Undefined Behavior
+P1705R1 Enumerating Core Undefined Behavior
+P1706R0 Programming Language Vulnerabilities for C++ update
+P1706R1 Programming Language Vulnerabilities for C++ update
+P1706R2 Programming Language Vulnerabilities for Safety Critical C++
+P1706R3 Programming Language Vulnerabilities for Safety Critical C++
+P1708R0 Simple Statistics functions
+P1708R1 Simple Statistical Functions
+P1708R2 Simple Statistical Functions
+P1708R3 Simple Statistical Functions
+P1708R4 Simple Statistical Functions
+P1708R5 Simple Statistical Functions
+P1708R6 Simple Statistical Functions
+P1708R7 Basic Statistics
+P1708R8 Basic Statistics
+P1709R0 Graph Data Structures
+P1709R1 Graph Data Structures
+P1709R2 Graph Library
+P1709R3 Graph Library
+P1709R4 Graph Library
+P1709R5 Graph Library
+P1710R0 Adding a global contract assumption mode
+P1711R0 What to do about contracts?
+P1713R0 Allowing both co_return; and co_return value; in the same coroutine
+P1714R0 NTTP are incomplete without float, double, and long double!
+P1714R1 NTTP are incomplete without float, double, and long double!
+P1715R0 Loosen restrictions on "_t" typedefs and "_v" values.
+P1715R1 Loosen restrictions on "_t" typedefs and "_v" values.
+P1716R0 ranges compare algorithm are over-constrained
+P1716R1 ranges compare algorithm are over-constrained
+P1716R2 ranges compare algorithm are over-constrained
+P1716R3 ranges compare algorithm are over-constrained
+P1717R0 Compile-time Metaprogramming in C++
+P1718R0 Mandating the Standard Library: Clause 25 - Algorithms library
+P1718R1 Mandating the Standard Library: Clause 25 - Algorithms library
+P1718R2 Mandating the Standard Library: Clause 25 - Algorithms library
+P1719R0 Mandating the Standard Library: Clause 26 - Numerics library
+P1719R1 Mandating the Standard Library: Clause 26 - Numerics library
+P1719R2 Mandating the Standard Library: Clause 26 - Numerics library
+P1720R0 Mandating the Standard Library: Clause 28 - Localization library
+P1720R1 Mandating the Standard Library: Clause 28 - Localization library
+P1720R2 Mandating the Standard Library: Clause 28 - Localization library
+P1721R0 Mandating the Standard Library: Clause 29 - Input/Output library
+P1721R1 Mandating the Standard Library: Clause 29 - Input/Output library
+P1721R2 Mandating the Standard Library: Clause 29 - Input/Output library
+P1722R0 Mandating the Standard Library: Clause 30 - Regular Expression library
+P1722R1 Mandating the Standard Library: Clause 30 - Regular Expression library
+P1722R2 Mandating the Standard Library: Clause 30 - Regular Expression library
+P1723R0 Mandating the Standard Library: Clause 31 - Atomics library
+P1723R1 Mandating the Standard Library: Clause 31 - Atomics library
+P1723R2 Mandating the Standard Library: Clause 31 - Atomics library
+P1724R0 C++ Standard Library Issues to be moved in Cologne
+P1725R0 Modular Topic Design
+P1725R1 Modular Topic Design
+P1726R0 Pointer lifetime-end zap
+P1726R1 Pointer lifetime-end zap
+P1726R2 Pointer lifetime-end zap
+P1726R3 Pointer lifetime-end zap
+P1726R4 Pointer lifetime-end zap
+P1726R5 Pointer lifetime-end zap (informational/historical)
+P1727R0 Issues with current flat_map proposal
+P1728R0 Preconditions, axiom-level contracts and assumptions — an in depth study
+P1729R0 Text Parsing
+P1729R1 Text Parsing
+P1729R2 Text Parsing
+P1729R3 Text Parsing
+P1730R0 Adding a global contract assumption mode
+P1731R0 Memory helper functions for containers
+P1731R1 Memory helper functions for containers
+P1732R0 Do not promise support for function syntax of operators
+P1732R1 Do not promise support for function syntax of operators
+P1732R2 Do not promise support for function syntax of operators
+P1732R3 Do not promise support for function syntax of operators
+P1732R4 Do not promise support for function syntax of operators
+P1733R0 User-friendly and Evolution-friendly Reflection: A Compromise
+P1734R0 Defaultable default constructors and destructors for all unions
+P1735R0 SG19: Machine Learning 2019/04/11-2019/06/13
+P1736R0 SG14: Low Latency Meeting Minutes 2019/04/17-2019/06/12
+P1737R0 unique_function vs. any_invokable - Bikeshedding Off the Rails
+P1738R0 The Executor Concept Hierarchy Needs a Single Root
+P1739R0 Type erasure for forwarding ranges in combination with "subrange-y" view adaptors
+P1739R1 Type erasure for forwarding ranges in combination with "subrange-y" view adaptors
+P1739R2 Avoid template bloat for forwarding ranges in combination with 'subrange-y' view adaptors.
+P1739R3 Avoid template bloat for safe_ranges in combination with 'subrange-y' view adaptors.
+P1739R4 Avoid template bloat for safe_ranges in combination with 'subrange-y' view adaptors.
+P1743R0 Contracts, Undefined Behavior, and Defensive Programming
+P1744R0 Avoiding Misuse of Contract-Checking
+P1745R0 Coroutine changes for C++20 and beyond
+P1746R0 Feedback on [P1386R2] std::audio
+P1746R1 Feedback on P1386R2 std::audio
+P1747R0 Don't use `char8_t` and `std::u8string` yet in P1389
+P1748R0 Fill in [delay.cpp] TODO in D1389
+P1748R1 Fill in [delay.cpp] TODO in D1389
+P1749R0 Access control for reflection
+P1750R0 A Proposal to Add Process Management to the C++ Standard Library
+P1750R1 A Proposal to Add Process Management to the C++ Standard Library
+P1751R0 Numeric Type Families
+P1753R0 Name Lookup Should "Find the First Thing of That Name"
+P1754R0 Rename concepts to standard_case for C++20, while we still can
+P1754R1 Rename concepts to standard_case for C++20, while we still can
+P1756R0 Pointer lifetime-end zap
+P1759R0 Native handle from file streams
+P1759R1 Native handle from file streams
+P1759R2 Native handle from file streams
+P1759R3 Native handles and file streams
+P1759R4 Native handles and file streams
+P1759R5 Native handles and file streams
+P1759R6 Native handles and file streams
+P1760R0 snapshot_source - A Horse with a Better Name
+P1761R0 Concurrent map customization options (SG1 version)
+P1762R0 Concurrent map customization options (LEWG version)
+P1764R0 ssize() Should be Named count()
+P1766R0 Mitigating minor modules maladies
+P1766R1 Mitigating minor modules maladies
+P1767R0 Packaging C++ Modules
+P1768R0 Contiguous Containers Should Contain .data()
+P1769R0 The "default" contract build-level and continuation-mode should be implementation-defined
+P1770R0 On vectors, tensors, matrices, and hypermatrices
+P1771R0 [[nodiscard]] for constructors
+P1771R1 [[nodiscard]] for constructors
+P1772R0 Variadic overload sets and overload sequences
+P1772R1 Variadic overload sets and overload sequences
+P1773R0 Contracts have failed to provide a portable "assume"
+P1774R0 Portable optimisation hints
+P1774R1 Portable optimisation hints
+P1774R2 Portable assumptions
+P1774R3 Portable assumptions
+P1774R4 Portable assumptions
+P1774R5 Portable assumptions
+P1774R6 Portable assumptions
+P1774R7 Portable assumptions
+P1774R8 Portable assumptions
+P1779R0 ABI isolation for member functions
+P1779R1 ABI isolation for member functions
+P1779R2 ABI isolation for member functions
+P1779R3 ABI isolation for member functions
+P1780R0 Modular Relaxed Dependencies: A new approach to the Out-Of-Thin-Air Problem
+P1782R0 Local contract restrictions
+P1782R1 Local contract restrictions
+P1786R0 Adding a global contract assumption mode
+P1787R0 Declarations and where to find them
+P1787R1 Declarations and where to find them
+P1787R2 Declarations and where to find them
+P1787R3 Declarations and where to find them
+P1787R4 Declarations and where to find them
+P1787R5 Declarations and where to find them
+P1787R6 Declarations and where to find them
+P1788R0 Reuse of the built modules (BMI)
+P1788R2 Reuse of the built modules (BMI)
+P1788R3 Reuse of the built modules (BMI)
+P1789R0 Library Support for Expansion Statements
+P1790R0 Networking TS changes to enable better DynamicBuffer composition
+P1790R1 Networking TS changes to enable better DynamicBuffer composition
+P1791R0 Evolution of the P0443 Unified Executors Proposal to accommodate new requirements
+P1792R0 Simplifying and generalising Sender/Receiver for asynchronous operations
+P1793R0 Simplifying Contract Syntax
+P1795R0 System topology discovery for heterogeneous & distributed computing
+P1795R1 System topology discovery for heterogeneous & distributed computing
+P1795R2 System topology discovery for heterogeneous &amp; distributed computing
+P1796R0 Effective Types: Examples
+P1797R0 C/C++ Memory Object Model Papers - Introduction
+P1798R0 SG14 Linear Algebra SIG Meeting Minutes 2018/10/10-2019/06/06
+P1801R0 Clarifying atomic[thread::id]::compare_exchange_*
+P1803R0 packexpr(args, I) - compile-time friendly pack inspection
+P1807R0 An Overview of Contracts Papers for Cologne
+P1808R0 Contra P0339 "polymorphic_allocator as a vocabulary type"
+P1810R0 A Quick Look at What P1754 Will Change
+P1811R0 Relaxing redefinition restrictions for re-exportation robustness
+P1812R0 Axioms should be assumable: a minimal fix for contracts
+P1813R0 A Concept Design for the Numeric Algorithms
+P1814R0 Wording for Class Template Argument Deduction for Alias Templates
+P1815R0 Translation-unit-local entities
+P1815R1 Translation-unit-local entities
+P1815R2 Translation-unit-local entities
+P1816R0 Wording for class template argument deduction for aggregates
+P1818R0 Narrowing and Widening Conversions
+P1818R1 Narrowing and Widening Conversions
+P1819R0 Interpolated Literals
+P1820R0 Recommendations for a compromise on handling errors and cancellations in executors
+P1823R0 Remove Contracts from C++20
+P1825R0 Merged wording for P0527R1 and P1155R3
+P1830R0 std::dependent_false
+P1830R1 std::dependent_false
+P1831R0 deprecating volatile: library
+P1831R1 deprecating volatile: library
+P1832R0 Improving Debug Builds Inline With User Expectation
+P1837R0 Remove NTTPs of class type from C++20
+P1838R0 Modules User-Facing Lexicon and File Extensions
+P1839R0 Accessing Object Representations
+P1839R1 Accessing Object Representations
+P1839R2 Accessing Object Representations
+P1839R3 Accessing Object Representations
+P1839R4 Accessing Object Representations
+P1839R5 Accessing object representations
+P1840R0 Cologne 2019, Record of Discussion
+P1841R0 Wording for Individually Specializable Numeric Traits
+P1841R1 Wording for Individually Specializable Numeric Traits
+P1841R2 Wording for Individually Specializable Numeric Traits
+P1841R3 Wording for Individually Specializable Numeric Traits
+P1842R0 Generalized Module (Dependency?) Mapper
+P1843R0 Comparison and Hasher Requirements
+P1844R0 Enhancement of regex
+P1844R1 Enhancement of regex
+P1845R0 2019-09-21 Denver Tooling Meeting
+P1846R0 Teach class Last
+P1847R0 Make declaration order layout mandated
+P1847R1 Make declaration order layout mandated
+P1847R2 Make declaration order layout mandated
+P1847R3 Make declaration order layout mandated
+P1847R4 Make declaration order layout mandated
+P1848R0 Improve rules of standard layout
+P1851R0 Guidelines For snake_case Concept Naming
+P1854R0 Conversion to execution encoding should not lead to loss of meaning
+P1854R1 Conversion to literal encoding should not lead to loss of meaning
+P1854R2 Conversion to literal encoding should not lead to loss of meaning
+P1854R3 Conversion to literal encoding should not lead to loss of meaning
+P1854R4 Making non-encodable string literals ill-formed
+P1855R0 Make <compare> freestanding
+P1856R0 Bit operations do not work on bytes: a generic fix
+P1857R0 Modules Dependency Discovery
+P1857R1 Modules Dependency Discovery
+P1857R2 Modules Dependency Discovery
+P1857R3 Modules Dependency Discovery
+P1858R0 Generalized pack declaration and usage
+P1858R1 Generalized pack declaration and usage
+P1858R2 Generalized pack declaration and usage
+P1859R0 Standard terminology for execution character set encodings
+P1860R0 C++ Networking Must Be Secure By Default
+P1861R0 Secure Connections in Networking TS
+P1861R1 Secure Networking in C++
+P1862R0 Ranges adaptors for non-copyable iterators
+P1862R1 Ranges adaptors for non-copyable iterators
+P1863R0 ABI - Now or Never
+P1863R1 ABI - Now or Never
+P1864R0 Defining Target Tuplets
+P1865R0 Add max() to latch and barrier
+P1865R1 Add max() to latch and barrier
+P1868R0 ? width: clarifying units of width and precision in std::format
+P1868R1 Unicorn width: clarifying units of width and precision in std::format
+P1868R2 Unicorn width: clarifying units of width and precision in std::format
+P1869R0 Rename 'condition_variable_any' interruptible wait methods
+P1869R1 Rename 'condition_variable_any' interruptible wait methods
+P1870R0 forwarding-range is too subtle
+P1870R1 forwarding-range is too subtle
+P1871R0 Should concepts be enabled or disabled?
+P1871R1 Concept traits should be named after concepts
+P1872R0 span should have size_type, not index_type
+P1873R0 remove.dots.in.module.names
+P1873R1 remove.dots.in.module.names
+P1874R0 Dynamic Initialization Order of Non-Local Variables in Modules
+P1874R1 Dynamic Initialization Order of Non-Local Variables in Modules
+P1875R0 Transactional Memory Lite Support in C++
+P1875R1 Transactional Memory Lite Support in C++
+P1875R2 Transactional Memory Lite Support in C++
+P1876R0 All The Module Names
+P1876R1 All The Module Names
+P1877R0 Saving Private Ranges: Recovering Lost Information from Comparison and Predicate Algorithms
+P1878R0 Constraining Readable Types
+P1878R1 Constraining Readable Types
+P1879R0 Please Don't Rewrite My String Literals
+P1880R0 uNstring Arguments Shall Be UTF-N Encoded
+P1881R0 Epochs: a backward-compatible language evolution mechanism
+P1881R1 Epochs: a backward-compatible language evolution mechanism
+P1882R0 Addition of a filter to recursive_directory_iterator
+P1883R0 Walkthrough of P1031s file_handle for LEWG-I
+P1883R1 file_handle and mapped_file_handle
+P1883R2 file_handle and mapped_file_handle
+P1884R0 Private Module Partition: An Inconsistent Boundary
+P1885R0 Naming Text Encodings to Demystify Them
+P1885R1 Naming Text Encodings to Demystify Them
+P1885R2 Naming Text Encodings to Demystify Them
+P1885R3 Naming Text Encodings to Demystify Them
+P1885R4 Naming Text Encodings to Demystify Them
+P1885R5 Naming Text Encodings to Demystify Them
+P1885R6 Naming Text Encodings to Demystify Them
+P1885R7 Naming Text Encodings to Demystify Them
+P1885R8 Naming Text Encodings to Demystify Them
+P1885R9 Naming Text Encodings to Demystify Them
+P1885R10 Naming Text Encodings to Demystify Them
+P1885R11 Naming Text Encodings to Demystify Them
+P1885R12 Naming Text Encodings to Demystify Them
+P1886R0 Error speed benchmarking
+P1887R0 Typesafe Reflection on attributes
+P1887R1 Reflection on attributes
+P1888R0 Executors without exception handling support
+P1889R0 C++ Numerics Work In Progress
+P1889R1 C++ Numerics Work In Progress
+P1890R0 C++ Numerics Work In Progress Issues
+P1891R0 The Linear-Algebra Effort
+P1892R0 Extended locale-specific presentation specifiers for std::format
+P1892R1 Extended locale-specific presentation specifiers for std::format
+P1893R0 Proposal of Contract Primitives
+P1894R0 Proposal of std::upto, std::indices and std::enumerate
+P1895R0 tag_invoke: A general pattern for supporting customisable functions
+P1896R0 SG16: Unicode meeting summaries 2019/06/12 - 2019/09/25
+P1897R0 Towards C++23 executors: An initial set of algorithms
+P1897R1 Towards C++23 executors: An initial set of algorithms
+P1897R2 Towards C++23 executors: A proposal for an initial set of algorithms
+P1897R3 Towards C++23 executors: A proposal for an initial set of algorithms
+P1898R0 Forward progress delegation for executors
+P1898R1 Forward progress delegation for executors
+P1899R0 stride_view
+P1899R1 stride_view
+P1899R2 stride_view
+P1899R3 stride_view
+P1900R0 Concepts-Adjacent Problems
+P1901R0 Enabling the Use of weak_ptr as Keys in Unordered Associative Containers
+P1901R1 Enabling the Use of weak_ptr as Keys in Unordered Associative Containers
+P1901R2 Enabling the Use of weak_ptr as Keys in Unordered Associative Containers
+P1902R0 Missing feature-test macros 2018-2019
+P1902R1 Missing feature-test macros 2017-2019
+P1905R0 In-Source Mechanism to Identify Importable Headers
+P1906R0 Provided operator= return lvalue-ref on rvalue
+P1907R0 Inconsistencies with non-type template parameters
+P1907R1 Inconsistencies with non-type template parameters
+P1908R0 Reserving Attribute Names for Future Use
+P1908R1 Reserving Attribute Names for Future Use
+P1908R2 Reserving Attribute Names for Future Use
+P1909R0 SG14: Low Latency Meeting Minutes 2019/08/14-2019/09/11
+P1910R0 SG14: Linear Algebra Meeting Minutes 2019/08/07-2019/10/02
+P1911R0 SG19: Machine Learning 2019/08/08-2019/09/11
+P1912R0 Interconvertible object representations
+P1912R1 Types with array-like object representations
+P1913R0 Comments on Audio Devices
+P1914R0 On the names of shift algorithms
+P1915R0 Expected Feedback from simd in the Parallelism TS 2
+P1916R0 There might not be an elegant OOTA fix
+P1917R0 C++ Library Issues to be moved in Belfast
+P1919R0 Expanding the Rights in SD-8
+P1919R1 Expanding the Rights in SD-8
+P1919R2 Expanding the Rights in SD-8
+P1919R3 Expanding the Rights in SD-8
+P1920R0 Proposal of Namespace Templates
+P1921R0 What's in a Name?
+P1922R0 Making std::list constexpr
+P1923R0 Making std::deque constexpr
+P1924R0 Making std::stack constexpr
+P1925R0 Making std::queue constexpr
+P1926R0 Making std::priority_queue constexpr
+P1927R0 Add std::is_partitioned_until algorithm
+P1928R0 Merge data-parallel types from the Parallelism TS 2
+P1928R1 Merge data-parallel types from the Parallelism TS 2
+P1928R2 Merge data-parallel types from the Parallelism TS 2
+P1928R3 Merge data-parallel types from the Parallelism TS 2
+P1928R4 std::simd - Merge data-parallel types from the Parallelism TS 2
+P1928R5 std::simd - Merge data-parallel types from the Parallelism TS 2
+P1928R6 std::simd - Merge data-parallel types from the Parallelism TS 2
+P1928R7 std::simd - Merge data-parallel types from the Parallelism TS 2
+P1928R8 std::simd - Merge data-parallel types from the Parallelism TS 2
+P1929R0 Making std::forward_list constexpr
+P1930R0 Towards a standard unit systems library
+P1932R0 Extension of the C++ random number generators
+P1933R0 Suggestions for bulk_execute
+P1934R0 boolean Considered Harmful
+P1935R0 A C++ Approach to Physical Units
+P1935R1 A C++ Approach to Physical Units
+P1935R2 A C++ Approach to Physical Units
+P1936R0 Dependent Static Assertion
+P1937R0 Fixing inconsistencies between `constexpr` and `consteval` functions
+P1937R1 Fixing inconsistencies between `constexpr` and `consteval` functions
+P1937R2 Fixing inconsistencies between `constexpr` and `consteval` functions
+P1938R0 if consteval
+P1938R1 if consteval
+P1938R2 if consteval
+P1938R3 if consteval
+P1943R0 Networking TS changes to improve completion token flexibility and performance
+P1944R0 Add Constexpr Modifiers to Functions in cstring and cwchar Headers
+P1944R1 Add Constexpr Modifiers to Functions in cstring and cwchar Headers
+P1945R0 Making More Objects Contiguous
+P1946R0 Allow defaulting comparisons by value
+P1947R0 C++ exceptions and alternatives
+P1948R0 Modules: Keep the dot
+P1949R0 C++ Identifier Syntax using Unicode Standard Annex 31
+P1949R1 C++ Identifier Syntax using Unicode Standard Annex 31
+P1949R2 C++ Identifier Syntax using Unicode Standard Annex 31
+P1949R3 C++ Identifier Syntax using Unicode Standard Annex 31
+P1949R4 C++ Identifier Syntax using Unicode Standard Annex 31
+P1949R5 C++ Identifier Syntax using Unicode Standard Annex 31
+P1949R6 C++ Identifier Syntax using Unicode Standard Annex 31
+P1949R7 C++ Identifier Syntax using Unicode Standard Annex 31
+P1950R0 An indirect value-type for C++
+P1950R1 An indirect value-type for C++
+P1950R2 An indirect value-type for C++
+P1951R0 Default Arguments for pair's Forwarding Constructor
+P1951R1 Default Arguments for pair's Forwarding Constructor
+P1953R0 Unicode Identifiers And Unicode
+P1955R0 Top Level Is Constant Evaluated
+P1955R1 Top Level Is Constant Evaluated
+P1956R0 On the naming of low-level bit manipulation functions
+P1956R1 On the naming of low-level bit manipulation functions
+P1957R0 Converting from T* to bool should be considered narrowing (re: US 212)
+P1957R1 Converting from T* to bool should be considered narrowing (re: US 212)
+P1957R2 Converting from T* to bool should be considered narrowing (re: US 212)
+P1958R0 C++ Concurrent Buffer Queue
+P1959R0 Remove std::weak_equality and std::strong_equality
+P1960R0 NB Comment Changes Reviewed by SG1
+P1961R0 Harmonizing the definitions of total order for pointers
+P1962R0 How can you be so certain?
+P1963R0 Fixing US 313
+P1964R0 Casting convertible_to<bool> considered harmful
+P1964R1 Wording for boolean-testable
+P1964R2 Wording for boolean-testable
+P1965R0 Blanket Wording for Specifying "Hidden Friends"
+P1967R0 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R1 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R2 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R3 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R4 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R5 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R6 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R7 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R8 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R9 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R10 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R11 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1967R12 #embed - a simple, scannable preprocessor-based resource acquisition method
+P1968R0 Core Language Working Group "tentatively ready" issues for the November, 2019 (Belfast) meeting
+P1969R0 Core Language Working Group "ready" issues for the November, 2019 (Belfast) meeting
+P1970R0 Consistency for size() functions
+P1970R1 Consistency for size() functions
+P1970R2 Consistency for size() functions: add ranges::ssize()
+P1971R0 Core Language Changes for NB Comments at the November, 2019 (Belfast) Meeting
+P1972R0 US105 Check satisfaction of constraints for non-templates when forming pointer to function
+P1973R0 Rename _default_init functions (NB Comment DE002)
+P1973R1 Rename _default_init functions (NB Comment DE002)
+P1974R0 Non-transient constexpr allocation using propconst
+P1975R0 Fixing the wording of parenthesized aggregate-initialization
+P1976R0 Fixed-size `span` construction from dynamic-size range
+P1976R1 Fixed-size 'span' construction from dynamic-size range
+P1976R2 Fixed-size 'span' construction from dynamic-size range
+P1978R0 Rename _default_init functions and do nothing more
+P1979R0 US086 Resolution
+P1980R0 Wording for CA 096
+P1981R0 Rename leap to leap_second
+P1982R0 Rename link to time_zone_link
+P1983R0 Wording for GB301, US296, US292, US291, and US283
+P1985R0 Universal template parameters
+P1985R1 Universal template parameters
+P1985R3 Universal template parameters
+P1988R0 Allow Templates in Local Classes
+P1988R1 Allow Templates in Local Classes
+P1989R0 Range constructor for std::string_view 2: Constrain Harder
+P1989R1 Range constructor for std::string_view 2: Constrain Harder
+P1989R2 Range constructor for std::string_view 2: Constrain Harder
+P1990R0 Add operator[] to std::initializer_list
+P1990R1 Add operator[] to std::initializer_list
+P1991R0 WG21 2019-11 Belfast Record of Discussion
+P1993R0 Restore factories to bulk_execute
+P1993R1 Restore shared state to bulk_execute
+P1994R0 elements_view needs its own sentinel
+P1994R1 elements_view needs its own sentinel
+P1995R0 Contracts - Use Cases
+P1995R1 Contracts - Use Cases
+P1996R0 Propagated template parameters
+P1997R0 Relaxing Restrictions on Arrays
+P1997R1 Relaxing Restrictions on Arrays
+P1998R0 Simple Facility for Lossless Integer Conversion
+P1998R1 Simple Facility for Lossless Integer Conversion
+P1999R0 Process proposal: double-check evolutionary material via a Tentatively Ready status
+P2000R0 Direction for ISO C++
+P2000R1 Direction for ISO C++
+P2000R2 Direction for ISO C++
+P2000R3 Direction for ISO C++
+P2000R4 Direction for ISO C++
+P2002R0 Defaulted comparison specification cleanups
+P2002R1 Defaulted comparison specification cleanups
+P2003R0 Fixing Internal and External Linkage Entities in Header Units
+P2004R0 Numbers and their Scopes
+P2005R0 A Brief 2D Graphics Review
+P2006R0 Eliminating heap-allocations in sender/receiver with connect()/start() as basis operations
+P2006R1 Eliminating heap-allocations in sender/receiver with connect()/start() as basis operations
+P2007R0 `std::from_chars` should work with `std::string_view`
+P2008R0 Enable variable template template parameters
+P2009R0 SG16: Unicode meeting summaries 2019-10-09 through 2019-12-11
+P2010R0 Remove iostream operators from P1889
+P2011R0 A pipeline-rewrite operator
+P2011R1 A pipeline-rewrite operator
+P2012R0 Fix the range-based for loop, Rev0ix the range-based for loop
+P2012R1 Fix the range-based for loop, Rev1
+P2012R2 Fix the range-based for loop, Rev2
+P2013R0 Freestanding Language: Optional ::operator new
+P2013R1 Freestanding Language: Optional ::operator new
+P2013R2 Freestanding Language: Optional ::operator new
+P2013R3 Freestanding Language: Optional ::operator new
+P2013R4 Freestanding Language: Optional ::operator new
+P2013R5 Freestanding Language: Optional ::operator new
+P2014R0 Proposed resolution for US061/US062 - aligned allocation of coroutine frames
+P2016R0 A step parameter for iota
+P2017R0 Conditionally safe ranges
+P2017R1 Conditionally borrowed ranges
+P2019R0 Usability improvements for std::thread
+P2019R1 Usability improvements for std::thread
+P2019R2 Usability improvements for std::thread
+P2019R3 Thread attributes
+P2019R4 Thread attributes
+P2019R5 Thread attributes
+P2020R0 Locales, Encodings and Unicode
+P2021R0 Negative zero strikes again
+P2022R0 Rangified version of lexicographical_compare_three_way
+P2022R1 Rangified version of lexicographical_compare_three_way
+P2022R2 Rangified version of lexicographical_compare_three_way
+P2022R3 Rangified version of lexicographical_compare_three_way
+P2024R0 Bloomberg Analysis of Unified Executors
+P2025R0 Guaranteed copy elision for named return objects
+P2025R1 Guaranteed copy elision for return variables
+P2025R2 Guaranteed copy elision for return variables
+P2026R0 A Constituent Study Group for Safety-Critical Applications
+P2027R0 Moved-from objects need not be valid
+P2028R0 What is ABI, and What Should WG21 Do About It?
+P2029R0 Proposed resolution for core issues 411, 1656, and 2333; escapes in character and string literals
+P2029R1 Proposed resolution for core issues 411, 1656, and 2333; escapes in character and string literals
+P2029R2 Proposed resolution for core issues 411, 1656, and 2333; escapes in character and string literals
+P2029R3 Proposed resolution for core issues 411, 1656, and 2333; escapes in character and string literals
+P2029R4 Proposed resolution for core issues 411, 1656, and 2333; escapes in character and string literals
+P2030R0 SG19: Machine Learning 2019/10/10-2020/01/09
+P2031R0 SG14: Meeting Minutes 2019/10/08-2020/01/07
+P2032R0 Contracts - What Came Before
+P2033R0 History of Executor Properties
+P2034R0 Partially Mutable Lambda Captures
+P2034R1 Partially Mutable Lambda Captures
+P2034R2 Partially Mutable Lambda Captures
+P2035R0 Value Proposition: Allocator-Aware (AA) Software
+P2036R0 Changing scope for lambda trailing-return-type
+P2036R1 Changing scope for lambda trailing-return-type
+P2036R2 Changing scope for lambda trailing-return-type
+P2036R3 Changing scope for lambda trailing-return-type
+P2037R0 String's gratuitous assignment
+P2037R1 String's gratuitous assignment
+P2038R0 Proposed nomenclature for contract-related proposals
+P2039R0 do_until Loop
+P2040R0 Reflection-based lazy-evaluation
+P2041R0 Deleting variable templates
+P2041R1 template = delete
+P2042R0 Alternate names for make_shared_default_init
+P2043R0 Don't constexpr All The Things
+P2044R0 Member Templates for Local Classes
+P2044R1 Member Templates for Local Classes
+P2044R2 Member Templates for Local Classes
+P2045R0 Missing Mandates for the standard library
+P2045R1 Missing Mandates for the standard library
+P2046R0 Rangify New Algorithms
+P2047R0 An allocator-aware optional type
+P2047R1 An allocator-aware optional type
+P2047R2 An allocator-aware optional type
+P2047R3 An allocator-aware optional type
+P2047R4 An allocator-aware optional type
+P2047R5 An allocator-aware optional type
+P2047R6 An allocator-aware optional type
+P2048R0 Prohibit zero and NULL from being used as null pointer literals
+P2049R0 Constraint refinement for special-cased functions
+P2050R0 Tweaks to the design of source code fragments
+P2051R0 C++ Library Issues to be moved in Prague
+P2052R0 Making modern C++ i/o a consistent API experience from bottom to top
+P2053R0 Defensive Checks Versus Input Validation
+P2053R1 Defensive Checks Versus Input Validation
+P2054R0 Audio I/O Software Use Cases
+P2054R1 Audio I/O Software Use Cases
+P2055R0 A Relaxed Guide to memory_order_relaxed
+P2057R0 SG14 SG19 Past, Present and Future status
+P2058R0 Make std::random_device Less Inscrutable
+P2059R0 Make Pseudo-random Numbers Portable
+P2060R0 Make Random Number Engines Seedable
+P2061R0 Sequential consistency for atomic memcpy
+P2062R0 The Circle Meta-model
+P2064R0 Assumptions
+P2065R0 naming and aliases
+P2066R0 Suggested draft TS for C++ Extensions for Transaction Memory Light
+P2066R1 Suggested draft TS for C++ Extensions for Transaction Memory Light
+P2066R2 Suggested draft TS for C++ Extensions for Transaction Memory Light
+P2066R3 Suggested draft TS for C++ Extensions for Transaction Memory Light
+P2066R4 Suggested draft TS for C++ Extensions for Minimal Transactional Memory
+P2066R5 Suggested draft TS for C++ Extensions for Minimal Transactional Memory
+P2066R6 Suggested draft TS for C++ Extensions for Minimal Transactional Memory
+P2066R7 Suggested draft TS for C++ Extensions for Minimal Transactional Memory
+P2066R8 Suggested draft TS for C++ Extensions for Minimal Transactional Memory
+P2066R9 Suggested draft TS for C++ Extensions for Minimal Transactional Memory
+P2066R10 Suggested draft TS for C++ Extensions for Minimal Transactional Memory
+P2067R0 Allowing trailing commas in ctor-initializer
+P2068R0 Using ?: to reduce the scope of constexpr-if
+P2069R0 Stackable, thread local, signal guards
+P2070R0 A case for optional and object_ptr
+P2071R0 Named universal character escapes
+P2071R1 Named universal character escapes
+P2071R2 Named universal character escapes
+P2072R0 Differentiable programming for C++
+P2072R1 Differentiable programming for C++
+P2073R0 Debugging C++ coroutines
+P2074R0 Asynchronous callstacks & coroutines
+P2075R0 Philox as an extension of the C++ RNG engines
+P2075R1 Philox as an extension of the C++ RNG engines
+P2075R2 Philox as an extension of the C++ RNG engines
+P2075R3 Philox as an extension of the C++ RNG engines
+P2076R0 Previous disagreements on Contracts
+P2077R0 Heterogeneous erasure overloads for associative containers
+P2077R1 Heterogeneous erasure overloads for associative containers
+P2077R2 Heterogeneous erasure overloads for associative containers
+P2077R3 Heterogeneous erasure overloads for associative containers
+P2078R0 Add new traits type std::is_complex
+P2079R0 Shared execution engine for executors
+P2079R1 Parallel Executor
+P2079R2 System execution context
+P2079R3 System execution context
+P2080R0 Polymorphic allocators: There is no such thing as One True Vocabulary Type
+P2081R0 Rebase the Library Fundamentals v3 TS on C++20
+P2081R1 Rebase the Library Fundamentals v3 TS on C++20
+P2082R0 Fixing CTAD for aggregates
+P2082R1 Fixing CTAD for aggregates
+P2085R0 Consistent defaulted comparisons
+P2087R0 Reflection Naming: fix reflexpr
+P2088R0 Reflection Naming: Reification
+P2089R0 Function parameter constraints are too fragile
+P2091R0 Issues with Range Access CPOs
+P2092R0 Disambiguating Nested-Requirements
+P2093R0 Formatted output
+P2093R1 Formatted output
+P2093R2 Formatted output
+P2093R3 Formatted output
+P2093R4 Formatted output
+P2093R5 Formatted output
+P2093R6 Formatted output
+P2093R7 Formatted output
+P2093R8 Formatted output
+P2093R9 Formatted output
+P2093R10 Formatted output
+P2093R11 Formatted output
+P2093R12 Formatted output
+P2093R13 Formatted output
+P2093R14 Formatted output
+P2095R0 Resolve lambda init-capture pack grammar (CWG2378)
+P2096R0 Generalized wording for partial specializations
+P2096R1 Generalized wording for partial specializations
+P2096R2 Generalized wording for partial specializations
+P2098R0 Proposing std::is_specialization_of
+P2098R1 Proposing std::is_specialization_of
+P2100R0 Keep unhandled_exception of a promise type mandatory - a response to US062 and FR066
+P2101R0 "Models" subsumes "satisfies" (Wording for US298 and US300)
+P2102R0 Make &quot;implicit expression variations&quot; more explicit (Wording for US185)
+P2103R0 Core Language Changes for NB Comments at the February, 2020 (Prague) Meeting
+P2104R0 Resolution for GB046 - Disallow changing concept values
+P2106R0 Alternative wording for GB315 and GB316
+P2107R0 Core issue 2436: US064 Copy semantics of coroutine parameters
+P2108R0 Core Language Working Group "ready" issues for the February, 2020 (Prague) meeting
+P2109R0 US084: Disallow "export import foo" outside of module interface
+P2113R0 Proposed resolution for 2019 comment CA 112
+P2114R0 Minimial Contract Use Cases
+P2115R0 US069: Merging of multiple definitions for unnamed unscoped enumerations
+P2116R0 Remove tuple-like protocol support from fixed-extent span
+P2117R0 C++ Standard Library Issues Resolved Directly In Prague
+P2119R0 Feedback on Simple Statistics functions
+P2120R0 Simplified structured bindings protocol with pack aliases
+P2123R0 interfaces: A Facility to Manage ABI/API Evolution
+P2125R0 The Ecosystem Expense of Vocabulary Types
+P2126R0 Unleashing the Power of Allocator-Aware (AA) Infrastructure
+P2128R0 Multidimensional subscript operator
+P2128R1 Multidimensional subscript operator
+P2128R2 Multidimensional subscript operator
+P2128R3 Multidimensional subscript operator
+P2128R4 Multidimensional subscript operator
+P2128R5 Multidimensional subscript operator
+P2128R6 Multidimensional subscript operator
+P2130R0 WG21 2020-02 Prague Record of Discussion
+P2131R0 Changes between C++17 and C++20
+P2132R0 Language Evolution status after Prague 2020
+P2133R0 The Incubator needs YOU!
+P2134R0 Kaizen*: keep improving together!
+P2136R0 invoke<R>
+P2136R1 invoke_r
+P2136R2 invoke_r
+P2136R3 invoke_r
+P2137R0 Goals and priorities for C++
+P2138R0 Rules of Design<=>Wording engagement
+P2138R1 Rules of Design<=>Wording engagement
+P2138R2 Rules of Design<=>Wording engagement
+P2138R3 Rules of Design <=> Specification engagement
+P2138R4 Rules of Design<=>Specification engagement
+P2139R0 Reviewing Deprecated Facilities of C++20 for C++23
+P2139R1 Reviewing Deprecated Facilities of C++20 for C++23
+P2139R2 Reviewing Deprecated Facilities of C++20 for C++23
+P2141R0 Aggregates are named tuples
+P2141R1 Aggregates are named tuples
+P2142R1 Allow '.' operator to work on pointers
+P2145R0 Evolving C++ Remotely
+P2145R1 Evolving C++ Remotely
+P2146R0 Modern std::byte stream IO for C++
+P2146R1 Modern std::byte stream IO for C++
+P2146R2 Modern std::byte stream IO for C++
+P2148R0 Library Evolution Design Guidelines
+P2149R0 Remove system_executor
+P2150R0 Down with typename in the library!
+P2152R0 Querying the alignment of an object
+P2152R1 Querying the alignment of an object
+P2155R0 Policy property for describing adjacency
+P2156R0 Allow Duplicate Attributes
+P2156R1 Allow Duplicate Attributes
+P2159R0 An Unbounded Decimal Floating-Point Type
+P2159R1 A Big Decimal Type
+P2160R0 Locks lock lockables (wording for LWG 2363)
+P2160R1 Locks lock lockables (wording for LWG 2363)
+P2161R0 Remove Default Candidate Executor
+P2161R1 Remove Default Candidate Executor
+P2161R2 Remove Default Candidate Executor
+P2162R0 Inheriting from std::variant (resolving LWG3052)
+P2162R1 Inheriting from std::variant (resolving LWG3052)
+P2162R2 Inheriting from std::variant (resolving LWG3052)
+P2163R0 Native tuples in C++
+P2164R0 views::enumerate
+P2164R1 views::enumerate
+P2164R2 views::enumerate
+P2164R3 views::enumerate
+P2164R4 views::enumerate
+P2164R5 views::enumerate
+P2164R6 views::enumerate
+P2164R7 views::enumerate
+P2164R8 views::enumerate
+P2164R9 views::enumerate
+P2165R0 Comparing pair and tuples
+P2165R1 Compatibility between tuple and tuple-like objects
+P2165R2 Compatibility between tuple, pair and tuple-like objects
+P2165R3 Compatibility between tuple, pair and tuple-like objects
+P2165R4 Compatibility between tuple, pair and tuple-like objects
+P2166R0 A Proposal to Prohibit std::basic_string and std::basic_string_view construction from nullptr
+P2166R1 A Proposal to Prohibit std::basic_string and std::basic_string_view construction from nullptr
+P2167R0 Improved Proposed Wording for LWG 2114
+P2167R1 Improved Proposed Wording for LWG 2114 (contextually convertible to bool)
+P2167R2 Improved Proposed Wording for LWG 2114 (contextually convertible to bool)
+P2167R3 Improved Proposed Wording for LWG 2114 (contextually convertible to bool)
+P2168R0 generator: A Synchronous Coroutine Generator Compatible With Ranges
+P2168R1 generator: A Synchronous Coroutine Generator Compatible With Ranges
+P2168R2 generator: A Synchronous Coroutine Generator Compatible With Ranges
+P2168R3 generator: A Synchronous Coroutine Generator Compatible With Ranges
+P2169R0 A Nice Placeholder With No Name
+P2169R1 A Nice Placeholder With No Name
+P2169R2 A Nice Placeholder With No Name
+P2169R3 A Nice Placeholder With No Name
+P2169R4 A Nice Placeholder With No Name
+P2170R0 Feedback on implementing the proposed std::error type
+P2171R0 Rebasing the Networking TS on C++20
+P2171R1 Rebasing the Networking TS on C++20 (revision 1)
+P2171R2 Rebasing the Networking TS on C++20 (revision 2)
+P2172R0 What do we want from a modularized Standard Library?
+P2173R0 Attributes on Lambda-Expressions
+P2173R1 Attributes on Lambda-Expressions
+P2174R0 Compound Literals
+P2174R1 Compound Literals
+P2175R0 Composable cancellation for sender-based async operations
+P2176R0 A different take on inexpressible conditions
+P2178R0 Misc lexing and string handling improvements
+P2178R1 Misc lexing and string handling improvements
+P2179R0 SG16: Unicode meeting summaries 2020-01-08 through 2020-05-27
+P2181R0 Correcting the Design of Bulk Execution
+P2181R1 Correcting the Design of Bulk Execution
+P2182R0 Contract Support: Defining the Minimum Viable Feature Set
+P2182R1 Contract Support: Defining the Minimum Viable Feature Set
+P2183R0 Executors Review: Properties
+P2184R0 Thriving in a crowded and changing world: C++ 2006-2020
+P2185R0 Contracts Use Case Categorization
+P2186R0 Removing Garbage Collection Support
+P2186R1 Removing Garbage Collection Support
+P2186R2 Removing Garbage Collection Support
+P2187R0 std::swap_if, std::predictable
+P2187R3 std::swap_if, std::predictable
+P2187R4 std::swap_if, std::predictable
+P2187R5 std::swap_if, std::predictable
+P2188R0 Zap the Zap: Pointers should just be bags of bits
+P2188R1 Zap the Zap: Pointers are sometimes just bags of bits
+P2191R0 Modules: ADL & GMFs do not play together well (anymore)
+P2192R0 std::valstat - function return type
+P2192R1 std::valstat - function return type
+P2192R2 std::valstat -Transparent Returns Handling
+P2192R3 std::valstat - Returns Handling
+P2193R0 How to structure a teaching topic
+P2193R1 How to structure a teaching topic
+P2194R0 The character set of the internal representation should be Unicode
+P2195R0 Electronic Straw Polls
+P2195R1 Electronic Straw Polls
+P2195R2 Electronic Straw Polls
+P2196R0 A lifetime-extending forwarder
+P2197R0 Formatting for std::complex
+P2198R0 Freestanding Feature-Test Macros and Implementation-Defined Extensions
+P2198R1 Freestanding Feature-Test Macros and Implementation-Defined Extensions
+P2198R2 Freestanding Feature-Test Macros and Implementation-Defined Extensions
+P2198R3 Freestanding Feature-Test Macros and Implementation-Defined Extensions
+P2198R4 Freestanding Feature-Test Macros and Implementation-Defined Extensions
+P2198R5 Freestanding Feature-Test Macros and Implementation-Defined Extensions
+P2198R6 Freestanding Feature-Test Macros and Implementation-Defined Extensions
+P2198R7 Freestanding Feature-Test Macros and Implementation-Defined Extensions
+P2199R0 Concepts to differentiate types
+P2201R0 Mixed string literal concatenation
+P2201R1 Mixed string literal concatenation
+P2202R0 Senders/Receivers group Executors review report
+P2203R0 LEWG Executors Customization Point Report
+P2205R0 Executors Review - Polymorphic Executor
+P2206R0 Executors Thread Pool review report
+P2207R0 Executors review: concepts breakout group report
+P2209R0 Bulk Schedule
+P2210R0 Superior String Splitting
+P2210R1 Superior String Splitting
+P2210R2 Superior String Splitting
+P2211R0 Exhaustiveness Checking for Pattern Matching
+P2212R0 Relax Requirements for time_point::clock
+P2212R1 Relax Requirements for time_point::clock
+P2212R2 Relax Requirements for time_point::clock
+P2213R0 Executors Naming
+P2213R1 Executors Naming
+P2214R0 A Plan for C++23 Ranges
+P2214R1 A Plan for C++23 Ranges
+P2214R2 A Plan for C++23 Ranges
+P2215R0 "Undefined behavior" and the concurrency memory model
+P2215R1 "Undefined behavior" and the concurrency memory model
+P2216R0 std::format improvements
+P2216R1 std::format improvements
+P2216R2 std::format improvements
+P2216R3 std::format improvements
+P2217R0 SG16: Unicode meeting summaries 2020-06-10 through 2020-08-26
+P2218R0 More flexible optional::value_or()
+P2219R0 P0443 Executors Issues Needing Resolution
+P2220R0 redefine properties in P0443
+P2221R0 define P0443 cpos with tag_invoke
+P2223R0 Trimming whitespaces before line splicing
+P2223R1 Trimming whitespaces before line splicing
+P2223R2 Trimming whitespaces before line splicing
+P2224R0 A Better bulk_schedule
+P2226R0 A function template to move from an object and reset it to its default constructed state
+P2227R0 Update normative reference to POSIX
+P2228R0 Slide Deck for P1949 EWG Presentation 20200924
+P2231R0 Add further constexpr support for optional/variant
+P2231R1 Add further constexpr support for optional/variant
+P2232R0 Zero-Overhead Deterministic Exceptions: Catching Values
+P2233R0 2020 Fall Library Evolution Polls
+P2233R1 2020 Fall Library Evolution Polls
+P2233R2 2020 Fall Library Evolution Polls
+P2233R3 2020 Fall Library Evolution Polls
+P2234R0 Consider a UB and IF-NDR Audit
+P2234R1 Consider a UB and IF-NDR Audit
+P2235R0 Disentangling schedulers and executors
+P2236R0 C++ Standard Library Issues to be moved in Virtual Plenary, Nov. 2020
+P2237R0 Metaprogramming
+P2238R0 Core Language Working Group "tentatively ready" issues for the November, 2020 meeting
+P2242R0 Non-literal variables (and labels and gotos) in constexpr functions
+P2242R1 Non-literal variables (and labels and gotos) in constexpr functions
+P2242R2 Non-literal variables (and labels and gotos) in constexpr functions
+P2242R3 Non-literal variables (and labels and gotos) in constexpr functions
+P2244R0 SG14: Low Latency/Games/Embedded/Finance/Simulation Meeting Minutes
+P2245R0 SG19: Machine Learning Meeting Minutes
+P2246R0 Character encoding of diagnostic text
+P2246R1 Character encoding of diagnostic text
+P2247R0 2020 Library Evolution Report
+P2247R1 2020 Library Evolution Report
+P2248R0 Enabling list-initialization for algorithms
+P2248R1 Enabling list-initialization for algorithms
+P2248R2 Enabling list-initialization for algorithms
+P2248R3 Enabling list-initialization for algorithms
+P2248R4 Enabling list-initialization for algorithms
+P2248R5 Enabling list-initialization for algorithms
+P2248R6 Enabling list-initialization for algorithms
+P2248R7 Enabling list-initialization for algorithms
+P2249R0 Mixed comparisons for smart pointers
+P2249R1 Mixed comparisons for smart pointers
+P2249R2 Mixed comparisons for smart pointers
+P2249R3 Mixed comparisons for smart pointers
+P2249R4 Mixed comparisons for smart pointers
+P2250R0 Scheduler vs Executor
+P2251R0 Require span & basic_string_view to be Trivially Copyable
+P2251R1 Require span & basic_string_view to be Trivially Copyable
+P2253R0 SG16: Unicode meeting summaries 2020-09-09 through 2020-11-11
+P2254R0 Executors Beyond Invocables
+P2255R0 A type trait to detect reference binding to temporary
+P2255R1 A type trait to detect reference binding to temporary
+P2255R2 A type trait to detect reference binding to temporary
+P2257R0 Blocking is an insufficient description for senders and receivers
+P2259R0 Repairing input range adaptors and counted_iterator
+P2259R1 Repairing input range adaptors and counted_iterator
+P2260R0 WG21 2020-11 Virtual Meeting Record of Discussion
+P2262R0 2020 Fall Library Evolution Poll Outcomes
+P2263R0 A call for a WG21 managed chat service
+P2263R1 A call for a WG21 managed chat service
+P2264R0 Make assert() macro user friendly for C and C++
+P2264R1 Make assert() macro user friendly for C and C++
+P2264R2 Make assert() macro user friendly for C and C++
+P2264R3 Make assert() macro user friendly for C and C++
+P2264R4 Make assert() macro user friendly for C and C++
+P2264R5 Make assert() macro user friendly for C and C++
+P2264R6 Make assert() macro user friendly for C and C++
+P2264R7 Make assert() macro user friendly for C and C++
+P2265R0 Renaming any_invocable
+P2265R1 Renaming any_invocable
+P2266R0 Simpler implicit move
+P2266R1 Simpler implicit move
+P2266R2 Simpler implicit move
+P2266R3 Simpler implicit move
+P2267R0 Library Evolution Policies
+P2267R1 Library Evolution Policies
+P2268R0 Freestanding Roadmap
+P2272R0 Safety & Security Review Board
+P2273R0 Making std::unique_ptr constexpr
+P2273R1 Making std::unique_ptr constexpr
+P2273R2 Making std::unique_ptr constexpr
+P2273R3 Making std::unique_ptr constexpr
+P2274R0 C and C++ Compatibility Study Group
+P2276R0 Fix std::cbegin(), std::ranges::cbegin, and cbegin() for span (fix of wrong fix of lwg3320)
+P2276R1 Fix cbegin
+P2277R0 Packs outside of Templates
+P2278R0 cbegin should always return a constant iterator
+P2278R1 cbegin should always return a constant iterator
+P2278R2 cbegin should always return a constant iterator
+P2278R3 cbegin should always return a constant iterator
+P2278R4 cbegin should always return a constant iterator
+P2279R0 We need a language mechanism for customization points
+P2280R0 Using unknown references in constant expressions
+P2280R1 Using unknown references in constant expressions
+P2280R2 Using unknown references in constant expressions
+P2280R3 Using unknown references in constant expressions
+P2280R4 Using unknown references in constant expressions
+P2281R0 Clarifying range adaptor objects
+P2281R1 Clarifying range adaptor objects
+P2283R0 constexpr for specialized memory algorithms
+P2283R1 constexpr for specialized memory algorithms
+P2283R2 constexpr for specialized memory algorithms
+P2285R0 Are default function arguments in the immediate context?
+P2286R0 Formatting Ranges
+P2286R1 Formatting Ranges
+P2286R2 Formatting Ranges
+P2286R3 Formatting Ranges
+P2286R4 Formatting Ranges
+P2286R5 Formatting Ranges
+P2286R6 Formatting Ranges
+P2286R7 Formatting Ranges
+P2286R8 Formatting Ranges
+P2287R0 Designated-initializers for base classes
+P2287R1 Designated-initializers for base classes
+P2287R2 Designated-initializers for base classes
+P2289R0 2021 Winter Library Evolution Polls
+P2290R0 Delimited escape sequences
+P2290R1 Delimited escape sequences
+P2290R2 Delimited escape sequences
+P2290R3 Delimited escape sequences
+P2291R0 Add Constexpr Modifiers to Functions to_chars and from_chars for Integral Types in Header
+P2291R1 Add Constexpr Modifiers to Functions to_chars and from_chars for Integral Types in Header
+P2291R2 Add Constexpr Modifiers to Functions to_chars and from_chars for Integral Types in Header
+P2291R3 Add Constexpr Modifiers to Functions to_chars and from_chars for Integral Types in Header
+P2295R0 Correct UTF-8 handling during phase 1 of translation
+P2295R1 Correct UTF-8 handling during phase 1 of translation
+P2295R2 Support for UTF-8 as a portable source file encoding
+P2295R3 Support for UTF-8 as a portable source file encoding
+P2295R4 Support for UTF-8 as a portable source file encoding
+P2295R5 Support for UTF-8 as a portable source file encoding
+P2295R6 Support for UTF-8 as a portable source file encoding
+P2297R0 Wording improvements for encodings and character sets
+P2299R0 `mdspan` and CTAD
+P2299R1 `mdspan` and CTAD
+P2299R2 `mdspan` and CTAD
+P2299R3 `mdspan`s of All Dynamic Extents
+P2300R0 std::execution
+P2300R1 std::execution
+P2300R2 std::execution
+P2300R3 `std::execution`
+P2300R4 std::execution
+P2300R5 `std::execution`
+P2300R6 `std::execution`
+P2300R7 `std::execution`
+P2301R0 Add a pmr alias for std::stacktrace
+P2301R1 Add a pmr alias for std::stacktrace
+P2302R0 Prefer std::ranges::contains over std::basic_string_view::contains
+P2302R1 std::ranges::contains
+P2302R2 std::ranges::contains
+P2302R3 std::ranges::contains
+P2302R4 std::ranges::contains
+P2303R0 Function literals and value closures
+P2303R1 Function literals and value closures
+P2303R2 Function literals and value closures
+P2303R3 Function literals and value closures
+P2303R4 Basic lambdas for C
+P2304R0 Improve type generic programming
+P2304R1 Improve type generic programming
+P2304R2 Improve type generic programming
+P2304R3 Improve type generic programming
+P2305R0 Type inference for variable definitions and function returns
+P2305R1 Type inference for variable definitions and function returns
+P2305R2 Type inference for variable definitions and function returns
+P2305R3 Type inference for variable definitions and function returns
+P2305R4 Type inference for variable definitions and function returns
+P2305R5 Type inference for object definitions
+P2306R0 Type-generic lambdas
+P2306R1 Type-generic lambdas
+P2306R2 Type-generic lambdas
+P2306R3 Type-generic lambdas
+P2307R0 Lvalue closures
+P2307R1 Lvalue closures
+P2307R2 Lvalue closures
+P2308R0 Template parameter initialization
+P2308R1 Template parameter initialization
+P2309R0 A common C/C++ core specification
+P2310R0 Revise spelling of keywords
+P2310R1 Revise spelling of keywords
+P2311R0 Make false and true first-class language features
+P2311R1 Make false and true first-class language features
+P2311R2 Make false and true first-class language features
+P2312R0 Introduce the nullptr constant
+P2312R1 Introduce the nullptr constant
+P2313R0 Core Language Working Group "tentatively ready" issues for the February, 2021 meeting
+P2314R0 Character sets and encodings
+P2314R1 Character sets and encodings
+P2314R2 Character sets and encodings
+P2314R3 Character sets and encodings
+P2314R4 Character sets and encodings
+P2315R0 C++ Standard Library Issues to be moved in Virtual Plenary, Feb. 2021
+P2316R0 Consistent character literal encoding
+P2316R1 Consistent character literal encoding
+P2316R2 Consistent character literal encoding
+P2317R0 C++ - An Invisible foundation of everything
+P2318R0 A Provenance-aware Memory Object Model for C
+P2318R1 A Provenance-aware Memory Object Model for C
+P2320R0 The Syntax of Static Reflection
+P2321R0 zip
+P2321R1 zip
+P2321R2 zip
+P2322R0 ranges::fold
+P2322R1 ranges::fold
+P2322R2 ranges::fold
+P2322R3 ranges::fold
+P2322R4 ranges::fold
+P2322R5 ranges::fold
+P2322R6 ranges::fold
+P2323R0 maybe_unused attribute for labels
+P2324R0 Labels at the end of compound statements (C compatibility)
+P2324R1 Labels at the end of compound statements (C compatibility)
+P2324R2 Labels at the end of compound statements (C compatibility)
+P2325R0 Views should not be required to be default constructible
+P2325R1 Views should not be required to be default constructible
+P2325R2 Views should not be required to be default constructible
+P2325R3 Views should not be required to be default constructible
+P2327R0 De-deprecating volatile compound assignment
+P2327R1 De-deprecating volatile compound operations
+P2328R0 join_view should join all views of ranges
+P2328R1 join_view should join all views of ranges
+P2329R0 Move, Copy, and Locality at Scale
+P2330R0 WG21 2021-02 Virtual Meeting Record of Discussion
+P2331R0 Unsequenced functions
+P2332R0 Establishing std::hive as replacement name for the proposed std::colony container
+P2333R0 2021 Winter Library Evolution Poll Outcomes
+P2334R0 Add support for preprocessing directives elifdef and elifndef
+P2334R1 Add support for preprocessing directives elifdef and elifndef
+P2337R0 Less constexpr for <cmath>
+P2338R0 Freestanding Library: Character primitives and the C library
+P2338R1 Freestanding Library: Character primitives and the C library
+P2338R2 Freestanding Library: Character primitives and the C library
+P2338R3 Freestanding Library: Character primitives and the C library
+P2338R4 Freestanding Library: Character primitives and the C library
+P2339R0 Contract violation handlers
+P2340R0 Clarifying the status of the ‘C headers’
+P2340R1 Clarifying the status of the "C headers"
+P2342R0 For a Few Punctuators More
+P2345R0 Relaxing Requirements of Moved-From Objects
+P2347R0 Argument type deduction for non-trailing parameter packs
+P2347R1 Argument type deduction for non-trailing parameter packs
+P2347R2 Argument type deduction for non-trailing parameter packs
+P2348R0 Whitespaces Wording Revamp
+P2348R1 Whitespaces Wording Revamp
+P2348R2 Whitespaces Wording Revamp
+P2348R3 Whitespaces Wording Revamp
+P2350R0 constexpr class
+P2350R1 constexpr class
+P2350R2 constexpr class
+P2351R0 Mark all library static cast wrappers as [[nodiscard]]
+P2352R0 SG16: Unicode meeting summaries 2020-12-09 through 2021-03-24
+P2353R0 Metaprograms and fragments are needed in comma-separated contexts
+P2355R0 Postfix fold expressions
+P2355R1 Postfix fold expressions
+P2356R0 Implementing Factory builder on top of P2320
+P2358R0 Defining Contracts
+P2360R0 Extend init-statement to allow alias-declaration
+P2361R0 Unevaluated string literals
+P2361R1 Unevaluated string literals
+P2361R2 Unevaluated strings
+P2361R3 Unevaluated strings
+P2361R4 Unevaluated strings
+P2361R5 Unevaluated strings
+P2361R6 Unevaluated strings
+P2362R0 Make obfuscating wide character literals ill-formed
+P2362R1 Remove non-encodable wide character literals and multicharacter wide character literals
+P2362R2 Remove non-encodable wide character literals and multicharacter wide character literals
+P2362R3 Remove non-encodable wide character literals and multicharacter wide character literals
+P2363R0 Extending associative containers with the remaining heterogeneous overloads
+P2363R1 Extending associative containers with the remaining heterogeneous overloads
+P2363R2 Extending associative containers with the remaining heterogeneous overloads
+P2363R3 Extending associative containers with the remaining heterogeneous overloads
+P2363R4 Extending associative containers with the remaining heterogeneous overloads
+P2363R5 Extending associative containers with the remaining heterogeneous overloads
+P2367R0 Remove misuses of list-initialization from Clause 24
+P2368R0 2021 Spring Library Evolution Polls
+P2368R1 2021 Spring Library Evolution Polls
+P2370R0 Stacktrace from exception
+P2370R1 Stacktrace from exception
+P2370R2 Stacktrace from exception
+P2372R0 Fixing locale handling in chrono formatters
+P2372R1 Fixing locale handling in chrono formatters
+P2372R2 Fixing locale handling in chrono formatters
+P2372R3 Fixing locale handling in chrono formatters
+P2374R0 views::cartesian_product
+P2374R1 views::cartesian_product
+P2374R2 views::cartesian_product
+P2374R3 views::cartesian_product
+P2374R4 views::cartesian_product
+P2375R0 Generalisation of nth_element to a range of nths
+P2375R1 Generalisation of nth_element to a range of nths
+P2376R0 Comments on Simple Statistical Functions (p1708r4): Contracts, Exceptions and Special cases
+P2377R0 [[nodiscard]] in the Standard Library: Clause 23 Iterators library
+P2378R0 Properly define blocks as part of the grammar
+P2378R1 Properly define blocks as part of the grammar
+P2380R0 reference_wrapper Associations
+P2380R1 reference_wrapper Associations
+P2381R0 Pattern Matching with Exception Handling
+P2382R0 Presentation Slides for P2123R0
+P2384R0 2021 Spring Library Evolution Poll Outcomes
+P2384R1 2021 Spring Library Evolution Poll Outcomes
+P2385R0 C++ Standard Library Issues to be moved in Virtual Plenary, June 2021
+P2386R0 Core Language Working Group "ready" Issues for the June, 2021 meeting
+P2387R0 Pipe support for user-defined range adaptors
+P2387R1 Pipe support for user-defined range adaptors
+P2387R2 Pipe support for user-defined range adaptors
+P2387R3 Pipe support for user-defined range adaptors
+P2388R0 Abort-only contract support
+P2388R1 Minimum Contract Support: either Ignore or Check_and_abort
+P2388R2 Minimum Contract Support: either Ignore or Check_and_abort
+P2388R3 Minimum Contract Support: either No_eval or Eval_and_abort
+P2388R4 Minimum Contract Support: either No_eval or Eval_and_abort
+P2390R0 Add annotations for unreachable control flow
+P2390R1 Add annotations for unreachable control flow
+P2390R2 Add annotations for unreachable control flow
+P2391R0 C23 Update Report
+P2392R0 Pattern matching using “is” and “as”
+P2392R1 Pattern matching using &quot;is&quot; and &quot;as&quot;
+P2392R2 Pattern matching using is and as
+P2393R0 Cleaning up integer-class types
+P2393R1 Cleaning up integer-class types
+P2395R0 WG21 2021-06 Virtual Meeting Record of Discussion
+P2396R0 Concurrency TS 2 fixes
+P2396R1 Concurrency TS 2 fixes
+P2397R0 SG16: Unicode meeting summaries 2021-04-14 through 2021-05-26
+P2400R0 Library Evolution Report
+P2400R1 Library Evolution Report: 2021-02-23 to 2021-05-25
+P2400R2 Library Evolution Report: 2021-06-01 to 2021-09-20
+P2400R3 Library Evolution Report: 2021-09-28 to 2022-01-25
+P2401R0 Add a conditional noexcept specification to std::exchange
+P2402R0 A free function linear algebra interface based on the BLAS (slides)
+P2403R0 Presentation on P2300 - std::execution
+P2404R0 Relaxing equality_comparable_with's and three_way_comparable_with's common reference requirements to
+P2404R1 Move-only types for equality_comparable_with, totally_ordered_with, and three_way_comparable_with
+P2404R2 Move-only types for equality_comparable_with, totally_ordered_with, and three_way_comparable_with
+P2404R3 Move-only types for equality_comparable_with, totally_ordered_with, and three_way_comparable_with
+P2405R0 nullopt_t and nullptr_t should both have operator and operator==
+P2406R0 Fix counted_iterator interaction with input iterators
+P2406R1 Fix counted_iterator interaction with input iterators
+P2406R2 Add lazy_counted_iterator
+P2406R3 Add lazy_counted_iterator
+P2406R4 Add lazy_counted_iterator
+P2406R5 Add lazy_counted_iterator
+P2407R0 Freestanding Library: Partial Classes
+P2407R1 Freestanding Library: Partial Classes
+P2407R2 Freestanding Library: Partial Classes
+P2407R3 Freestanding Library: Partial Classes
+P2407R4 Freestanding Library: Partial Classes
+P2407R5 Freestanding Library: Partial Classes
+P2408R0 Ranges views as inputs to non-Ranges algorithms
+P2408R1 Ranges views as inputs to non-Ranges algorithms
+P2408R2 Ranges iterators as inputs to non-Ranges algorithms
+P2408R3 Ranges iterators as inputs to non-Ranges algorithms
+P2408R4 Ranges iterators as inputs to non-Ranges algorithms
+P2408R5 Ranges iterators as inputs to non-Ranges algorithms
+P2409R0 Requirements for Usage of C++ Modules at Bloomberg
+P2410R0 Type-and-resource safety in modern C++
+P2411R0 Thoughts on pattern matching
+P2412R0 Minimal module support for the standard library
+P2413R0 Remove unsafe conversions of unique_ptr
+P2414R0 Pointer lifetime-end zap proposed solutions
+P2414R1 Pointer lifetime-end zap proposed solutions
+P2414R2 Pointer lifetime-end zap proposed solutions
+P2415R0 What is a view?
+P2415R1 What is a view?
+P2415R2 What is a view?
+P2416R0 Presentation of requirements in the standard library
+P2416R1 Presentation of requirements in the standard library
+P2416R2 Presentation of requirements in the standard library
+P2417R0 A more constexpr bitset
+P2417R1 A more constexpr bitset
+P2417R2 A more constexpr bitset
+P2418R0 Add support for std::generator-like types to std::format
+P2418R1 Add support for std::generator-like types to std::format
+P2418R2 Add support for std::generator-like types to std::format
+P2419R0 Clarify handling of encodings in localized formatting of chrono types
+P2419R1 Clarify handling of encodings in localized formatting of chrono types
+P2419R2 Clarify handling of encodings in localized formatting of chrono types
+P2420R0 2021 Summer Library Evolution Polls
+P2423R0 C Floating Point Study Group Liaison Report
+P2424R0 Abbreviated Parameters
+P2425R0 Expression Function Body
+P2428R0 Slides: BSI issues with P2300
+P2429R0 Concepts Error Messages for Humans
+P2430R0 Slides: Partial success scenarios with P2300
+P2431R0 Presentation: Plans for P2300 Revision 2
+P2432R0 Fixing istream_view
+P2432R1 Fix istream_view, Rev 1
+P2434R0 Nondeterministic pointer provenance
+P2435R0 2021 Summer Library Evolution Poll Outcomes
+P2435R1 2021 Summer Library Evolution Poll Outcomes
+P2436R0 2021 September Library Evolution Polls
+P2437R0 Support for #warning
+P2437R1 Support for #warning
+P2438R0 std::string::substr() &&
+P2438R1 std::string::substr() &&
+P2438R2 std::string::substr() &&
+P2439R0 Slides for P2415R1, what is a view?
+P2440R0 ranges::iota, ranges::shift_left, and ranges::shift_right
+P2440R1 ranges::iota, ranges::shift_left, and ranges::shift_right
+P2441R0 views::join_with
+P2441R1 views::join_with
+P2441R2 views::join_with
+P2442R0 Windowing range adaptors: views::chunk and views::slide
+P2442R1 Windowing range adaptors: views::chunk and views::slide
+P2443R0 views::chunk_by
+P2443R1 views::chunk_by
+P2444R0 The Asio asynchronous model
+P2445R0 forward_like
+P2445R1 forward_like
+P2446R0 views::move
+P2446R1 views::all_move
+P2446R2 views::as_rvalue
+P2447R0 std::span and the missing constructor
+P2447R1 std::span and the missing constructor
+P2447R2 std::span and the missing constructor
+P2447R3 std::span over an initializer list
+P2447R4 std::span over an initializer list
+P2447R5 std::span over an initializer list
+P2447R6 std::span over an initializer list
+P2448R0 Relaxing some constexpr restrictions
+P2448R1 Relaxing some constexpr restrictions
+P2448R2 Relaxing some constexpr restrictions
+P2450R0 C++ Standard Library Issues to be moved in Virtual Plenary, Oct. 2021
+P2451R0 2021 September Library Evolution Poll Outcomes
+P2452R0 2021 October Library Evolution and Concurrency Polls on Networking and Executors
+P2453R0 2021 October Library Evolution Poll Outcomes
+P2454R0 2021 November Library Evolution Polls
+P2455R0 2021 November Library Evolution Poll Outcomes
+P2456R0 2021 December Library Evolution Polls
+P2457R0 2021 December Library Evolution Poll Outcomes
+P2458R0 2022 January Library Evolution Polls
+P2458R1 2022 January Library Evolution Polls
+P2459R0 2022 January Library Evolution Poll Outcomes
+P2460R0 Relax requirements on wchar_t to match existing practices
+P2460R1 Relax requirements on wchar_t to match existing practices
+P2460R2 Relax requirements on wchar_t to match existing practices
+P2461R0 Closure-based Syntax for Contracts
+P2461R1 Closure-based Syntax for Contracts
+P2462R0 Core Language Working Group “ready” issues for the October, 2021 meeting
+P2463R0 Slides for P2444r0 The Asio asynchronous model
+P2464R0 Ruminations on networking and executors
+P2465R0 Standard Library Modules std and std.all
+P2465R1 Standard Library Modules std and std.compat
+P2465R2 Standard Library Modules std and std.compat
+P2465R3 Standard Library Modules std and std.compat
+P2466R0 The notes on contract annotations
+P2467R0 Support exclusive mode for fstreams
+P2467R1 Support exclusive mode for fstreams
+P2468R0 The Equality Operator You Are Looking For
+P2468R1 The Equality Operator You Are Looking For
+P2468R2 The Equality Operator You Are Looking For
+P2469R0 Response to P2464: The Networking TS is baked, P2300 Sender/Receiver is not.
+P2470R0 Slides for presentation of P2300R2: std::execution (sender/receiver)
+P2471R0 NetTS, ASIO and Sender Library Design Comparison
+P2471R1 NetTS, ASIO and Sender Library Design Comparison
+P2472R0 make_function_ref: A More Functional function_ref
+P2472R1 make function_ref more functional
+P2472R2 make function_ref more functional
+P2472R3 make function_ref more functional
+P2473R0 Distributing C++ Module Libraries
+P2473R1 Distributing C++ Module Libraries
+P2474R0 views::repeat
+P2474R1 views::repeat
+P2474R2 views::repeat
+P2475R0 WG21 2021-10 Virtual Meeting Record of Discussion
+P2477R0 Allow programmer to control and detect coroutine elision by static constexpr bool should_elide() and
+P2477R1 Allow programmer to control and detect coroutine elision by static constexpr bool must_elide() and
+P2477R2 Allow programmer to control and detect coroutine elision
+P2477R3 Allow programmers to control coroutine elision
+P2478R0 _Thread_local for better C++ interoperability with C
+P2479R0 Slides for P2464
+P2480R0 Response to P2471: "NetTS, Asio, and Sender library design comparison" - corrected and expanded
+P2481R0 Forwarding reference to specific type/template
+P2481R1 Forwarding reference to specific type/template
+P2481R2 Forwarding reference to specific type/template
+P2483R0 Support Non-copyable Types for single_view
+P2484R0 Extending class types as non-type template parameters
+P2485R0 Do not add value_exists and value_or to C++23
+P2486R0 Structured naming for function object and CPO values
+P2486R1 Structured naming for function object and CPO values
+P2487R0 Attribute-like syntax for contract annotations
+P2487R1 Is attribute-like syntax adequate for contract annotations?
+P2489R0 Library Evolution Plan for Completing C++23
+P2490R0 Zero-overhead exception stacktraces
+P2490R3 Zero-overhead exception stacktraces
+P2491R0 Text encodings follow-up
+P2492R0 Attending C++ Standards Committee Meetings During a Pandemic
+P2493R0 Missing feature test macros for C++20 core papers
+P2494R0 Relaxing range adaptors to allow for move only types
+P2494R1 Relaxing range adaptors to allow for move only types
+P2494R2 Relaxing range adaptors to allow for move only types
+P2495R0 Interfacing stringstreams with string_view
+P2495R1 Interfacing stringstreams with string_view
+P2495R2 Interfacing stringstreams with string_view
+P2495R3 Interfacing stringstreams with string_view
+P2497R0 Testing for success or failure of charconv functions
+P2498R0 Forward compatibility of text_encoding with additional encoding registries
+P2498R1 Forward compatibility of text_encoding with additional encoding registries
+P2499R0 string_view range constructor should be explicit
+P2500R0 C++17 parallel algorithms and P2300
+P2500R1 C++ parallel algorithms and P2300
+P2500R2 C++ parallel algorithms and P2300
+P2501R0 Undo the rename of views::move and views::as_const
+P2502R0 std::generator: Synchronous Coroutine Generator for Ranges
+P2502R1 std::generator: Synchronous Coroutine Generator for Ranges
+P2502R2 std::generator: Synchronous Coroutine Generator for Ranges
+P2504R0 Computations as a global solution to concurrency
+P2505R0 Monadic Functions for std::expected
+P2505R1 Monadic Functions for std::expected
+P2505R2 Monadic Functions for std::expected
+P2505R3 Monadic Functions for std::expected
+P2505R4 Monadic Functions for std::expected
+P2505R5 Monadic Functions for std::expected
+P2506R0 std::lazy: a coroutine for deferred execution
+P2507R0 Only [[assume]] conditional-expressions
+P2507R1 Limit [[assume]] to conditional-expressions
+P2508R0 Exposing std::basic-format-string
+P2508R1 Exposing std::basic-format-string
+P2508R2 Exposing std::basic-format-string
+P2509R0 A proposal for a type trait to detect value-preserving conversions
+P2510R0 Formatting pointers
+P2510R1 Formatting pointers
+P2510R2 Formatting pointers
+P2510R3 Formatting pointers
+P2511R0 Beyond operator(): NTTP callables in type-erased call wrappers
+P2511R1 Beyond operator(): NTTP callables in type-erased call wrappers
+P2511R2 Beyond operator(): NTTP callables in type-erased call wrappers
+P2512R0 SG16: Unicode meeting summaries 2021-06-09 through 2021-12-15
+P2513R0 char8_t Compatibility and Portability Fixes
+P2513R1 char8_t Compatibility and Portability Fix
+P2513R2 char8_t Compatibility and Portability Fix
+P2513R3 char8_t Compatibility and Portability Fix
+P2513R4 char8_t Compatibility and Portability Fix
+P2514R0 std::breakpoint
+P2515R0 std::is_debugger_present
+P2516R0 string_view is implicitly convertible from what?
+P2517R0 Add a conditional noexcept specification to std::apply
+P2517R1 Add a conditional noexcept specification to std::apply
+P2520R0 move_iterator should be a random access iterator
+P2521R0 Contract support — Working Paper
+P2521R1 Contract support — Working Paper
+P2521R2 Contract support - Working Paper
+P2521R3 Contract support — Record of SG21 consensus
+P2521R4 Contract support — Record of SG21 consensus
+P2521R5 Contract support — Record of SG21 consensus
+P2523R0 Request for re-inclusion of std::hive proposal in C++23
+P2524R0 SG14: Low Latency/Games/Embedded/Finance/Simulation 2020/12/09-2022/01/12
+P2525R0 SG19: Machine Learning Meeting Minutes 2020/12/10-2022/01/13
+P2527R0 std::variant_alternative_index and std::variant_alternative_index_v
+P2527R1 std::variant_alternative_index and std::tuple_element_index
+P2527R2 std::variant_alternative_index and std::tuple_element_index
+P2527R3 std::variant_alternative_index and std::tuple_element_index
+P2528R0 C/C++ Identifier Security using Unicode Standard Annex 39
+P2529R0 generator should have T&& reference_type
+P2530R0 Why Hazard Pointers should be in C++26
+P2530R1 Why Hazard Pointers should be in C++26
+P2530R2 Why Hazard Pointers should be in C++26
+P2530R3 Hazard Pointers for C++26
+P2531R0 C++ Standard Library Issues to be moved in Virtual Plenary, Feb. 2022
+P2532R0 Removing exception_ptr from the Receiver Concepts
+P2533R0 Core Language Working Group "ready" Issues for the February, 2022 meeting
+P2534R0 Slides: function_ref in the wild (P0792R7 presentation)
+P2535R0 Message fences
+P2536R0 Distributing C++ Module Libraries with dependencies json files.
+P2537R0 Relax va_start Requirements to Match C
+P2537R1 Relax va_start Requirements to Match C
+P2537R2 Relax va_start Requirements to Match C
+P2538R0 ADL-proof std::projected
+P2538R1 ADL-proof std::projected
+P2539R0 Should the output of std::print to a terminal be synchronized with the underlying stream?
+P2539R1 Should the output of std::print to a terminal be synchronized with the underlying stream?
+P2539R2 Should the output of std::print to a terminal be synchronized with the underlying stream?
+P2539R3 Should the output of std::print to a terminal be synchronized with the underlying stream?
+P2539R4 Should the output of std::print to a terminal be synchronized with the underlying stream?
+P2540R0 Empty Product for certain Views
+P2540R1 Empty Product for certain Views
+P2541R0 Consider renaming remove_quals
+P2542R0 views::concat
+P2542R1 views::concat
+P2542R2 views::concat
+P2542R3 views::concat
+P2542R4 views::concat
+P2542R5 views::concat
+P2542R6 views::concat
+P2542R7 views::concat
+P2544R0 C++ exceptions are becoming more and more problematic
+P2545R0 Why RCU Should be in C++26
+P2545R1 Why RCU Should be in C++26
+P2545R2 Why RCU Should be in C++26
+P2545R3 Why RCU Should be in C++26
+P2545R4 Read-Copy Update (RCU)
+P2546R0 Debugging Support
+P2546R1 Debugging Support
+P2546R2 Debugging Support
+P2546R3 Debugging Support
+P2546R4 Debugging Support
+P2546R5 Debugging Support
+P2547R0 Language support for customisable functions
+P2547R1 Language support for customisable functions
+P2548R0 copyable_function
+P2548R1 copyable_function
+P2548R2 copyable_function
+P2548R3 copyable_function
+P2548R4 copyable_function
+P2548R5 copyable_function
+P2548R6 copyable_function
+P2549R0 std::unexpected should have error() as member accessor
+P2549R1 std::unexpected should have error() as member accessor
+P2550R0 ranges::copy should say output_iterator somewhere
+P2551R0 Clarify intent of P1841 numeric traits
+P2551R1 Clarify intent of P1841 numeric traits
+P2551R2 Clarify intent of P1841 numeric traits
+P2552R0 On the ignorability of standard attributes
+P2552R1 On the ignorability of standard attributes
+P2552R2 On the ignorability of standard attributes
+P2552R3 On the ignorability of standard attributes
+P2553R0 Make mdspan size_type controllable
+P2553R1 Make mdspan size_type controllable
+P2554R0 C-Array Interoperability of MDSpan
+P2555R0 Naming improvements for std::execution
+P2555R1 Naming improvements for std::execution
+P2557R0 WG21 2022-02 Virtual Meeting Record of Discussion
+P2558R0 Add @, $, and ` to the basic character set
+P2558R1 Add @, $, and ` to the basic character set
+P2558R2 Add @, $, and ` to the basic character set
+P2559R0 Plan for Concurrency Technical Specification Version 2
+P2559R1 Plan for Concurrency Technical Specification Version 2
+P2560R0 Comparing value- and type-based reflection
+P2561R0 operator??
+P2561R1 An error propagation operator
+P2561R2 A control flow operator
+P2562R0 constexpr Stable Sorting
+P2562R1 constexpr Stable Sorting
+P2564R0 consteval needs to propagate up
+P2564R1 consteval needs to propagate up
+P2564R2 consteval needs to propagate up
+P2564R3 consteval needs to propagate up
+P2565R0 Supporting User-Defined Attributes
+P2568R0 Proposal of std::map::at_ptr
+P2569R0 *_HAS_SUBNORM==0 implies what?
+P2570R0 On side effects in contract annotations
+P2570R1 Contract predicates that are not predicates
+P2570R2 Contract predicates that are not predicates
+P2572R0 std::format() fill character allowances
+P2572R1 std::format() fill character allowances
+P2573R0 = delete("should have a reason");
+P2573R1 = delete("should have a reason");
+P2574R0 2022-05 Library Evolution Polls
+P2575R0 2022-05 Library Evolution Poll Outcomes
+P2576R0 The constexpr specifier for object definitions
+P2577R0 C++ Modules Discovery in Prebuilt Library Releases
+P2577R1 C++ Modules Discovery in Prebuilt Library Releases
+P2577R2 C++ Modules Discovery in Prebuilt Library Releases
+P2579R0 Mitigation strategies for P2036 “Changing scope for lambda trailing-return-type”
+P2580R0 Tuple protocol for C-style arrays T[N]
+P2581R0 Specifying the Interoperability of Binary Module Interface Files
+P2581R1 Specifying the Interoperability of Built Module Interface Files
+P2581R2 Specifying the Interoperability of Built Module Interface Files
+P2582R0 Wording for class template argument deduction from inherited constructors
+P2582R1 Wording for class template argument deduction from inherited constructors
+P2584R0 A More Composable from_chars
+P2585R0 Improving default container formatting
+P2585R1 Improving default container formatting
+P2586R0 Standard Secure Networking
+P2587R0 to_string or not to_string
+P2587R1 to_string or not to_string
+P2587R2 to_string or not to_string
+P2587R3 to_string or not to_string
+P2588R0 Relax std::barrier phase completion step guarantees
+P2588R1 Relax std::barrier phase completion step guarantees
+P2588R2 Relax std::barrier phase completion step guarantees
+P2588R3 Relax std::barrier phase completion step guarantees
+P2589R0 static operator[]
+P2589R1 static operator[]
+P2590R0 Explicit lifetime management
+P2590R1 Explicit lifetime management
+P2590R2 Explicit lifetime management
+P2591R0 Concatenation of strings and string views
+P2591R1 Concatenation of strings and string views
+P2591R2 Concatenation of strings and string views
+P2591R3 Concatenation of strings and string views
+P2591R4 Concatenation of strings and string views
+P2592R0 Hashing support for std::chrono value classes
+P2592R1 Hashing support for std::chrono value classes
+P2592R2 Hashing support for std::chrono value classes
+P2592R3 Hashing support for std::chrono value classes
+P2593R0 Allowing static_assert(false)
+P2593R1 Allowing static_assert(false)
+P2594R0 Slides: Allow programmer to control and detect coroutine elision (P2477R2 Presentation))
+P2594R1 Slides: Allow programmer to control coroutine elision (P2477R3 Presentation))
+P2596R0 Improve std::hive::reshape
+P2598R0 “Changing scope for lambda trailing-return-type” (P2036) should not be a DR
+P2599R0 mdspan::size_type should be index_type
+P2599R1 mdspan::size_type should be index_type
+P2599R2 index _type & size_type in mdspan
+P2600R0 A minimal ADL restriction to avoid ill-formed template instantiation
+P2601R0 To make redundant empty angle brackets optional for class template argument lists
+P2601R1 Make redundant empty angle brackets optional
+P2602R0 Poison Pills are Too Toxic
+P2602R1 Poison Pills are Too Toxic
+P2602R2 Poison Pills are Too Toxic
+P2603R0 member function pointer to function pointer
+P2603R1 member function pointer to function pointer
+P2604R0 MDSPAN: rename pointer and contiguous
+P2605R0 SG16: Unicode meeting summaries 2022-01-12 through 2022-06-08
+P2607R0 Let alignas specify minimum alignment
+P2608R0 Allow multiple init-statements
+P2609R0 Relaxing Ranges Just A Smidge
+P2609R1 Relaxing Ranges Just A Smidge
+P2609R2 Relaxing Ranges Just A Smidge
+P2609R3 Relaxing Ranges Just A Smidge
+P2610R0 2022-07 Library Evolution Polls
+P2611R0 2022-07 Library Evolution Poll Outcomes
+P2613R0 Add the missing `empty` to `mdspan`
+P2613R1 Add the missing `empty` to `mdspan`
+P2614R0 Deprecate numeric_limits::has_denorm
+P2614R1 Deprecate numeric_limits::has_denorm
+P2614R2 Deprecate numeric_limits::has_denorm
+P2615R0 Meaningful exports
+P2615R1 Meaningful exports
+P2616R0 Making std::atomic notification/wait operations usable in more situations
+P2616R1 Making std::atomic notification/wait operations usable in more situations
+P2616R2 Making std::atomic notification/wait operations usable in more situations
+P2616R3 Making std::atomic notification/wait operations usable in more situations
+P2616R4 Making std::atomic notification/wait operations usable in more situations
+P2617R0 Responses to NB comments on DTS 12907 "Extensions to C++ for Transactional Memory Version 2"
+P2618R0 C++ Standard Library Issues to be moved in Virtual Plenary, Jul. 2022
+P2620R0 Lifting artificial restriction on universal character names
+P2620R1 Lifting artificial restriction on universal character names
+P2620R2 Improve the wording for Universal Character Names in identifiers
+P2621R0 UB? In my Lexer?
+P2621R1 UB? In my Lexer?
+P2621R2 UB? In my Lexer?
+P2621R3 UB? In my Lexer?
+P2622R0 Core Language Working Group "ready" Issues for the July, 2022 meeting
+P2623R0 implicit constant initialization
+P2623R1 implicit constant initialization
+P2623R2 implicit constant initialization
+P2624R0 Make operations on bools more portable
+P2625R0 Slides: Life without operator() (P2511R1 presentation)
+P2626R0 charN_t incremental adoption: Casting pointers of UTF character types
+P2627R0 WG21 2022-07 Virtual Meeting Record of Discussion
+P2628R0 Extend barrier APIs with memory_order
+P2629R0 barrier token-less split arrive/wait
+P2630R0 Submdspan
+P2630R1 Submdspan
+P2630R2 Submdspan
+P2630R3 Submdspan
+P2630R4 Submdspan
+P2631R0 Publish TS Library Fundamentals v3 Now!
+P2632R0 A plan for better template meta programming facilities in C++26
+P2633R0 thread_local_inherit: Enhancing thread-local storage
+P2634R0 Allow qualifiers in constructor declarations
+P2635R0 Enhancing the break statement
+P2636R0 References to ranges should always be viewable
+P2636R1 References to ranges should always be viewable
+P2636R2 References to ranges should always be viewable
+P2637R0 Member visit and apply
+P2637R1 Member visit
+P2637R2 Member visit
+P2637R3 Member visit
+P2638R0 Intel's response to P1915R0 for std::simd parallelism in TS 2
+P2639R0 Static Allocations
+P2640R0 Modules: Inner-scope Namespace Entities: Exported or Not?
+P2640R1 Modules: Inner-scope Namespace Entities: Exported or Not?
+P2640R2 Modules: Inner-scope Namespace Entities: Exported or Not?
+P2641R0 Checking if a union alternative is active
+P2641R1 Checking if a union alternative is active
+P2641R2 Checking if a union alternative is active
+P2641R3 Checking if a union alternative is active
+P2641R4 Checking if a union alternative is active
+P2642R0 Padded mdspan layouts
+P2642R1 Padded mdspan layouts
+P2642R2 Padded mdspan layouts
+P2642R3 Padded mdspan layouts
+P2642R4 Padded mdspan layouts
+P2642R5 Padded mdspan layouts
+P2643R0 Improving C++ concurrency features
+P2643R1 Improving C++ concurrency features
+P2644R0 Get Fix of Broken Range-based for Loop Finally Done
+P2644R1 Final Fix of Broken Range based for Loop Rev 1
+P2646R0 Explicit Assumption Syntax Can Reduce Run Time
+P2647R0 Permitting static constexpr variables in constexpr functions
+P2647R1 Permitting static constexpr variables in constexpr functions
+P2648R0 2022-10 Library Evolution Polls
+P2649R0 2022-10 Library Evolution Poll Outcomes
+P2650R0 2022-11 Library Evolution Polls
+P2652R0 Disallow user specialization of allocator_traits
+P2652R1 Disallow user specialization of allocator_traits
+P2652R2 Disallow user specialization of allocator_traits
+P2653R0 Update Annex E based on Unicode 15.0 UAX 31
+P2653R1 Update Annex E based on Unicode 15.0 UAX 31
+P2654R0 Modules and Macros
+P2655R0 common_reference_t of reference_wrapper Should Be a Reference Type
+P2655R1 common_reference_t of reference_wrapper Should Be a Reference Type
+P2655R2 common_reference_t of reference_wrapper Should Be a Reference Type
+P2655R3 common_reference_t of reference_wrapper Should Be a Reference Type
+P2656R0 C++ Ecosystem International Standard
+P2656R1 C++ Ecosystem International Standard
+P2656R2 C++ Ecosystem International Standard
+P2657R0 C++ is the next C++
+P2657R1 C++ is the next C++
+P2658R0 temporary storage class specifiers
+P2658R1 temporary storage class specifiers
+P2659R0 A Proposal to Publish a Technical Specification for Contracts
+P2659R1 A Proposal to Publish a Technical Specification for Contracts
+P2659R2 A Proposal to Publish a Technical Specification for Contracts
+P2660R0 Proposed Contracts TS
+P2661R0 Miscellaneous amendments to the Contracts TS
+P2662R0 Pack Indexing
+P2662R1 Pack Indexing
+P2662R2 Pack Indexing
+P2662R3 Pack Indexing
+P2663R0 Proposal to support interleaved complex values in std::simd
+P2663R1 Proposal to support interleaved complex values in std::simd
+P2663R2 Proposal to support interleaved complex values in std::simd
+P2663R3 Proposal to support interleaved complex values in std::simd
+P2663R4 Proposal to support interleaved complex values in std::simd
+P2663R5 Proposal to support interleaved complex values in std::simd
+P2664R0 Proposal to extend std::simd with permutation API
+P2664R1 Proposal to extend std::simd with permutation API
+P2664R2 Proposal to extend std::simd with permutation API
+P2664R3 Proposal to extend std::simd with permutation API
+P2664R4 Proposal to extend std::simd with permutation API
+P2664R5 Proposal to extend std::simd with permutation API
+P2664R6 Proposal to extend std::simd with permutation API
+P2665R0 Allow calling overload sets containing T, constT&
+P2666R0 Last use optimization
+P2667R0 Support for static and SBO vectors by allocators
+P2668R0 Role based parameter passing
+P2669R0 Deprecate changing kind of names in class template specializations
+P2670R0 Non-transient constexpr allocation
+P2670R1 Non-transient constexpr allocation
+P2671R0 Syntax choices for generalized pack declaration and usage
+P2672R0 Exploring the Design Space for a Pipeline Operator
+P2673R0 Common Description Format for C++ Libraries and Packages
+P2674R0 A trait for implicit lifetime types
+P2674R1 A trait for implicit lifetime types
+P2675R0 LWG3780: The Paper (format's width estimation is too approximate and not forward compatible)
+P2675R1 LWG3780: The Paper (format's width estimation is too approximate and not forward compatible)
+P2676R0 The Val Object Model
+P2677R0 Reconsidering concepts in-place syntax
+P2677R2 Reconsidering concepts in-place syntax
+P2678R0 SG16: Unicode meeting summaries 2022-06-22 through 2022-09-28
+P2679R0 Fixing std::start_lifetime_as for arrays
+P2679R1 Fixing std::start_lifetime_as and std::start_lifetime_as_array
+P2679R2 Fixing std::start_lifetime_as and std::start_lifetime_as_array
+P2680R0 Contracts for C++: Prioritizing Safety
+P2680R1 Contracts for C++: Prioritizing Safety
+P2681R0 More Stats Functions
+P2681R1 More Basic Statistics
+P2682R0 Transactional Memory TS2 Editor's Report
+P2683R0 SG14: Low Latency/Games/Embedded/Finance/Simulation virtual meeting minutes 2022/02/09-2022/10/12
+P2684R0 SG19: Machine Learning Virtual Meeting Minutes 2022/02/10-2022/10/13
+P2685R0 Language Support For Scoped Allocators
+P2685R1 Language Support For Scoped Objects
+P2686R0 Updated wording and implementation experience for P1481 (constexpr structured bindings)
+P2686R1 constexpr structured bindings and references to constexpr variables
+P2686R2 constexpr structured bindings and references to constexpr variables
+P2687R0 Design Alternatives for Type-and-Resource Safe C++
+P2688R0 Pattern Matching Discussion for Kona 2022
+P2689R0 atomic_accessor
+P2689R1 atomic_accessor
+P2689R2 atomic_accessor
+P2690R0 C++17 parallel algorithms and P2300
+P2690R1 Presentation for C++17 parallel algorithms and P2300
+P2691R0 Allow referencing inline functions with internal linkage from outside their defining header unit
+P2692R0 Generic Programming is just Programming
+P2693R0 Formatting thread::id and stacktrace
+P2693R1 Formatting thread::id and stacktrace
+P2695R0 A proposed plan for contracts in C++
+P2695R1 A proposed plan for contracts in C++
+P2696R0 Introduce Cpp17Swappable as additional convenience requirements
+P2697R0 Interfacing bitset with string_view
+P2697R1 Interfacing bitset with string_view
+P2698R0 Unconditional termination is a serious problem
+P2700R0 Questions on P2680 “Contracts for C++: Prioritizing Safety”
+P2700R1 Questions on P2680 "Contracts for C++: Prioritizing Safety"
+P2701R0 Translating Linker Input Files to Module Metadata Files
+P2702R0 Specifying Importable Headers
+P2703R0 C++ Standard Library Ready Issues to be moved in Kona, Nov. 2022
+P2704R0 C++ Standard Library Immediate Issues to be moved in Kona, Nov. 2022
+P2705R0 C++ Library Fundamentals TS Issues to be moved in Kona, Nov. 2022
+P2706R0 Drafting for US 26-061: Redundant specification for defaulted functions
+P2708R0 No Future Fundamentals TSes
+P2708R1 No Future Fundamentals TSes
+P2709R0 Core Language Working Group “ready” Issues for the November, 2022 meeting
+P2710R0 Core Language Working Group NB comment resolutions for the November, 2022 meeting
+P2711R0 Making multi-param (and other converting) constructors of views explicit
+P2711R1 Making multi-param constructors of views explicit
+P2712R0 Classification of Contract-Checking Predicates
+P2713R0 Escaping improvements in std::format
+P2713R1 Escaping improvements in std::format
+P2714R0 Bind front and back to NTTP callables
+P2714R1 Bind front and back to NTTP callables
+P2717R0 Tool Introspection
+P2717R1 Tool Introspection
+P2717R2 Tool Introspection
+P2717R3 Tool Introspection
+P2717R4 Tool Introspection
+P2717R5 Tool Introspection
+P2718R0 Wording for P2644R1 Fix for Range-based for Loop
+P2722R0 Slides: Beyond operator() (P2511R2 presentation)
+P2723R0 Zero-initialize objects of automatic storage duration
+P2723R1 Zero-initialize objects of automatic storage duration
+P2724R0 constant dangling
+P2724R1 constant dangling
+P2725R0 std::integral_constant Literals
+P2725R1 std::integral_constant Literals
+P2726R0 Better std::tuple Indexing
+P2727R0 std::iterator_interface
+P2727R1 std::iterator_interface
+P2727R2 std::iterator_interface
+P2727R3 std::iterator_interface
+P2728R0 Unicode in the Library, Part 1: UTF Transcoding
+P2728R1 Unicode in the Library, Part 1: UTF Transcoding
+P2728R2 Unicode in the Library, Part 1: UTF Transcoding
+P2728R3 Unicode in the Library, Part 1: UTF Transcoding
+P2728R4 Unicode in the Library, Part 1: UTF Transcoding
+P2728R5 Unicode in the Library, Part 1: UTF Transcoding
+P2728R6 Unicode in the Library, Part 1: UTF Transcoding
+P2729R0 Unicode in the Library, Part 2: Normalization
+P2730R0 variable scope
+P2730R1 variable scope
+P2732R0 WG21 November 2022 Kona meeting Record of Discussion
+P2733R0 Fix handling of empty specifiers in std::format
+P2733R1 Fix handling of empty specifiers in std::format
+P2733R2 Fix handling of empty specifiers in std::format
+P2733R3 Fix handling of empty specifiers in std::format
+P2734R0 Adding the new 2022 SI prefixes
+P2735R0 C xor C++ Programming
+P2736R0 Referencing the Unicode Standard
+P2736R2 Referencing the Unicode Standard
+P2737R0 Proposal of Condition-centric Contracts Syntax
+P2738R0 constexpr cast from void*: towards constexpr type-erasure
+P2738R1 constexpr cast from void*: towards constexpr type-erasure
+P2739R0 A call to action: Think seriously about "safety" then do something sensible about it
+P2740R0 Simpler implicit dangling resolution
+P2740R1 Simpler implicit dangling resolution
+P2740R2 Simpler implicit dangling resolution
+P2741R0 user-generated static_assert messages
+P2741R1 user-generated static_assert messages
+P2741R2 user-generated static_assert messages
+P2741R3 user-generated static_assert messages
+P2742R0 indirect dangling identification
+P2742R1 indirect dangling identification
+P2742R2 indirect dangling identification
+P2743R0 Contracts for C++: Prioritizing Safety - Presentation slides of P2680R0
+P2746R0 Deprecate and Replace Fenv Rounding Modes
+P2746R1 Deprecate and Replace Fenv Rounding Modes
+P2746R2 Deprecate and Replace Fenv Rounding Modes
+P2746R3 Deprecate and Replace Fenv Rounding Modes
+P2747R0 Limited support for constexpr void*
+P2747R1 constexpr placement new
+P2748R0 Disallow Binding a Returned glvalue to a Temporary
+P2748R1 Disallow Binding a Returned Glvalue to a Temporary
+P2748R2 Disallow Binding a Returned Glvalue to a Temporary
+P2748R3 Disallow Binding a Returned Glvalue to a Temporary
+P2748R4 Disallow Binding a Returned Glvalue to a Temporary
+P2749R0 Down with "character"
+P2750R0 C Dangling Reduction
+P2750R1 C Dangling Reduction
+P2750R2 C Dangling Reduction
+P2751R0 Evaluation of Checked Contracts
+P2751R1 Evaluation of Checked Contracts
+P2752R0 Static storage for braced initializers
+P2752R1 Static storage for braced initializers
+P2752R2 Static storage for braced initializers
+P2752R3 Static storage for braced initializers
+P2754R0 Deconstructing Avoiding Uninitialized Reads of Auto Variables
+P2755R0 A Bold Plan for a Complete Contracts Facility
+P2756R0 Proposal of Simple Contract Side Effect Semantics
+P2757R0 Type checking format args
+P2757R1 Type checking format args
+P2757R2 Type checking format args
+P2757R3 Type checking format args
+P2758R0 Emitting messages at compile time
+P2758R1 Emitting messages at compile time
+P2759R0 DG Opinion on Safety for ISO C++
+P2759R1 DG Opinion on Safety for ISO C++
+P2760R0 A Plan for C++26 Ranges
+P2760R1 A Plan for C++26 Ranges
+P2761R0 Slides: If structured binding (P0963R1 presentation)
+P2762R0 Sender/Receiver Interface For Networking
+P2762R1 Sender/Receiver Interface For Networking
+P2762R2 Sender/Receiver Interface For Networking
+P2763R0 `layout_stride` static extents default constructor fix
+P2763R1 `layout_stride` static extents default constructor fix
+P2764R0 SG14: Low Latency/Games/Embedded/Finance/Simulation virtual meeting minutes 2023/01/11
+P2765R0 SG19: Machine Learning Virtual Meeting Minutes 2022/12/08-2023/01/12
+P2766R0 SG16: Unicode meeting summaries 2022-10-12 through 2022-12-14
+P2767R0 flat_map/flat_set omnibus
+P2767R1 flat_map/flat_set omnibus
+P2767R2 flat_map/flat_set omnibus
+P2769R0 get_element customization point object
+P2769R1 get_element customization point object
+P2770R0 Stashing stashing iterators for proper flattening
+P2771R0 Towards memory safety in C++
+P2771R1 Towards memory safety in C++
+P2772R0 std::integral_constant literals do not suffice - constexpr_t?
+P2773R0 Considerations for Unicode algorithms
+P2774R0 Scoped thread-local storage
+P2774R1 Concurrent object pool (was: Scoped thread-local storage)
+P2775R0 2023-05 Library Evolution Polls
+P2776R0 2023-05 Library Evolution Poll Outcomes
+P2779R0 Make basic_string_view's range construction conditionally explicit
+P2779R1 Make basic_string_view's range construction conditionally explicit
+P2780R0 Caller-side precondition checking, and Eval_and_throw
+P2781R1 std::constexpr_v
+P2781R2 std::constexpr_v
+P2781R3 std::constexpr_v
+P2782R0 A proposal for a type trait to detect if value initialization can be achieved by zero-filling
+P2784R0 Not halting the program after detected contract violation
+P2785R0 Relocating prvalues
+P2785R1 Relocating prvalues
+P2785R2 Relocating prvalues
+P2785R3 Relocating prvalues
+P2786R0 Trivial relocatability options
+P2786R1 Trivial relocatability options
+P2786R2 Trivial relocatability options
+P2786R3 Trivial Relocatability For C++26
+P2787R0 pmr::generator - Promise Types are not Values
+P2787R1 pmr::generator - Promise Types are not Values
+P2788R0 Linkage for modular constants
+P2789R0 C++ Standard Library Ready Issues to be moved in Issaquah, Feb. 2023
+P2790R0 C++ Standard Library Immediate Issues to be moved in Issaquah, Feb. 2023
+P2791R0 mandate concepts for new features
+P2795R0 Correct and incorrect code, and &quot;erroneous behaviour&quot;
+P2795R1 Erroneous behaviour for uninitialized reads
+P2795R2 Erroneous behaviour for uninitialized reads
+P2795R3 Erroneous behaviour for uninitialized reads
+P2795R4 Erroneous behaviour for uninitialized reads
+P2796R0 Core Language Working Group "ready" Issues for the February, 2023 meeting
+P2797R0 Proposed resolution for CWG2692 Static and explicit object member functions with the same par
+P2798R0 Fix layout mappings all static extent default constructor
+P2799R0 Closed ranges may be a problem; breaking counted_iterator is not the solution
+P2800R0 Dependency flag soup needs some fiber
+P2802R0 Presentation of P1385R7 to LEWG at Issaquah 2023
+P2803R0 std::simd Intro slides
+P2805R0 fiber_context: fibers without scheduler - LEWG slides
+P2806R0 do expressions
+P2806R1 do expressions
+P2806R2 do expressions
+P2807R0 Issaquah Slides for Intel response to std::simd
+P2808R0 Internal linkage in the global module
+P2809R0 Trivial infinite loops are not Undefined Behavior
+P2809R1 Trivial infinite loops are not Undefined Behavior
+P2809R2 Trivial infinite loops are not Undefined Behavior
+P2810R0 is_debugger_present is_replaceable
+P2810R1 is_debugger_present is_replaceable
+P2810R2 is_debugger_present is_replaceable
+P2810R3 is_debugger_present is_replaceable
+P2811R0 Contract Violation Handlers
+P2811R1 Contract Violation Handlers
+P2811R2 Contract Violation Handlers
+P2811R3 Contract Violation Handlers
+P2811R4 Contract Violation Handlers
+P2811R5 Contract-Violation Handlers
+P2811R6 Contract-Violation Handlers
+P2811R7 Contract-Violation Handlers
+P2812R0 P1673R11 LEWG presentation
+P2814R0 Trivial Relocatability --- Comparing P1144 with P2786
+P2814R1 Trivial Relocatability --- Comparing P1144 with P2786
+P2815R0 Slides for presentation on P2188R1
+P2816R0 Safety Profiles: Type-and-resource Safe programming in ISO Standard C++
+P2817R0 The idea behind the contracts MVP
+P2818R0 Uniform Call Syntax for explicit-object member functions
+P2819R0 Add tuple protocol to complex
+P2819R1 Add tuple protocol to complex
+P2819R2 Add tuple protocol to complex
+P2821R0 span.at()
+P2821R1 span.at()
+P2821R2 span.at()
+P2821R3 span.at()
+P2821R4 span.at()
+P2821R5 span.at()
+P2824R0 WG21 February 2023 Issaquah meeting Record of Discussion
+P2825R0 calltarget(unevaluated-call-expression)
+P2826R0 Replacement functions
+P2826R1 Replacement functions
+P2827R0 Floating-point overflow and underflow in from_chars (LWG 3081)
+P2827R1 Floating-point overflow and underflow in from_chars (LWG 3081)
+P2828R0 Copy elision for direct-initialization with a conversion function (Core issue 2327)
+P2828R1 Copy elision for direct-initialization with a conversion function (Core issue 2327)
+P2828R2 Copy elision for direct-initialization with a conversion function (Core issue 2327)
+P2829R0 Proposal of Contracts Supporting Const-On-Definition Style
+P2830R0 constexpr type comparison
+P2830R1 constexpr type comparison
+P2831R0 Functions having a narrow contract should not be noexcept
+P2833R0 Freestanding Library: inout expected span
+P2833R1 Freestanding Library: inout expected span
+P2833R2 Freestanding Library: inout expected span
+P2834R0 Semantic Stability Across Contract-Checking Build Modes
+P2834R1 Semantic Stability Across Contract-Checking Build Modes
+P2835R0 Expose std::atomic_ref's object address
+P2835R1 Expose std::atomic_ref's object address
+P2835R2 Expose std::atomic_ref's object address
+P2836R0 std::const_iterator often produces an unexpected type
+P2836R1 std::basic_const_iterator should follow its underlying type's convertibility
+P2837R0 Planning to Revisit the Lakos Rule
+P2838R0 Unconditional contract violation handling of any kind is a serious problem
+P2839R0 Nontrivial relocation via a new "owning reference" type
+P2841R0 Concept Template Parameters
+P2841R1 Concept Template Parameters
+P2842R0 Destructor Semantics Do Not Affect Constructible Traits
+P2843R0 Preprocessing is never undefined
+P2845R0 Formatting of std::filesystem::path
+P2845R1 Formatting of std::filesystem::path
+P2845R2 Formatting of std::filesystem::path
+P2845R3 Formatting of std::filesystem::path
+P2845R4 Formatting of std::filesystem::path
+P2845R5 Formatting of std::filesystem::path
+P2846R0 size_hint: Eagerly reserving memory for not-quite-sized lazy ranges
+P2846R1 size_hint: Eagerly reserving memory for not-quite-sized lazy ranges
+P2848R0 std::is_uniqued
+P2850R0 Minimal Compiler Preserved Dependencies
+P2852R0 Contract violation handling semantics for the contracts MVP
+P2853R0 Proposal of std::contract_violation
+P2855R0 Member customization points for Senders and Receivers
+P2857R0 P2596R0 Critique
+P2858R0 Noexcept vs contract violations
+P2861R0 The Lakos Rule: Narrow Contracts And `noexcept` Are Inherently Incompatible
+P2862R0 text_encoding::name() should never return null values
+P2862R1 text_encoding::name() should never return null values
+P2863R0 Review Annex D for C++26
+P2863R1 Review Annex D for C++26
+P2863R2 Review Annex D for C++26
+P2863R3 Review Annex D for C++26
+P2864R0 Remove Deprecated Arithmetic Conversion on Enumerations From C++26
+P2864R1 Remove Deprecated Arithmetic Conversion on Enumerations From C++26
+P2864R2 Remove Deprecated Arithmetic Conversion on Enumerations From C++26
+P2865R0 Remove Deprecated Array Comparisons from C++26
+P2865R1 Remove Deprecated Array Comparisons from C++26
+P2865R2 Remove Deprecated Array Comparisons from C++26
+P2865R3 Remove Deprecated Array Comparisons from C++26
+P2865R4 Remove Deprecated Array Comparisons from C++26
+P2866R0 Remove Deprecated Volatile Features From C++26
+P2866R1 Remove Deprecated Volatile Features From C++26
+P2867R0 Remove Deprecated strstreams From C++26
+P2867R1 Remove Deprecated strstreams From C++26
+P2868R0 Remove Deprecated `std::allocator` Typedef From C++26
+P2868R1 Remove Deprecated `std::allocator` Typedef From C++26
+P2868R2 Remove Deprecated `std::allocator` Typedef From C++26
+P2868R3 Remove Deprecated `std::allocator` Typedef From C++26
+P2869R0 Remove Deprecated `shared_ptr` Atomic Access APIs From C++26
+P2869R1 Remove Deprecated `shared_ptr` Atomic Access APIs From C++26
+P2869R2 Remove Deprecated `shared_ptr` Atomic Access APIs From C++26
+P2869R3 Remove Deprecated `shared_ptr` Atomic Access APIs From C++26
+P2870R0 Remove `basic_string::reserve()` From C++26
+P2870R1 Remove `basic_string::reserve()` From C++26
+P2870R2 Remove `basic_string::reserve()` From C++26
+P2870R3 Remove `basic_string::reserve()` From C++26
+P2871R0 Remove Deprecated Unicode Conversion Facets From C++26
+P2871R1 Remove Deprecated Unicode Conversion Facets From C++26
+P2871R2 Remove Deprecated Unicode Conversion Facets From C++26
+P2871R3 Remove Deprecated Unicode Conversion Facets From C++26
+P2872R0 Remove `wstring_convert` From C++26
+P2872R1 Remove `wstring_convert` From C++26
+P2872R2 Remove `wstring_convert` From C++26
+P2873R0 Remove Deprecated locale category facets for Unicode from C++26
+P2874R0 Mandating Annex D
+P2874R1 Mandating Annex D
+P2874R2 Mandating Annex D
+P2875R0 Undeprecate `polymorphic_allocator::destroy` For C++26
+P2875R1 Undeprecate `polymorphic_allocator::destroy` For C++26
+P2875R2 Undeprecate `polymorphic_allocator::destroy` For C++26
+P2876R0 Proposal to extend std::simd with more constructors and accessors
+P2877R0 Contract Build Modes and Semantics
+P2878R0 Reference checking
+P2878R1 Reference checking
+P2878R2 Reference checking
+P2878R3 Reference checking
+P2878R4 Reference checking
+P2878R5 Reference checking
+P2878R6 Reference checking
+P2880R0 Algorithm-like vs std::simd based RNG API
+P2881R0 Generator-based for loop
+P2882R0 An Event Model for C++ Executors
+P2883R0 `offsetof` Should Be A Keyword In C++26
+P2884R0 `assert` Should Be A Keyword In C++26
+P2885R0 Requirements for a Contracts syntax
+P2885R1 Requirements for a Contracts syntax
+P2885R2 Requirements for a Contracts syntax
+P2885R3 Requirements for a Contracts syntax
+P2886R0 Concurrency TS2 Editor's report
+P2887R0 SG14: Low Latency/Games/Embedded/Finance/Simulation virtual meeting minutes to 2023/05/11
+P2888R0 SG19: Machine Learning Virtual Meeting Minutes to 2023/05/12
+P2889R0 Distributed Arrays
+P2890R0 Contracts on lambdas
+P2890R1 Contracts on lambdas
+P2890R2 Contracts on lambdas
+P2891R0 SG16: Unicode meeting summaries 2023-01-11 through 2023-05-10
+P2892R0 std::simd Types Should be Regular
+P2893R0 Variadic Friends
+P2893R1 Variadic Friends
+P2894R0 Constant evaluation of Contracts
+P2894R1 Constant evaluation of Contracts
+P2894R2 Constant evaluation of Contracts
+P2895R0 noncopyable and nonmoveable utility classes
+P2896R0 Outstanding design questions for the Contracts MVP
+P2897R0 aligned_accessor: An mdspan accessor expressing pointer overalignment
+P2897R1 aligned_accessor: An mdspan accessor expressing pointer overalignment
+P2898R0 Importable Headers are Not Universally Implementable
+P2898R1 Build System Requirements for Importable Headers
+P2900R0 Contracts for C++
+P2900R1 Contracts for C++
+P2900R2 Contracts for C++
+P2900R3 Contracts for C++
+P2900R4 Contracts for C++
+P2901R0 Extending linear algebra support to batched operations
+P2902R0 constexpr 'Parallel' Algorithms
+P2904R0 Removing exception in precedence rule(s) when using member pointer syntax
+P2905R0 Runtime format strings
+P2905R1 Runtime format strings
+P2905R2 Runtime format strings
+P2906R0 Structured bindings for std::extents
+P2909R0 Dude, where's my char?
+P2909R1 Fix formatting of code units as integers (Dude, where's my char?)
+P2909R2 Fix formatting of code units as integers (Dude, where's my char?)
+P2909R3 Fix formatting of code units as integers (Dude, where's my char?)
+P2909R4 Fix formatting of code units as integers (Dude, where's my char?)
+P2910R0 C++ Standard Library Ready Issues to be moved in Varna, Jun. 2023
+P2911R0 Python Bindings with Value-Based Reflection
+P2911R1 Python Bindings with Value-Based Reflection
+P2912R0 Concurrent queues and sender/receivers
+P2915R0 Proposed resolution to CWG1223
+P2917R0 An in-line defaulted destructor should keep the copy- and move-operations
+P2917R1 An in-line defaulted destructor should keep the copy- and move-operations
+P2918R0 Runtime format strings II
+P2918R1 Runtime format strings II
+P2918R2 Runtime format strings II
+P2920R0 Library Evolution Leadership's Understanding of the Noexcept Policy History
+P2921R0 Exploring std::expected based API alternatives for buffer_queue
+P2922R0 Core Language Working Group "ready" Issues for the June, 2023 meeting
+P2925R0 inplace_vector - D0843R7 LEWG presentation
+P2926R0 std::simd types should be regular - P2892R0 LEWG presentation
+P2927R0 Observing exceptions stored in exception_ptr
+P2929R0 simd_invoke
+P2930R0 Formatter specializations for the standard library
+P2931R0 WG21 June 2023 Varna Meeting Record of Discussion
+P2932R0 A Principled Approach to Open Design Questions for Contracts
+P2932R1 A Principled Approach to Open Design Questions for Contracts
+P2932R2 A Principled Approach to Open Design Questions for Contracts
+P2932R3 A Principled Approach to Open Design Questions for Contracts
+P2933R0 std::simd overloads for <bit> header
+P2933R1 std::simd overloads for <bit> header
+P2935R0 An Attribute-Like Syntax for Contracts
+P2935R1 An Attribute-Like Syntax for Contracts
+P2935R2 An Attribute-Like Syntax for Contracts
+P2935R3 An Attribute-Like Syntax for Contracts
+P2935R4 An Attribute-Like Syntax for Contracts
+P2937R0 Freestanding: Remove strtok
+P2940R0 switch for Pattern Matching
+P2941R0 Identifiers for Pattern Matching
+P2944R0 Comparisons for reference_wrapper
+P2944R1 Comparisons for reference_wrapper
+P2944R2 Comparisons for reference_wrapper
+P2945R0 Additional format specifiers for time_point
+P2946R0 A flexible solution to the problems of `noexcept`
+P2946R1 A flexible solution to the problems of `noexcept`
+P2947R0 Contracts must avoid disclosing sensitive information
+P2949R0 Slides for P2861R0: Narrow Contracts and `noexcept` are Inherently Incompatable
+P2950R0 Slides for P2836R1: std::basic_const_iterator should follow its underlying type's convertibility
+P2951R0 Shadowing is good for safety
+P2951R1 Shadowing is good for safety
+P2951R2 Shadowing is good for safety
+P2951R3 Shadowing is good for safety
+P2952R0 auto& operator=(X&&) = default
+P2952R1 auto& operator=(X&&) = default
+P2953R0 Forbid defaulting operator=(X&&) &&
+P2954R0 Contracts and virtual functions for the Contracts MVP
+P2955R0 Safer Range Access
+P2955R1 Safer Range Access
+P2956R0 Add saturating library support to std::simd
+P2957R0 Contracts and coroutines
+P2957R1 Contracts and coroutines
+P2958R0 typeof and typeof_unqual
+P2959R0 Container Relocation
+P2960R0 Concurrency TS Editor's report for N4956
+P2961R0 A natural syntax for Contracts
+P2961R1 A natural syntax for Contracts
+P2961R2 A natural syntax for Contracts
+P2962R0 Communicating the Baseline Compile Command for C++ Modules support
+P2963R0 Ordering of constraints involving fold expressions
+P2963R1 Ordering of constraints involving fold expressions
+P2966R0 Making C++ Better for Game Developers — Progress Report
+P2966R1 Making C++ Better for Game Developers — Progress Report
+P2967R0 Relocation Is A Library Interface
+P2968R0 Make std::ignore a first-class object
+P2968R1 Make std::ignore a first-class object
+P2968R2 Make std::ignore a first-class object
+P2969R0 Contract annotations are potentially-throwing
+P2971R0 Implication for C++
+P2971R1 Implication for C++
+P2972R0 2023-09 Library Evolution Polls
+P2973R0 Erroneous behaviour for missing return from assignment
+P2976R0 Freestanding Library: algorithm, numeric, and random
+P2977R0 Module commands database format
+P2978R0 A New Approach For Compiling C++
+P2979R0 The Need for Design Policies in WG21
+P2980R0 A motivation, scope, and plan for a physical quantities and units library
+P2980R1 A motivation, scope, and plan for a quantities and units library
+P2981R0 Improving our safety with a physical quantities and units library
+P2981R1 Improving our safety with a physical quantities and units library
+P2982R0 `std::quantity` as a numeric type
+P2982R1 `std::quantity` as a numeric type
+P2984R0 Reconsider Redeclaring static constexpr Data Members
+P2984R1 Reconsider Redeclaring static constexpr Data Members
+P2985R0 A type trait for detecting virtual base classes
+P2986R0 Generic Function Pointer
+P2988R0 std::optional<T&>
+P2988R1 std::optional<T&>
+P2989R0 A Simple Approach to Universal Template Parameters
+P2990R0 C++ Modules Roadmap
+P2991R0 Stop Forcing std::move to Pessimize
+P2992R0 Attribute [[discard]] and attributes on expressions
+P2994R0 On the Naming of Packs
+P2995R0 SG16: Unicode meeting summaries 2023-05-24 through 2023-09-27
+P2996R0 Reflection for C++26
+P2996R1 Reflection for C++26
+P2997R0 Removing the common reference requirement from the indirectly invocable concepts
+P2999R0 Sender Algorithm Customization
+P2999R1 Sender Algorithm Customization
+P2999R2 Sender Algorithm Customization
+P2999R3 Sender Algorithm Customization
+P3001R0 std::hive and containers like it are not a good fit for the standard library
+P3002R0 Guidelines for allocators in new library classes
+P3003R0 The design of a library of number concepts
+P3006R0 Launder less
+P3007R0 Return object semantics in postconditions
+P3008R0 Atomic floating-point min/max
+P3009R0 Injected class name in the base specifier list
+P3010R0 Using Reflection to Replace a Metalanguage for Generating JS Bindings
+P3011R0 Supporting document for Hive proposal #1: outreach for evidence of container-style use in industry
+P3012R0 Supporting document for Hive proposal #2: use of std::list in open source codebases
+P3014R0 Customizing std::expected's exception
+P3015R0 Rebuttal to Additional format specifiers for time_point
+P3016R0 Resolve inconsistencies in begin/end for valarray and braced initializer lists
+P3016R1 Resolve inconsistencies in begin/end for valarray and braced initializer lists
+P3018R0 Low-Level Integer Arithmetic
+P3019R0 Vocabulary Types for Composite Class Design
+P3019R1 Vocabulary Types for Composite Class Design
+P3019R2 Vocabulary Types for Composite Class Design
+P3019R3 Vocabulary Types for Composite Class Design
+P3020R0 2023-09 Library Evolution Poll Outcomes
+P3021R0 Unified function call syntax (UFCS)
+P3022R0 A Boring Thread Attributes Interface
+P3022R1 A Boring Thread Attributes Interface
+P3023R0 C++ Should Be C++
+P3023R1 C++ Should Be C++
+P3024R0 Interface Directions for std::simd
+P3025R0 SG14: Low Latency/Games/Embedded/Financial trading/Simulation virtual Minutes to 2023/09/12
+P3026R0 SG19: Machine Learning virtual Meeting Minutes to 2023/07/13
+P3027R0 UFCS is a breaking change, of the absolutely worst kind
+P3028R0 An Overview of Syntax Choices for Contracts
+P3029R0 Better mdspan's CTAD
+P3031R0 Resolve CWG2561: conversion function for lambda with explicit object parameter
+P3033R0 Should we import function bodies to get the better optimizations?
+P3034R0 Module Declarations Shouldn't be Macros
+P3037R0 constexpr std::shared_ptr
+P3038R0 Concrete suggestions for initial Profiles
+P3039R0 Automatically Generate `operator->`
+P3040R0 C++ Standard Library Ready Issues to be moved in Kona, Nov. 2023
+P3041R0 Transitioning from "#include" World to Modules
+P3042R0 Vocabulary Types for Composite Class Design
+P3043R0 Slides: Using variable template template without meta programming
+P3044R0 sub-string_view from string
+P3046R0 Core Language Working Group "ready" Issues for the November, 2023 meeting
+P3050R0 Optimize linalg::conjugated for noncomplex value types
+P3051R0 Structured Response Files
+P3052R0 view_interface::at()
+P3053R0 2023-12 Library Evolution Polls
+P3054R0 2023-12 Library Evolution Poll Outcomes
+P3055R0 Relax wording to permit relocation optimizations in the STL
+P3056R0 what ostream exception
+P3057R0 Two finer-grained compilation model for named modules
+P3059R0 Making user-defined constructors of view iterators/sentinels private
+P3060R0 Add std::ranges::upto(n)
+P3061R0 WG21 2023-11 Kona Record of Discussion
+P3062R0 C++ Should Be C++ - Presentation
+P3066R0 Allow repeating contract annotations on non-first declarations
+P3070R0 Formatting enums
+P3071R0 Protection against modifications in contracts
+P3071R1 Protection against modifications in contracts
+P3072R0 Hassle-free thread attributes
+P3074R0 constexpr union lifetime
+P3075R0 Adding an Undefined Behavior and IFNDR Annex
+P3079R0 Should ignore and observe exist for constant evaluation of contracts?
+P3084R0 Slides for LEWG views::maybe 20240109
+P3086R0 Proxy: A Pointer-Semantics-Based Polymorphism Library
+P3087R0 Make direct-initialization for enumeration types at least as permissive as direct-list-initialization

--- a/src/mailing_info.cpp
+++ b/src/mailing_info.cpp
@@ -55,14 +55,23 @@ void replace_all_irefs(std::vector<lwg::issue> const & issues, std::string & s) 
 } // close unnamed namespace
 
 auto lwg::make_html_anchor(lwg::issue const & iss) -> std::string {
-   auto temp = std::to_string(iss.num);
+   auto num = std::to_string(iss.num);
+   auto title = iss.title;
+   // Remove XML elements from the title to just get the text nodes.
+   for (auto p = title.find('<'); p != title.npos; p = title.find('<', p))
+      title.erase(p, title.find('>', p) + 1 - p);
+   // Attribute text is delimited with quotes so replace them with "&quot;".
+   for (auto p = title.find('"'); p != title.npos; p = title.find('"', p+6))
+      title.replace(p, 1, "&quot;");
 
    std::string result{"<a href=\""};
    result += filename_for_status(iss.stat);
    result += '#';
-   result += temp;
+   result += num;
+   result += "\" title=\"";
+   result += title;
    result += "\">";
-   result += temp;
+   result += num;
    result += "</a>";
    return result;
 }


### PR DESCRIPTION
This adds popup `title` text to the hyperlinks generated by `<iref ref="..."/>` and `<paper num="..."/>` tags in issues.

This makes it easier to see which issue/paper a link refers to, without having to click on the link.