### PR TITLE
Support simple markdown-like syntax for inline code

### DIFF
--- a/src/issues.cpp
+++ b/src/issues.cpp
@@ -149,8 +149,8 @@ auto lwg::parse_issue_from_file(std::string tx, std::string const & filename,
          continue;
       }
       auto code = "<code>" + escape_special_chars(tx.substr(p + 1, p2 - p - 1)) + "</code>";
-      tx.replace(p, p2 - p + 1, code);
-      p += code.size();
+      tx.replace(p+1, p2 - p - 1, code);
+      p += code.size() + 2;
    }
 
    issue is;


### PR DESCRIPTION
This adds a preprocessing step to the issue text before starting to process it as XML. Any block delimited by triple-backticks (alone on a line) will be enclosed in `<pre>` and `<code>` elements, Any text enclosed by a single backtick (without any intervening newlines) will be enclosed in a `<code>` element.

In both cases, all occurrences of the characters `&` and `<` and `>` inside the code element will be replaced with the corresponding HTML entities.

This makes it much simpler to write (and copy & paste) C++ code into issues.