### PR TITLE
Un-Pending some old issues

### DIFF
--- a/xml/issue2125.xml
+++ b/xml/issue2125.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="2125" status="Pending NAD Editorial">
+<issue num="2125" status="NAD Editorial">
 <title><tt>TimedMutex</tt> specification problem</title>
 <section><sref ref="[thread.timedmutex.requirements]"/><sref ref="[thread.timedmutex.class]"/></section>
 <submitter>Vicente J. Botet Escriba</submitter>
@@ -13,7 +13,7 @@
 <sref ref="[thread.timedmutex.class]"/> says:
 </p>
 <blockquote><p>
-The class <tt>timed_mutex</tt> shall satisfy all of the <tt>TimedMutex</tt> requirements (<sref ref="[thread.timedmutex.requirements]"/>). 
+The class <tt>timed_mutex</tt> shall satisfy all of the <tt>TimedMutex</tt> requirements (<sref ref="[thread.timedmutex.requirements]"/>).
 It shall be a standardlayout class (Clause <sref ref="[class]"/>).
 </p></blockquote>
 <p>

--- a/xml/issue2302.xml
+++ b/xml/issue2302.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
-<!DOCTYPE issue SYSTEM "lwg-issue.dtd" [ 
+<!DOCTYPE issue SYSTEM "lwg-issue.dtd" [
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2302" status="Pending NAD">
+<issue num="2302" status="Resolved">
 <title>Passing null pointer to placement new</title>
 <section><sref ref="[new.delete.placement]"/></section>
 <submitter>Marc Glisse</submitter>
@@ -12,10 +12,10 @@
 
 <discussion>
 <p>
-Based on <a href="http://stackoverflow.com/questions/17571103/passing-null-pointer-to-placement-new">this discussion</a> 
+Based on <a href="http://stackoverflow.com/questions/17571103/passing-null-pointer-to-placement-new">this discussion</a>
 and as discussed in <a href="http://listarchives.isocpp.org/cgi-bin/wg21/message?wg=core&amp;msg=23998">c++std-core-23998</a> and
-<a href="http://listarchives.isocpp.org/cgi-bin/wg21/message?wg=lib&amp;msg=34442">c++std-lib-34442</a>, calling placement new currently forces the 
-compiler to check if the pointer is null before initializing the object (a non-negligible cost). It seems many people were not 
+<a href="http://listarchives.isocpp.org/cgi-bin/wg21/message?wg=lib&amp;msg=34442">c++std-lib-34442</a>, calling placement new currently forces the
+compiler to check if the pointer is null before initializing the object (a non-negligible cost). It seems many people were not
 aware of this and they consider it a user error to pass a null pointer to it.
 <p/>
 Proposed resolution: for <tt>operator new</tt> and <tt>operator new[]</tt>, add:
@@ -28,7 +28,7 @@ Proposed resolution: for <tt>operator new</tt> and <tt>operator new[]</tt>, add:
 <p>
 AJM to supply the rationale...
 </p>
-
+<note>2026-04-09; This was resolved by <a href="https://wg21.link/cwg1748">CWG 1748</a>.</note>
 </discussion>
 
 <resolution>

--- a/xml/issue2382.xml
+++ b/xml/issue2382.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8' standalone='no'?>
-<!DOCTYPE issue SYSTEM "lwg-issue.dtd" [ 
+<!DOCTYPE issue SYSTEM "lwg-issue.dtd" [
   <!ENTITY nbsp "&#160;">
 ] >
 
-<issue num="2382" status="Pending NAD">
+<issue num="2382" status="Resolved">
 <title>Unclear order of container update versus object destruction on removing an object</title>
 <section><sref ref="[reentrancy]"/></section>
 <submitter>Peter Kasting</submitter>
@@ -12,8 +12,8 @@
 
 <discussion>
 <p>
-The standard does not seem to discuss reentrant access to a container during removal of an element, 
-leaving it unclear whether a removed object is destroyed before or after it is removed from the container.  
+The standard does not seem to discuss reentrant access to a container during removal of an element,
+leaving it unclear whether a removed object is destroyed before or after it is removed from the container.
 For example, the behavior of the following code seems to be unspecified:
 </p>
 <blockquote><pre>
@@ -59,9 +59,9 @@ Object 1 is removed from the map before being destroyed
 Object 0 is destroyed before being removed from the map
 </pre></blockquote>
 <p>
-The core issue here is whether an object removed from a container should be destroyed before or after 
-it is removed from the container. The current standard seems to be silent on this issue. 
-The above output demonstrates that the behavior is actually inconsistent. (It's difficult to fully 
+The core issue here is whether an object removed from a container should be destroyed before or after
+it is removed from the container. The current standard seems to be silent on this issue.
+The above output demonstrates that the behavior is actually inconsistent. (It's difficult to fully
 describe Visual Studio's behavior; for example, changing <tt>main()</tt> in the above example to the following:)
 </p>
 <blockquote><pre>
@@ -86,7 +86,7 @@ Object 1 is destroyed before being removed from the map
 Object 0 is removed from the map before being destroyed
 </pre></blockquote>
 <p>
-In my opinion, the standard should explicitly describe when objects are destroyed as part of removal from a container. 
+In my opinion, the standard should explicitly describe when objects are destroyed as part of removal from a container.
 To me, it makes the most sense to say that objects should be removed from the container before they are destroyed.
 </p>
 <note>2014-05-07, Jeffrey Yasskin comments</note>
@@ -115,8 +115,9 @@ STL: We need more wording about how container methods can be reentrency.
 <p/>
 Jeffrey: The title for this issue is confusing, what we really want is "reentrancy for objects".
 <p/>
-Alisdair: Should we then close 2382 as NAD with a link to the new issue? 
+Alisdair: Should we then close 2382 as NAD with a link to the new issue?
 </p>
+<note>2026-04-09; This was resolved by <iref ref="2414"/>.</note>
 </discussion>
 
 <resolution>

--- a/xml/issue2382.xml
+++ b/xml/issue2382.xml
@@ -117,7 +117,7 @@ Jeffrey: The title for this issue is confusing, what we really want is "reentran
 <p/>
 Alisdair: Should we then close 2382 as NAD with a link to the new issue?
 </p>
-<note>2026-04-09; This was resolved by <iref ref="2414"/>.</note>
+<note>2026-04-09; This was resolved by LWG <iref ref="2414"/>.</note>
 </discussion>
 
 <resolution>


### PR DESCRIPTION
We still have three "Pending NAD Editorial" issues after this.

https://cplusplus.github.io/LWG/issue2126 is mostly done but bits and pieces are missing.
https://cplusplus.github.io/LWG/issue2134 isn't done.
https://cplusplus.github.io/LWG/issue2178 isn't done.

I have reclassified the two "Pending NAD" issues as "Resolved" - one by a core issue in 2014, and one by a library issue we just moved in Croydon.