### PR TITLE
Update bin/build_pgms.sh to just use make

### DIFF
--- a/bin/build_pgms.sh
+++ b/bin/build_pgms.sh
@@ -1,7 +1,2 @@
 #!/bin/sh
-echo '"Use -m32 switch to force 32-bit build"'
-${CXX:-g++} $* -std=c++17 -Wall -DNDEBUG -O2 -o bin/lists src/date.cpp src/issues.cpp src/status.cpp src/sections.cpp src/mailing_info.cpp src/report_generator.cpp src/metadata.cpp src/lists.cpp
-${CXX:-g++} $* -std=c++17 -Wall -o bin/section_data src/section_data.cpp
-${CXX:-g++} $* -std=c++17 -Wall -o bin/toc_diff src/toc_diff.cpp
-${CXX:-g++} $* -std=c++17 -Wall -DNDEBUG -O2 -o bin/list_issues src/date.cpp src/issues.cpp src/status.cpp src/sections.cpp src/metadata.cpp src/list_issues.cpp
-${CXX:-g++} $* -std=c++17 -Wall -DNDEBUG -O2 -o bin/set_status  src/set_status.cpp src/status.cpp
+make -C $(dirname $0)/.. clean pgms


### PR DESCRIPTION
~~Add the new source file from Tim's #439 change~~

There's no good reason why this script is needed to build with -DNDEBUG
and without -g. The performance of the programs is more than adequate
even with assert(std::is_sorted(...)) checks in them.
    
Just make this script use 'make clean pgms' so that it doesn't need to
be maintained to add new source files, so that the .o files can be
reused for multiple programs, and so that it shares the same build flags
as the makefile.

