### PR TITLE
Add script for verifying source code changes

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -54,3 +54,15 @@ jobs:
         path: html/issue*.html
         retention-days: 7
         if-no-files-found: ignore
+
+    - name: Check source code changes
+      continue-on-error: true
+      run: |
+        git fetch --depth 2 origin master
+        if ! git diff --quiet origin/master HEAD -- src
+        then
+          if ! bin/check-html-diffs.sh origin/master always
+          then
+            echo "::warning title=html-diffs::Generated HTML files do not match"
+          fi
+        fi

--- a/bin/check-html-diffs.sh
+++ b/bin/check-html-diffs.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+old=$(mktemp -d ./mailing.old.XXXXXX)
+new=$(mktemp -d ./mailing.new.XXXXXX)
+echo Building lists at HEAD
+make clean
+make lists -j4
+sed -i 's/Revised ....-..-.. at ..:..:.. UTC/Revised .../' mailing/*.html
+mv mailing $new
+git checkout ${1-origin/master} -- src
+echo Building lists with code from `git rev-parse origin/master`
+make clean
+make lists -j4
+git checkout HEAD -- src
+sed -i 's/Revised ....-..-.. at ..:..:.. UTC/Revised .../' mailing/*.html
+mv mailing $old
+diff -u -r --color=${2:-auto} $old $new || exit
+rm -r $old $new
+echo No changes to HTML files


### PR DESCRIPTION
Also use the new script in the check-pr.yml workflow.

The new script can be used to check that changes to the C++ code do not produce unwanted differences in the generated HTML. That can be used in the workflow that runs on pull requests.

Here's an example of the output when the generated HTML changes:

https://github.com/jwakely/LWG/actions/runs/11674543132/job/32507431334

Expanding the "**>** Annotations" output and clicking on the warning jumps to the diff for the generated HTML files.