### PR TITLE
Generate HTML5 instead of HTML 4.01

### DIFF
--- a/bin/issues_to_be_moved.sh
+++ b/bin/issues_to_be_moved.sh
@@ -123,9 +123,8 @@ dump_issues()
 }
 
 cat <<EOT
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
-    "http://www.w3.org/TR/html4/strict.dtd">
-<html>
+<!DOCTYPE HTML>
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <title>C++ Standard Library Issues to be moved in $meeting</title>

--- a/src/issues.cpp
+++ b/src/issues.cpp
@@ -158,6 +158,13 @@ auto lwg::parse_issue_from_file(std::string tx, std::string const & filename,
       p += code.size();
    }
 
+   // <tt> is obsolete in HTML5, replace with <code>:
+   for (auto p = tx.find("<tt"); p != tx.npos; p = tx.find("<tt", p+5))
+      if (tx.at(p+3) == '>' || tx.at(p+3) == ' ')
+         tx.replace(p, 3, "<code");
+   for (auto p = tx.find("</tt>"); p != tx.npos; p = tx.find("</tt>", p+7))
+         tx.replace(p, 5, "</code>");
+
    issue is;
 
    // Get issue number

--- a/xml/lwg-issues.xml
+++ b/xml/lwg-issues.xml
@@ -1393,7 +1393,7 @@ ownership of it.
   <p><b><a name="NAD">NAD</a></b> - The LWG has reached consensus that
   the issue is not a defect in the Standard.</p>
 
-  <p><b><a name="NAD Editorial">NAD Editorial</a></b> - The LWG has reached consensus that
+  <p><b><a id="NAD_Editorial">NAD Editorial</a></b> - The LWG has reached consensus that
   the issue can either be handled editorially, or is handled by a paper (usually
   linked to in the rationale).</p>
 
@@ -1412,13 +1412,13 @@ ownership of it.
 
   <p>The following statuses have been retired, but may show up on older issues lists.</p>
 
-  <p><b><a name="NAD Future">NAD Future</a></b> - In addition to the regular status, the
+  <p><b><a name="NAD_Future">NAD Future</a></b> - In addition to the regular status, the
   LWG believes that this issue should be revisited at the next revision of the standard.
   That is now an ongoing task managed by the Library Evolution Working Group, and most
-  issues in this status were reopended with the status <a href="#NAD Editorial">LEWG</a>.
+  issues in this status were reopended with the status <a href="#NAD_Editorial">LEWG</a>.
   </p>
 
-  <p><b><a name="NAD Concepts">NAD Concepts</a></b> - This status reflects an evolution
+  <p><b><a id="NAD_Concepts">NAD Concepts</a></b> - This status reflects an evolution
   of the language during the development of C++11, where a new feature entered the
   language, called <i>concepts</i>, that fundamentally changed the way templates would
   be specified and written.  While this language feature was removed towards the end of
@@ -1428,7 +1428,7 @@ ownership of it.
   the concepts feature.  All such issues have been closed with this status, and may be
   revisitted should this or a similar language feature return for a future standard.</p>
 
-  <p><b><a name="NAD Arrays">NAD Arrays</a></b> - This status reflects an evolution
+  <p><b><a id="NAD_Arrays">NAD Arrays</a></b> - This status reflects an evolution
   of the language during the development of C++14/17, where work on a Technical
   Specification, called the <i>Arrays TS</i> was begun. In early 2016, this work was
   abandoned, and the work item was officially withdrawn.  During development of the TS,


### PR DESCRIPTION
- Use HTML5 DOCTYPE.
- Use CSS to style tables instead of obsolete HTML attributes.
- Use `id` attributes instead of `name`. Sanitize the values of all such attributes (and corresponding URLs using them) so that they don't contain spaces.
- Do not create duplicate `id` attributes in index pages that aren't sorted by section.
- Postprocess issues to replace obsolete `<tt>` elements with `<code>`.

There are validation errors for some of the issues themselves, due to the use of `<p/>` as a paragraph break, which is not correct HTML5. Paragraphs should start with `<p>` and end with `</p>`, not just be started implictly and then separated by `<p/>`.

Wrong:

	This is paragraph one.
	<p/>
	This is paragraph two.

Also wrong:

	<p>
	This is paragraph one.
	<p/>
	This is paragraph two.
	</p>

Right:

	<p>
	This is paragraph one.
	</p>
	<p>
	This is paragraph two.
	</p>