### PR TITLE
Updated priorties from April and May 2026

### DIFF
--- a/xml/issue4121.xml
+++ b/xml/issue4121.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="4121" status="New">
+<issue num="4121" status="Tentatively Ready">
 <title><code>ranges::to</code> constructs associative containers via <code>c.emplace(c.end(), *it)</code></title>
 <section><sref ref="[range.utility.conv.general]"/></section>
 <submitter>Hewill Kang</submitter>
@@ -181,6 +181,11 @@ Hewill noted that all the standard sequence containers that could use
 `c.emplace(c.end(), ref)` would already have used the `emplace_back` branch,
 so there's no point using `c.emplace`. Just change that branch to use
 `emplace_hint` for associative containers.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set status to Tentatively Ready after nine votes in favour during reflector poll.
 </p>
 
 </discussion>

--- a/xml/issue4545.xml
+++ b/xml/issue4545.xml
@@ -9,7 +9,7 @@ missing a representability precondition for the padded stride</title>
 </section>
 <submitter>Xi Chen</submitter>
 <date>18 Mar 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -43,6 +43,16 @@ void test() {
   assert(dst.stride(1) == 0);
 }
 </pre></blockquote>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+<p>
+There was split regarding P3 or P4. The `layout_stride` also require
+only `required_span_size` to be representable, allowing `strides` to
+overflow.
+</p>
 </discussion>
 
 <resolution>

--- a/xml/issue4546.xml
+++ b/xml/issue4546.xml
@@ -8,7 +8,7 @@
 </section>
 <submitter>Hewill Kang</submitter>
 <date>19 Mar 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -18,6 +18,14 @@ cannot be used as a template parameter even if it is a constant expression. This
 <p/>
 Given that integer-class types should behave like regular integers, and those types in MSVC-STL and libstdc++ are 
 both implemented as structural types, it would be better to be clear about the wording.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+<p>
+Need additional statement clarifying when the types are template-argument-equivalent.
 </p>
 </discussion>
 

--- a/xml/issue4547.xml
+++ b/xml/issue4547.xml
@@ -8,7 +8,7 @@
 </section>
 <submitter>Eric Niebler</submitter>
 <date>19 Mar 2026</date>
-<priority>99</priority>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -48,6 +48,14 @@ subexpression to an rvalue reference parameter.
 The intention was that the template parameter `Sndr` would be deduced preserving the <i>cv</i>- and 
 reference-qualification of the sender subexpression. In order to achieve that, we need to add a deduction 
 guide.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 2 after reflector poll.
+</p>
+<p>
+There were only 3 votes, but all in favor of P0.
 </p>
 </discussion>
 

--- a/xml/issue4551.xml
+++ b/xml/issue4551.xml
@@ -6,7 +6,7 @@
 <section><sref ref="[exec.on]"/></section>
 <submitter>Eric Niebler</submitter>
 <date>23 Mar 2026</date>
-<priority>99</priority>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -35,6 +35,12 @@ auto sndr2 = get_completion_domain&lt;&gt;(get_env(sndr), env)
 We can use this to query to make `transform_sender` use the domain of `sch` to find a customization 
 of `on(sch, sndr)`.
 </p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 2 after reflector poll.
+</p>
+
 </discussion>
 
 <resolution>

--- a/xml/issue4559.xml
+++ b/xml/issue4559.xml
@@ -10,7 +10,7 @@
 </section>
 <submitter>Hewill Kang</submitter>
 <date>27 Mar 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -24,6 +24,15 @@ it's not within reasonable ranges.
 Given that we provided <code>reserve_hint</code> for <code>concat_view</code> to resolve NB comment <a
    href="https://github.com/cplusplus/nbballot/issues/821">FR-025-246</a>, it seems that only these three views
 are available, but not provided; it's time to do so.</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+<p>
+Concerns with `cartesian_product` as any overestimation will be amplified
+expoentially. P0 votes for `zip` only change.
+</p>
 </discussion>
 
 <resolution>

--- a/xml/issue4559.xml
+++ b/xml/issue4559.xml
@@ -31,7 +31,7 @@ Set priority to 3 after reflector poll.
 </p>
 <p>
 Concerns with `cartesian_product` as any overestimation will be amplified
-expoentially. P0 votes for `zip` only change.
+exponentially. P0 votes for just the `zip` change.
 </p>
 </discussion>
 

