### PR TITLE
Use <details> for superseded resolutions

### DIFF
--- a/src/lists.cpp
+++ b/src/lists.cpp
@@ -220,9 +220,9 @@ namespace
          { "duplicate", {} },
          { "note", { "<p><i>[", "]</i></p>\n"} },
          { "superseded",
-            { "<p><strong>Previous resolution [SUPERSEDED]:</strong></p>\n"
-               "<blockquote class=\"note\">\n",
-               "</blockquote>" } },
+            { "<details class='superseded'>"
+              "<summary>Previous resolution [SUPERSEDED]</summary>\n",
+              "</details>" } },
    };
 }
 

--- a/src/report_generator.cpp
+++ b/src/report_generator.cpp
@@ -189,9 +189,14 @@ R"(<!DOCTYPE html>
   li {text-align:justify}
   pre code.backtick::before { content: "`" }
   pre code.backtick::after { content: "`" }
-  blockquote.note
+  details.superseded { border-left: solid grey 2px; }
+  details.superseded > summary { font-weight: bold; cursor: pointer; padding: 0px 5px;}
+  details.superseded > summary::after { font-weight: normal; color: grey; }
+  details.superseded[open] > summary::after { content: " <click to collapse>"; }
+  details.superseded:not([open]) > summary::after { content: " <click to expand>"; }
+  blockquote.note, details.superseded[open]::details-content
   {
-    background-color:#E0E0E0;
+    background-color: #E0E0E0;
     padding-left: 15px;
     padding-right: 15px;
     padding-top: 1px;
@@ -227,8 +232,7 @@ R"(<!DOCTYPE html>
      a:visited {
         color: #6af
      }
-     blockquote.note
-     {
+     blockquote.note, details.superseded[open]::details-content {
         background-color: rgba(255, 255, 255, .10)
      }
   }


### PR DESCRIPTION
This makes them hidden by default and expandable by clicking.