### PR TITLE
switch to using git log --raw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ meta-data/dates: xml/issue[0-9]*.xml bin/make_dates.py
 	  rm $@.new; \
 	  $(call update,$@); \
 	else \
-	  git whatchanged --no-show-signature --pretty=%ct | $(python) bin/make_dates.py > $@; \
+	  git log --raw --no-show-signature --pretty=%ct | $(python) bin/make_dates.py > $@; \
 	fi
 
 new-papers:

--- a/bin/make_dates.py
+++ b/bin/make_dates.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# usage: git whatchanged --no-show-signature --pretty=%ct | python bin/make_dates.py > dates
+# usage: git log --raw --no-show-signature --pretty=%ct | python bin/make_dates.py > dates
 
 import sys
 import re


### PR DESCRIPTION
```
'git whatchanged' is nominated for removal.
If you still use this command, please add an extra
option, '--i-still-use-this', on the command line
and let us know you still use it by sending an e-mail
to <git@vger.kernel.org>.  Thanks.
fatal: refusing to run without --i-still-use-this
```