--- a/xml/issue4561.xml
+++ b/xml/issue4561.xml
@@ -8,7 +8,7 @@
 </section>
 <submitter>Hewill Kang</submitter>
 <date>27 Mar 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -22,6 +22,16 @@ we can just provide const <code>begin</code> to reduce the number of template in
 <p>
 And it is also reasonable to only provide <code>const</code> end in the case of 
 <code><i>simple-view</i></code> for the same reason.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+<p>
+The discussion concluded that this is not user-observable change,
+as we assume that if view `begin()` and `begin() const` return the same
+type, then their behavior is equivalent.
 </p>
 </discussion>
 

--- a/xml/issue4562.xml
+++ b/xml/issue4562.xml
@@ -8,7 +8,7 @@
 </section>
 <submitter>S. B. Tam</submitter>
 <date>29 Mar 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -29,6 +29,12 @@ exhaustive in this case, but <sref ref="[mdspan.layout.stride.obs]"/>/6.2 requir
 <p/>
 Should `is_exhaustive` be made to return `true` in this case (which is more correct and also easier to implement)?
 </p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+
 </discussion>
 
 <resolution>

--- a/xml/issue4564.xml
+++ b/xml/issue4564.xml
@@ -8,7 +8,7 @@
 </section>
 <submitter>Marek Polacek</submitter>
 <date>31 Mar 2026</date>
-<priority>99</priority>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -43,6 +43,16 @@ something like:
 <tt>[: <i>R</i> :]</tt> is a valid <i>splice-expression</i> <ins>that doesn't 
 designate a template</ins>.
 </p></blockquote>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 2 after reflector poll.
+</p>
+<p>
+The `[:R:]` is not valid splice-expression for template. However,
+we need to handle direct base class relantionships and non-static
+data members. In this cases `reflect_constant(_array)` calls are ill-formed.
+</p>
 </discussion>
 
 <resolution>

--- a/xml/issue4565.xml
+++ b/xml/issue4565.xml
@@ -8,7 +8,7 @@
 </section>
 <submitter>Hewill Kang</submitter>
 <date>03 Apr 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -35,6 +35,18 @@ ranges::subrange&lt;Derived*&gt; sd;
 ranges::subrange&lt;Base*&gt; sb = sd;                        // error
 ranges::subrange&lt;const Base*&gt; sb = views::as_const(sd); // <span style="color:#C80000;font-weight:bold">ok</span>
 </pre></blockquote>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+
+<p>
+"It seems like we should apply this protection to all iterator adaptors.
+Derived-to-base conversions are not valid for pointers that are used as
+iterators."
+</p>
+
 </discussion>
 
 <resolution>

--- a/xml/issue4566.xml
+++ b/xml/issue4566.xml
@@ -31,7 +31,7 @@ Set priority to 3 after reflector poll.
 </p>
 <p>
 We spell explicit requirments on validity of `NestedAccessor::element_type` construction,
-and not include in in alias definition.
+and do not include it in the alias definition.
 </p>
 </discussion>
 

--- a/xml/issue4566.xml
+++ b/xml/issue4566.xml
@@ -10,7 +10,7 @@
 </section>
 <submitter>Hewill Kang</submitter>
 <date>08 Apr 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -23,6 +23,15 @@ returns <code>const ScalingFactor&amp;</code>.
 Furthermore, both <code>scaled_accessor</code> and <code>conjugated_accessor</code>'s
 <code>access</code> construct <code>NestedAccessor::element_type</code> via
 <code><i>nested-accessor</i>.access(p, i)</code>, but this may not be well-formed.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+<p>
+We spell explicit requirments on validity of `NestedAccessor::element_type` construction,
+and not include in in alias definition.
 </p>
 </discussion>
 

--- a/xml/issue4569.xml
+++ b/xml/issue4569.xml
@@ -9,7 +9,7 @@
 </section>
 <submitter>Hewill Kang</submitter>
 <date>12 Apr 2026</date>
-<priority>99</priority>
+<priority>4</priority>
 
 <discussion>
 <p>
@@ -38,6 +38,15 @@ m[0, 1]; // <span style="color:#C80000;font-weight:bold">not rejected in libstdc
 </pre></blockquote>
 <p>
 It should be emphasized that we provided very similar wording in <sref ref="[coro.generator.class]"/> p1.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 4 after reflector poll.
+</p>
+<p>
+This seem to only affected contrived examples, that will
+be ill-formed as soon as you try to use result `mdspan`.
 </p>
 </discussion>
 

--- a/xml/issue4569.xml
+++ b/xml/issue4569.xml
@@ -45,8 +45,8 @@ It should be emphasized that we provided very similar wording in <sref ref="[cor
 Set priority to 4 after reflector poll.
 </p>
 <p>
