### PR TITLE
Centralize metadata reading to handle non-default paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ all: pgms
 
 pgms: $(PGMS)
 
-bin/lists: src/date.o src/issues.o src/status.o src/sections.o src/mailing_info.o src/report_generator.o src/lists.o
+bin/lists: src/date.o src/issues.o src/status.o src/sections.o src/mailing_info.o src/report_generator.o src/lists.o src/metadata.o
 
 bin/section_data: src/section_data.o
 
 bin/toc_diff: src/toc_diff.o
 
-bin/list_issues: src/date.o src/issues.o src/status.o src/sections.o src/list_issues.o
+bin/list_issues: src/date.o src/issues.o src/status.o src/sections.o src/list_issues.o src/metadata.o
 
 bin/set_status: src/set_status.o src/status.o
 

--- a/src/issues.cpp
+++ b/src/issues.cpp
@@ -3,7 +3,7 @@
 #endif
 
 #include "issues.h"
-#include "sections.h"
+#include "metadata.h"
 #include "status.h"
 
 #include <algorithm>
@@ -64,26 +64,10 @@ auto make_date(std::tm const & mod) -> gregorian::date {
    return gregorian::year((unsigned short)(mod.tm_year+1900)) / (mod.tm_mon+1) / mod.tm_mday;
 }
 
