### PR TITLE
Update 4421 resolution

### DIFF
--- a/xml/issue4421.xml
+++ b/xml/issue4421.xml
@@ -46,7 +46,7 @@ constexpr to_chars_result to_chars(char* first, char* last, <i>integer-type</i> 
 <p/>
 -5- <i>Effects</i>: The value of `value` is converted to a string of digits in the given base (with no redundant
 leading zeroes) <ins>in the ordinary literal encoding (<sref ref="[lex.charset]"/>)</ins>. Digits in the range 
-10..35 (inclusive) are represented as lowercase characters <tt><ins>'</ins>a<ins>'</ins>..<ins>'</ins>z<ins>'</ins></tt>. If
+10..35 (inclusive) are represented as lowercase characters `a..z`. If
 `value` is less than zero, the representation starts with `'-'`.
 </p>
 </blockquote>


### PR DESCRIPTION
It was pointed out that the character literals `'a'..'z'` are not contiguous in EBCDIC, so using range notation for such literals makes no sense.