-This seem to only affected contrived examples, that will
-be ill-formed as soon as you try to use result `mdspan`.
+This seems to only affected contrived examples, that will
+be ill-formed as soon as you try to use the resulting `mdspan`.
 </p>
 </discussion>
 

--- a/xml/issue4570.xml
+++ b/xml/issue4570.xml
@@ -8,7 +8,7 @@
 </section>
 <submitter>Eric Niebler</submitter>
 <date>13 Apr 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -43,6 +43,15 @@ they do not have a common type as determined by `common_type_t`.
 We can patch this up easily enough: if <tt>common_type_t&lt;Domains...&gt;</tt> is ill-formed, 
 we should check if <tt>common_type_t&lt;default_domain, Domains...&gt;</tt> is well-formed, this 
 will correctly handle the case when all the domains are convertible to `default_domain`.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+<p>
+The expected design regarding domain conversion is unclear, and
+concerns regarding special treatment of `default_domain` were raised.
 </p>
 </discussion>
 

--- a/xml/issue4571.xml
+++ b/xml/issue4571.xml
@@ -52,7 +52,7 @@ Set priority to 3 after reflector poll.
 <p>
 The meaning of "merging specializations" in the note is unclear.
 It is unclear if well-formed program can differentiate between
-atomic initiantiation produce from primary template or specializations
+atomic instantiations produced from the primary template or specializations
 (full or partial).
 </p>
 </discussion>

--- a/xml/issue4571.xml
+++ b/xml/issue4571.xml
@@ -9,7 +9,7 @@
 </section>
 <submitter>Jiang An</submitter>
 <date>17 Apr 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
@@ -43,6 +43,17 @@ program-defined specialization.
 Given it's unclear whether program-defined specializations of `atomic` and `atomic_ref` make sense, and 
 there're some potential drawbacks allowing them, perhaps it would be better to disallow specializing 
 `atomic` and `atomic_ref`.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+<p>
+The meaning of "merging specializations" in the note is unclear.
+It is unclear if well-formed program can differentiate between
+atomic initiantiation produce from primary template or specializations
+(full or partial).
 </p>
 </discussion>
 

--- a/xml/issue4572.xml
+++ b/xml/issue4572.xml
@@ -177,7 +177,7 @@ case of a much bigger problem", as <i>"little more than handwaving"</i>.
 Set priority to 2 after reflector poll.
 </p>
 <p>
-Extensive regarding reflector discussion. Strong opoisition to the changes,
+Extensive reflector discussion. Strong opposition to the changes,
 being a pessimization for all unique-key lookups, implementation divergence,
 and recent changes in implementtion that silently broke user libraries.
 </p>

--- a/xml/issue4572.xml
+++ b/xml/issue4572.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="4572" status="New">
+<issue num="4572" status="LEWG">
 <title>Key ordering requirements of associative containers are poorly specified</title>
 <section>
 <sref ref="[associative.reqmts.general]"/>
@@ -10,7 +10,7 @@
 </section>
 <submitter>Joaquin M López Muñoz</submitter>
 <date>19 Apr 2026</date>