-struct issue_mod_time {
-   int id;
-   std::time_t t;
-   operator std::pair<const int, std::time_t>() const { return { id, t }; }
-   friend std::istream& operator>>(std::istream& in, issue_mod_time& v) { return in >> v.id >> v.t; }
-};
-
-auto git_commit_times() -> std::map<int, std::time_t>
-{
-  using Iter = std::istream_iterator<issue_mod_time>;
-  std::ifstream f{"meta-data/dates"};
-  std::map<int, std::time_t> times{ Iter{f}, Iter{} };
-  return times;
-}
-
-auto report_date_file_last_modified(std::filesystem::path const & filename) -> gregorian::date {
+auto report_date_file_last_modified(std::filesystem::path const & filename, lwg::metadata const& meta) -> gregorian::date {
    std::time_t mtime;
    int id = std::stoi(filename.filename().stem().native().substr(5));
-   static auto git_times = git_commit_times();
-   if (auto it = git_times.find(id); it != git_times.end())
+   if (auto it = meta.git_commit_times.find(id); it !=  meta.git_commit_times.end())
       mtime = it->second;
    else
    {
@@ -112,7 +96,8 @@ std::string escape_special_chars(std::string s) {
 } // close unnamed namespace
 
 auto lwg::parse_issue_from_file(std::string tx, std::string const & filename,
-  lwg::section_map & section_db) -> issue {
+  lwg::metadata & meta) -> issue {
+   auto& section_db = meta.section_db;
    struct bad_issue_file : std::runtime_error {
       bad_issue_file(std::string const & filename, std::string error_message)
          : runtime_error{"Error parsing issue file " + filename + ": " + error_message}
@@ -263,7 +248,7 @@ auto lwg::parse_issue_from_file(std::string tx, std::string const & filename,
       is.date = parse_date(temp);
 
       // Get modification date
-      is.mod_date = report_date_file_last_modified(filename);
+      is.mod_date = report_date_file_last_modified(filename, meta);
    }
    catch(std::exception const & ex) {
       throw bad_issue_file{filename, ex.what()};

--- a/src/issues.h
+++ b/src/issues.h
@@ -9,7 +9,7 @@
 
 // solution specific headers
 #include "date.h"
-#include "sections.h"
+#include "metadata.h"
 #include "status.h"
 
 namespace lwg
@@ -38,7 +38,7 @@ struct order_by_issue_number {
     bool operator()(int x,           issue const & y) const noexcept   {  return x     < y.num;   }
 };
 
-auto parse_issue_from_file(std::string file_contents, std::string const & filename, lwg::section_map & section_db) -> issue;
+auto parse_issue_from_file(std::string file_contents, std::string const & filename, lwg::metadata & meta) -> issue;
   // Seems appropriate constructor behavior.
   //
   // Note that 'section_db' is modifiable as new (unknown) sections may be inserted,

--- a/src/lists.cpp
+++ b/src/lists.cpp
@@ -78,7 +78,7 @@ auto is_issue_xml_file(fs::directory_entry const & e) {
    return false;
 }
 
-auto read_issues(fs::path const & issues_path, lwg::section_map & section_db) -> std::vector<lwg::issue> {
+auto read_issues(fs::path const & issues_path, lwg::metadata & meta) -> std::vector<lwg::issue> {
    // Open the specified directory, 'issues_path', and iterate all the '.xml' files
    // it contains, parsing each such file as an LWG issue document.  Return the set
    // of issues as a vector.
@@ -87,7 +87,7 @@ auto read_issues(fs::path const & issues_path, lwg::section_map & section_db) ->
    for (auto ent : fs::directory_iterator(issues_path)) {
       if (is_issue_xml_file(ent)) {
          fs::path const issue_file = ent.path();
-         issues.emplace_back(parse_issue_from_file(read_file_into_string(issue_file), issue_file.string(), section_db));
+         issues.emplace_back(parse_issue_from_file(read_file_into_string(issue_file), issue_file.string(), meta));
       }
    }
 
@@ -218,18 +218,9 @@ namespace
    };
 }
 
-std::unordered_map<std::string, std::string> paper_titles = [] {
-   std::unordered_map<std::string, std::string> titles;
-   std::ifstream in{"meta-data/paper_titles.txt"};
-   std::string paper_number, title;
-   while (in >> paper_number && std::getline(in, title))
-      titles[paper_number] = title;
-   return titles;
-}();
-
 // The title of the specified paper, formatted as an HTML title="..." attribute.
-std::string paper_title_attr(std::string paper_number) {
-   auto title = paper_titles[paper_number];
+std::string paper_title_attr(std::string paper_number, lwg::metadata& meta) {
+   auto title = meta.paper_titles[paper_number];
    if (!title.empty())
    {
       title = lwg::replace_reserved_char(std::move(title), '&', "&amp;");
@@ -242,8 +233,9 @@ std::string paper_title_attr(std::string paper_number) {
 void format_issue_as_html(lwg::issue & is,
                           std::vector<lwg::issue>::iterator first_issue,
                           std::vector<lwg::issue>::iterator last_issue,
-                          lwg::section_map & section_db) {
+                          lwg::metadata & meta) {
 
+   auto& section_db = meta.section_db;
    std::vector<std::string> tag_stack; // stack of open XML tags as we parse
 
    // Used by fix_tags to report errors.
@@ -453,7 +445,7 @@ void format_issue_as_html(lwg::issue & is,
                std::transform(paper_number.begin(), paper_number.end(), paper_number.begin(),
                      [] (unsigned char c) { return std::toupper(c); });
 
-               auto title = paper_title_attr(paper_number);
+               auto title = paper_title_attr(paper_number, meta);
 
                j -= i - 1;
                std::string r = "<a href=\"https://wg21.link/" + paper_number + "\"" + title + ">" + paper_number + "</a>";
@@ -497,7 +489,7 @@ void format_issue_as_html(lwg::issue & is,
 }
 
 
-void prepare_issues(std::vector<lwg::issue> & issues, lwg::section_map & section_db) {
+void prepare_issues(std::vector<lwg::issue> & issues, lwg::metadata & meta) {
    // Initially sort the issues by issue number, so each issue can be correctly 'format'ted
    sort(issues.begin(), issues.end(), lwg::order_by_issue_number{});
 
@@ -507,7 +499,7 @@ void prepare_issues(std::vector<lwg::issue> & issues, lwg::section_map & section
    // Currently, the 'format' function takes a reference-to-non-const-vector-of-issues purely to
    // mark up information related to duplicates, so processing duplicates in a separate pass may
    // clarify the code.
-   for (auto & i : issues) { format_issue_as_html(i, issues.begin(), issues.end(), section_db); }
+   for (auto & i : issues) { format_issue_as_html(i, issues.begin(), issues.end(), meta); }
 
    // Issues will be routinely re-sorted in later code, but contents should be fixed after formatting.
    // This suggests we may want to be storing some kind of issue handle in the functions that keep
@@ -754,20 +746,10 @@ int main(int argc, char* argv[]) {
       const fs::path target_path{path / "mailing"};
       check_is_directory(target_path);
 
-
-      lwg::section_map section_db =[&path]() {
-         auto filename = path / "meta-data" / "section.data";
-         std::ifstream infile{filename};
-         if (!infile.is_open()) {
-            throw std::runtime_error{"Can't open section.data at " + path.string() + "meta-data"};
-         }
-         std::cout << "Reading section-tag index from: " << filename << std::endl;
-
-         return lwg::read_section_db(infile);
-      }();
+      auto metadata = lwg::metadata::read_from_path(path);
 #if defined (DEBUG_LOGGING)
       // dump the contents of the section index
-      for (auto const & elem : section_db ) {
+      for (auto const & elem : metadata.section_db ) {
          std::string temp = elem.first;
          temp.erase(temp.end()-1);
          temp.erase(temp.begin());
@@ -793,11 +775,11 @@ int main(int argc, char* argv[]) {
 
 
       std::cout << "Reading issues from: " << issues_path << std::endl;
-      auto issues = read_issues(issues_path, section_db);
-      prepare_issues(issues, section_db);
+      auto issues = read_issues(issues_path, metadata);
+      prepare_issues(issues, metadata);
 
 
-      lwg::report_generator generator{lwg_issues_xml, section_db};
+      lwg::report_generator generator{lwg_issues_xml, metadata.section_db};
 
 
       // issues must be sorted by number before making the mailing list documents

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1,0 +1,46 @@
+#include "metadata.h"
+
+#include <fstream>
+#include <iterator>
+#include <iostream>
+
+namespace {
+    struct issue_mod_time {
+        int id;
+        std::time_t t;
+        operator std::pair<const int, std::time_t>() const { return { id, t }; }
+        friend std::istream& operator>>(std::istream& in, issue_mod_time& v) { return in >> v.id >> v.t; }
+    };
+
+    auto read_git_commit_times(std::filesystem::path const& path) -> std::map<int, std::time_t>
+    {
+        using Iter = std::istream_iterator<issue_mod_time>;
+        std::ifstream f{path};
+        std::map<int, std::time_t> times{ Iter{f}, Iter{} };
+        return times;
+    }
+
+    auto read_paper_titles(std::filesystem::path const& path) -> std::unordered_map<std::string, std::string> {
+        std::unordered_map<std::string, std::string> titles;
+        std::ifstream in{path};
+        std::string paper_number, title;
+        while (in >> paper_number && std::getline(in, title))
+        titles[paper_number] = title;
+        return titles;
+    }
+
+}
+
+auto lwg::metadata::read_from_path(std::filesystem::path const& path) -> metadata {
+    auto filename = path / "meta-data" / "section.data";
+    std::ifstream infile{filename};
+    if (!infile.is_open()) {
+        throw std::runtime_error{"Can't open section.data at " + path.string() + "meta-data"};
+    }
+    std::cout << "Reading section-tag index from: " << filename << std::endl;
+    return {
+        read_section_db(infile),
+        read_git_commit_times(path / "meta-data" / "dates"),
+        read_paper_titles(path / "meta-data" / "paper_titles.txt"),
+    };
+}

--- a/src/metadata.h
+++ b/src/metadata.h
@@ -1,0 +1,21 @@
+#ifndef INCLUDE_LWG_METADATA_H
+#define INCLUDE_LWG_METADATA_H
+#include "sections.h"
+#include <map>
+#include <unordered_map>
+#include <ctime>
+#include <filesystem>
+
+namespace lwg {
+
+// Various things read from meta-data/
+struct metadata {
+    section_map section_db;
+    std::map<int, std::time_t> git_commit_times;
+    std::unordered_map<std::string, std::string> paper_titles;
+
+    static metadata read_from_path(std::filesystem::path const& path);
+};
+
+}
+#endif


### PR DESCRIPTION
`bin/lists` takes an optional path argument and reads issues and `meta-data/section.data` relative to that path instead of the current path.

`meta-data/dates` and `meta-data/paper_titles.txt`, however, are read relative to the current path. So when using a non-default path the generation still mostly works, but you get wrong dates and no paper titles :(

This PR consolidates all the metadata into one class that can be extended if needed, and ensures that they are all read relative to the provided path.