### PR TITLE
Add (i) snapshot links to output of <iref> elements

### DIFF
--- a/src/lists.cpp
+++ b/src/lists.cpp
@@ -431,6 +431,9 @@ void format_issue_as_html(lwg::issue & is,
                }
                else {
                   r = make_html_anchor(*n);
+                  r += "<sup><a href=\"https://cplusplus.github.io/LWG/issue";
+                  r += std::to_string(num);
+                  r += "\" title=\"Latest snapshot\">(i)</a></sup>";
                }
 
                j -= i - 1;


### PR DESCRIPTION
The links generated by <iref> always go to the full issues list, which can be slow to load. In those full lists the issue number includes a (i) superscript that links to the single-page view of the issue. This change makes <iref> elements also add a (i) superscript linking to the single-page version of the issue.