-<priority>99</priority>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -170,6 +170,16 @@ problems regarding the extent of applicability of semantic requirements (both fo
 <sref ref="[structure.requirements]"/>/8 tries to provide some leeway for the specific case 
 of `concept`s in a manner described by <paper num="P2027R0"/>, section "This is a special 
 case of a much bigger problem", as <i>"little more than handwaving"</i>.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 2 after reflector poll.
+</p>
+<p>
+Extensive regarding reflector discussion. Strong opoisition to the changes,
+being a pessimization for all unique-key lookups, implementation divergence,
+and recent changes in implementtion that silently broke user libraries.
 </p>
 </discussion>
 

--- a/xml/issue4573.xml
+++ b/xml/issue4573.xml
@@ -8,12 +8,26 @@
 </section>
 <submitter>Hewill Kang</submitter>
 <date>19 Apr 2026</date>
-<priority>99</priority>
+<priority>3</priority>
 
 <discussion>
 <p>
 The `view_interface` can provide only a const `cbegin` member when the derived class is
 <code><i>simple-view</i></code>, which helps reduce template instantiation.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 3 after reflector poll.
+</p>
+<p>
+This does not seem to eliminate class template instantiations, so
+may not be improvement. Would benefit from benchmarks.
+</p>
+<p>
+We could go even further and replace <tt>!simple_range&lt;R&gt;</tt>,
+with <tt>!input_range&lt;const R&gt;</tt>, due `ranges::cbegin` and
+`ranges::cend` using <tt><i>possibly-constant-range</i></tt>.
 </p>
 </discussion>
 

--- a/xml/issue4573.xml
+++ b/xml/issue4573.xml
@@ -22,11 +22,11 @@ Set priority to 3 after reflector poll.
 </p>
 <p>
 This does not seem to eliminate class template instantiations, so
-may not be improvement. Would benefit from benchmarks.
+may not be an improvement. Would benefit from benchmarks.
 </p>
 <p>
 We could go even further and replace <tt>!simple_range&lt;R&gt;</tt>,
-with <tt>!input_range&lt;const R&gt;</tt>, due `ranges::cbegin` and
+with <tt>!input_range&lt;const R&gt;</tt>, due to `ranges::cbegin` and
 `ranges::cend` using <tt><i>possibly-constant-range</i></tt>.
 </p>
 </discussion>

--- a/xml/issue4574.xml
+++ b/xml/issue4574.xml
@@ -9,7 +9,7 @@
 </section>
 <submitter>Zhihao Yuan</submitter>
 <date>27 Apr 2026</date>
-<priority>99</priority>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -49,6 +49,14 @@ The 2nd template argument of `constant_wrapper`
 is defaulted to `decltype(X)::type`, it may
 need to be <em>required</em> to be `decltype(X)::type` to
 reliably provide value.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 2 after reflector poll.
+</p>
+<p>
+This should be resolved by <paper num="P4206R0"/>.
 </p>
 </discussion>
 

--- a/xml/issue4575.xml
+++ b/xml/issue4575.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8' standalone='no'?>
 <!DOCTYPE issue SYSTEM "lwg-issue.dtd">
 
-<issue num="4575" status="New">
+<issue num="4575" status="SG1">
 <title>No formal wording associates single total order of allocation/deallocation operations with the coherence rule</title>
 <section>
 <sref ref="[new.delete.dataraces]"/>
 </section>
 <submitter>jim x</submitter>
 <date>03 May 2026</date>
-<priority>99</priority>
+<priority>4</priority>
 
 <discussion>
 <p>
@@ -59,6 +59,11 @@ even if we associate the coherence rule with happens-before, the total order is
 <tt>#1 &lt; #3 &lt; #2</tt>(or, <tt>#3 &lt; #1 &lt; #2</tt>), it seems that the "next allocation" 
 is meaningless if it is relative to the deallocation. Furthermore, de-shall is meaningful here 
 because we impose a requirement on the implementations.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 4 and send to SG1 after reflector poll.
 </p>
 </discussion>
 

--- a/xml/issue4576.xml
+++ b/xml/issue4576.xml
@@ -8,7 +8,7 @@
 </section>
 <submitter>S. B. Tam</submitter>
 <date>05 May 2026</date>
-<priority>99</priority>
+<priority>2</priority>
 
 <discussion>
 <p>
@@ -16,6 +16,14 @@ The use of `template [: x :]` (introduced in LWG <iref ref="4316"/>) is incorrec
 is a <i>splice-expression</i> (which can only designate a function template or variable template), 
 and an unparenthesized <i>splice-expression</i> is not allowed as a <i>template-argument</i> per 
 <sref ref="[temp.names]"/>/6.
+</p>
+
+<note>2026-05-29; Reflector poll.</note>
+<p>
+Set priority to 2 after reflector poll.
+</p>
+<p>
+We should merge 1.1 and 1.2.
 </p>
 </discussion>
 


### PR DESCRIPTION
Everything except 4572 was not upated in the PR.

Close to TR issues:
* [4568](https://cplusplus.github.io/LWG/lwg-active.html#4560) - 5 P0, no @jwakely vote
* [4579](https://cplusplus.github.io/LWG/lwg-active.html#4579) - 5 P0, no @jwakely vote
* [4567](https://cplusplus.github.io/LWG/lwg-active.html#4560) - 6 P0, but Peter wasn't clear if he is opposing

A lot of P0, but some suggestion for LEWG nod, we could handle them on today meeting
* [4563](https://cplusplus.github.io/LWG/lwg-active.html#4563)
* [4558](https://cplusplus.github.io/LWG/lwg-active.html#4558)

Things for LEWG:
*  [4560](https://cplusplus.github.io/LWG/lwg-active.html#4560) - Generally needs paper
*  [4572](https://cplusplus.github.io/LWG/lwg-active.html#4572) - People are split on change, but seem important
   **UPDATED**.

NAD, by may be worth revisit, given that all implementations have it:
*  [4577](https://cplusplus.github.io/LWG/lwg-active.html#4577)